### PR TITLE
fix: unset Nix toolchain variables in devenv flutter script

### DIFF
--- a/.changeset/fix-devenv-nix-toolchain.md
+++ b/.changeset/fix-devenv-nix-toolchain.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Unset Nix toolchain environment variables in `flutter` devenv script to prevent conflicts with Xcode builds.

--- a/devenv.nix
+++ b/devenv.nix
@@ -56,6 +56,20 @@
     "flutter" = {
       exec = ''
         set -e
+        # Unset Nix toolchain variables that conflict with Xcode builds
+        unset CC CXX LD AR NM RANLIB STRIP OBJCOPY OBJDUMP SIZE STRINGS
+        unset NIX_CC NIX_BINTOOLS NIX_CFLAGS_COMPILE NIX_LDFLAGS
+        unset NIX_HARDENING_ENABLE NIX_ENFORCE_NO_NATIVE
+        unset NIX_DONT_SET_RPATH NIX_DONT_SET_RPATH_FOR_BUILD NIX_NO_SELF_RPATH
+        unset NIX_IGNORE_LD_THROUGH_GCC
+        unset NIX_BINTOOLS_WRAPPER_TARGET_HOST_arm64_apple_darwin
+        unset NIX_CC_WRAPPER_TARGET_HOST_arm64_apple_darwin
+        unset NIX_PKG_CONFIG_WRAPPER_TARGET_HOST_arm64_apple_darwin
+        unset SDKROOT MACOSX_DEPLOYMENT_TARGET
+        unset CFLAGS CXXFLAGS LDFLAGS ARCHFLAGS
+        unset PKG_CONFIG PKG_CONFIG_PATH
+        unset LD_LIBRARY_PATH LD_DYLD_PATH
+        unset cmakeFlags
         fvm flutter $@
       '';
       description = "Run flutter commands.";


### PR DESCRIPTION
## Summary
- Unset Nix/devenv toolchain environment variables (`CC`, `CXX`, `NIX_CFLAGS_COMPILE`, `NIX_LDFLAGS`, etc.) in the `flutter` devenv script before delegating to `fvm flutter`
- These variables point to Nix store paths that conflict with Xcode's own toolchain during `flutter run` and `flutter build` on macOS

## Test plan
- [x] Verified `flutter run` succeeds on iOS Simulator with the unset variables
- [ ] Run `devenv shell` and confirm `flutter run` works without manual env overrides
- [ ] Confirm `flutter build ios` completes successfully