### PR TITLE
feat: add move money between envelopes

### DIFF
--- a/.changeset/feat-move-money.md
+++ b/.changeset/feat-move-money.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Add move money between envelopes within the same budget month.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -181,5 +181,12 @@
   "reportsTransactions": "Transactions",
   "reportsSpendingByCategory": "Spending by Category",
   "reportsEmptyTitle": "No Data Yet",
-  "reportsEmptySubtitle": "Add transactions to see spending reports for this month"
+  "reportsEmptySubtitle": "Add transactions to see spending reports for this month",
+  "moveMoneyTitle": "Move Money",
+  "moveMoneyFrom": "From Envelope",
+  "moveMoneyTo": "To Envelope",
+  "moveMoneyButton": "Move",
+  "moveMoneySuccess": "Money moved between envelopes",
+  "moveMoneyError": "Could not move money. Please try again.",
+  "moveMoneySameError": "Cannot move money to the same envelope"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1101,6 +1101,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Add transactions to see spending reports for this month'**
   String get reportsEmptySubtitle;
+
+  /// No description provided for @moveMoneyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Move Money'**
+  String get moveMoneyTitle;
+
+  /// No description provided for @moveMoneyFrom.
+  ///
+  /// In en, this message translates to:
+  /// **'From Envelope'**
+  String get moveMoneyFrom;
+
+  /// No description provided for @moveMoneyTo.
+  ///
+  /// In en, this message translates to:
+  /// **'To Envelope'**
+  String get moveMoneyTo;
+
+  /// No description provided for @moveMoneyButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Move'**
+  String get moveMoneyButton;
+
+  /// No description provided for @moveMoneySuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Money moved between envelopes'**
+  String get moveMoneySuccess;
+
+  /// No description provided for @moveMoneyError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not move money. Please try again.'**
+  String get moveMoneyError;
+
+  /// No description provided for @moveMoneySameError.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot move money to the same envelope'**
+  String get moveMoneySameError;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -536,4 +536,25 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get reportsEmptySubtitle =>
       'Add transactions to see spending reports for this month';
+
+  @override
+  String get moveMoneyTitle => 'Move Money';
+
+  @override
+  String get moveMoneyFrom => 'From Envelope';
+
+  @override
+  String get moveMoneyTo => 'To Envelope';
+
+  @override
+  String get moveMoneyButton => 'Move';
+
+  @override
+  String get moveMoneySuccess => 'Money moved between envelopes';
+
+  @override
+  String get moveMoneyError => 'Could not move money. Please try again.';
+
+  @override
+  String get moveMoneySameError => 'Cannot move money to the same envelope';
 }

--- a/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.dart
+++ b/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.dart
@@ -50,6 +50,46 @@ class MonthlyAllocationActions extends _$MonthlyAllocationActions {
     return const AsyncValue.data(null);
   }
 
+  Future<List<MonthlyAllocation>> moveMoney({
+    required String fromEnvelopeId,
+    required String toEnvelopeId,
+    required String budgetId,
+    required int year,
+    required int month,
+    required int amountCents,
+  }) async {
+    state = const AsyncValue.loading();
+    final client = ref.read(serverpodClientProvider);
+    try {
+      final result = await client.monthlyAllocation.moveMoney(
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(fromEnvelopeId),
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(toEnvelopeId),
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(budgetId),
+        year,
+        month,
+        amountCents,
+      );
+      if (ref.mounted) {
+        ref
+          ..invalidate(monthlyAllocationsProvider(budgetId, year, month))
+          ..invalidate(budgetMonthlySummaryProvider(budgetId));
+        state = const AsyncValue.data(null);
+      }
+      return result;
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+
   Future<MonthlyAllocation> upsertAllocation({
     required String envelopeId,
     required String budgetId,

--- a/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.g.dart
@@ -212,7 +212,7 @@ final class MonthlyAllocationActionsProvider
 }
 
 String _$monthlyAllocationActionsHash() =>
-    r'56ac88a82c6aafc01cac0d6e8b5f1e6d360ccb4a';
+    r'9b96e3434f1699b02f0bc6be98794233908ec309';
 
 abstract class _$MonthlyAllocationActions extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -11,6 +11,7 @@ import 'package:openbudget_app/src/features/budget/providers/selected_month_prov
 import 'package:openbudget_app/src/features/budget/screens/add_category_dialog.dart';
 import 'package:openbudget_app/src/features/budget/screens/add_envelope_dialog.dart';
 import 'package:openbudget_app/src/features/budget/screens/edit_envelope_dialog.dart';
+import 'package:openbudget_app/src/features/budget/screens/move_money_dialog.dart';
 import 'package:openbudget_app/src/features/budget/widgets/budget_header.dart';
 import 'package:openbudget_app/src/features/budget/widgets/category_group.dart';
 import 'package:openbudget_app/src/routing/route_names.dart';
@@ -241,12 +242,40 @@ class BudgetDetailScreen extends HookConsumerWidget {
                       label: Text(l10n.budgetAddExpense),
                     ),
                   ),
+                  const SizedBox(width: SpacingTokens.sm),
+                  IconButton.filled(
+                    onPressed: () => _showMoveMoneyDialog(
+                      context,
+                      summary.categories,
+                      year: summary.year,
+                      month: summary.month,
+                    ),
+                    icon: const Icon(Icons.swap_horiz_rounded),
+                    tooltip: l10n.moveMoneyTitle,
+                  ),
                 ],
               ),
             ),
           ),
         );
       },
+    );
+  }
+
+  void _showMoveMoneyDialog(
+    BuildContext context,
+    List<CategoryWithEnvelopes> categories, {
+    required int year,
+    required int month,
+  }) {
+    showDialog<void>(
+      context: context,
+      builder: (_) => MoveMoneyDialog(
+        budgetId: budgetId,
+        year: year,
+        month: month,
+        categories: categories,
+      ),
     );
   }
 

--- a/openbudget_app/lib/src/features/budget/screens/move_money_dialog.dart
+++ b/openbudget_app/lib/src/features/budget/screens/move_money_dialog.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/monthly_allocation_provider.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class MoveMoneyDialog extends HookConsumerWidget {
+  const MoveMoneyDialog({
+    required this.budgetId,
+    required this.year,
+    required this.month,
+    required this.categories,
+    super.key,
+  });
+
+  final String budgetId;
+  final int year;
+  final int month;
+  final List<CategoryWithEnvelopes> categories;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final amountController = useTextEditingController();
+    final fromEnvelopeId = useState<String?>(null);
+    final toEnvelopeId = useState<String?>(null);
+    final isSubmitting = useState(false);
+
+    // Build a flat list of envelopes with category labels.
+    final envelopeItems = <DropdownMenuItem<String>>[];
+    for (final cat in categories) {
+      for (final me in cat.monthlyEnvelopes) {
+        final envId = me.envelope.id?.toString() ?? '';
+        envelopeItems.add(
+          DropdownMenuItem(
+            value: envId,
+            child: Text('${cat.category.name} > ${me.envelope.name}'),
+          ),
+        );
+      }
+    }
+
+    return AlertDialog(
+      title: Text(l10n.moveMoneyTitle),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            DropdownButtonFormField<String>(
+              initialValue: fromEnvelopeId.value,
+              decoration: InputDecoration(
+                labelText: l10n.moveMoneyFrom,
+                prefixIcon: const Icon(Icons.arrow_upward_rounded),
+              ),
+              items: envelopeItems,
+              onChanged: (v) => fromEnvelopeId.value = v,
+            ),
+            const SizedBox(height: SpacingTokens.md),
+            DropdownButtonFormField<String>(
+              initialValue: toEnvelopeId.value,
+              decoration: InputDecoration(
+                labelText: l10n.moveMoneyTo,
+                prefixIcon: const Icon(Icons.arrow_downward_rounded),
+              ),
+              items: envelopeItems,
+              onChanged: (v) => toEnvelopeId.value = v,
+            ),
+            const SizedBox(height: SpacingTokens.md),
+            TextField(
+              controller: amountController,
+              decoration: InputDecoration(
+                labelText: l10n.transactionAmountLabel,
+                prefixIcon: const Icon(Icons.attach_money),
+              ),
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.dialogCancel),
+        ),
+        FilledButton(
+          onPressed: isSubmitting.value
+              ? null
+              : () => _submit(
+                  context,
+                  ref,
+                  amountController,
+                  fromEnvelopeId,
+                  toEnvelopeId,
+                  isSubmitting,
+                ),
+          child: isSubmitting.value
+              ? const SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(l10n.moveMoneyButton),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _submit(
+    BuildContext context,
+    WidgetRef ref,
+    TextEditingController amountController,
+    ValueNotifier<String?> fromEnvelopeId,
+    ValueNotifier<String?> toEnvelopeId,
+    ValueNotifier<bool> isSubmitting,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (fromEnvelopeId.value == null || toEnvelopeId.value == null) return;
+    if (fromEnvelopeId.value == toEnvelopeId.value) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.moveMoneySameError),
+          backgroundColor: colorScheme.error,
+        ),
+      );
+      return;
+    }
+
+    final amount = double.tryParse(amountController.text.trim()) ?? 0;
+    if (amount <= 0) return;
+
+    final amountCents = (amount * 100).round();
+    isSubmitting.value = true;
+
+    try {
+      await ref
+          .read(monthlyAllocationActionsProvider.notifier)
+          .moveMoney(
+            fromEnvelopeId: fromEnvelopeId.value!,
+            toEnvelopeId: toEnvelopeId.value!,
+            budgetId: budgetId,
+            year: year,
+            month: month,
+            amountCents: amountCents,
+          );
+      messenger.showSnackBar(SnackBar(content: Text(l10n.moveMoneySuccess)));
+      if (context.mounted) Navigator.of(context).pop();
+    } on Exception catch (_) {
+      isSubmitting.value = false;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.moveMoneyError),
+          backgroundColor: colorScheme.error,
+        ),
+      );
+    }
+  }
+}

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -562,6 +562,27 @@ class EndpointMonthlyAllocation extends _i1.EndpointRef {
     {'budgetId': budgetId, 'year': year, 'month': month},
   );
 
+  /// Moves money between two envelopes in the same budget and month.
+  _i2.Future<List<_i10.MonthlyAllocation>> moveMoney(
+    _i1.UuidValue fromEnvelopeId,
+    _i1.UuidValue toEnvelopeId,
+    _i1.UuidValue budgetId,
+    int year,
+    int month,
+    int amountCents,
+  ) => caller.callServerEndpoint<List<_i10.MonthlyAllocation>>(
+    'monthlyAllocation',
+    'moveMoney',
+    {
+      'fromEnvelopeId': fromEnvelopeId,
+      'toEnvelopeId': toEnvelopeId,
+      'budgetId': budgetId,
+      'year': year,
+      'month': month,
+      'amountCents': amountCents,
+    },
+  );
+
   /// Deletes a monthly allocation by ID.
   _i2.Future<_i10.MonthlyAllocation> delete(_i1.UuidValue allocationId) =>
       caller.callServerEndpoint<_i10.MonthlyAllocation>(

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -878,6 +878,52 @@ class Endpoints extends _i1.EndpointDispatch {
                     params['month'],
                   ),
         ),
+        'moveMoney': _i1.MethodConnector(
+          name: 'moveMoney',
+          params: {
+            'fromEnvelopeId': _i1.ParameterDescription(
+              name: 'fromEnvelopeId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'toEnvelopeId': _i1.ParameterDescription(
+              name: 'toEnvelopeId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'year': _i1.ParameterDescription(
+              name: 'year',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+            'month': _i1.ParameterDescription(
+              name: 'month',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+            'amountCents': _i1.ParameterDescription(
+              name: 'amountCents',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['monthlyAllocation'] as _i10.MonthlyAllocationEndpoint)
+                  .moveMoney(
+                    session,
+                    params['fromEnvelopeId'],
+                    params['toEnvelopeId'],
+                    params['budgetId'],
+                    params['year'],
+                    params['month'],
+                    params['amountCents'],
+                  ),
+        ),
         'delete': _i1.MethodConnector(
           name: 'delete',
           params: {

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -43,6 +43,7 @@ envelope:
 monthlyAllocation:
   - upsert:
   - list:
+  - moveMoney:
   - delete:
 payee:
   - create:

--- a/openbudget_server/lib/src/monthly_allocations/monthly_allocation_endpoint.dart
+++ b/openbudget_server/lib/src/monthly_allocations/monthly_allocation_endpoint.dart
@@ -45,6 +45,27 @@ class MonthlyAllocationEndpoint extends Endpoint {
     );
   }
 
+  /// Moves money between two envelopes in the same budget and month.
+  Future<List<MonthlyAllocation>> moveMoney(
+    Session session,
+    UuidValue fromEnvelopeId,
+    UuidValue toEnvelopeId,
+    UuidValue budgetId,
+    int year,
+    int month,
+    int amountCents,
+  ) async {
+    return MonthlyAllocationService.moveMoney(
+      session,
+      fromEnvelopeId: fromEnvelopeId,
+      toEnvelopeId: toEnvelopeId,
+      budgetId: budgetId,
+      year: year,
+      month: month,
+      amountCents: amountCents,
+    );
+  }
+
   /// Deletes a monthly allocation by ID.
   Future<MonthlyAllocation> delete(
     Session session,

--- a/openbudget_server/lib/src/monthly_allocations/monthly_allocation_service.dart
+++ b/openbudget_server/lib/src/monthly_allocations/monthly_allocation_service.dart
@@ -72,6 +72,65 @@ class MonthlyAllocationService {
     );
   }
 
+  /// Moves money between two envelopes in the same budget and month.
+  ///
+  /// Decreases the source envelope allocation and increases the target.
+  static Future<List<MonthlyAllocation>> moveMoney(
+    Session session, {
+    required UuidValue fromEnvelopeId,
+    required UuidValue toEnvelopeId,
+    required UuidValue budgetId,
+    required int year,
+    required int month,
+    required int amountCents,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+    await EnvelopeService.getById(session, envelopeId: fromEnvelopeId);
+    await EnvelopeService.getById(session, envelopeId: toEnvelopeId);
+
+    // Get or create source allocation.
+    final fromExisting = await MonthlyAllocation.db.findFirstRow(
+      session,
+      where: (t) =>
+          t.envelopeId.equals(fromEnvelopeId) &
+          t.year.equals(year) &
+          t.month.equals(month),
+    );
+
+    final fromAllocated = (fromExisting?.allocatedCents ?? 0) - amountCents;
+    final updatedFrom = await upsert(
+      session,
+      envelopeId: fromEnvelopeId,
+      budgetId: budgetId,
+      year: year,
+      month: month,
+      allocatedCents: fromAllocated,
+      carryoverCents: fromExisting?.carryoverCents ?? 0,
+    );
+
+    // Get or create target allocation.
+    final toExisting = await MonthlyAllocation.db.findFirstRow(
+      session,
+      where: (t) =>
+          t.envelopeId.equals(toEnvelopeId) &
+          t.year.equals(year) &
+          t.month.equals(month),
+    );
+
+    final toAllocated = (toExisting?.allocatedCents ?? 0) + amountCents;
+    final updatedTo = await upsert(
+      session,
+      envelopeId: toEnvelopeId,
+      budgetId: budgetId,
+      year: year,
+      month: month,
+      allocatedCents: toAllocated,
+      carryoverCents: toExisting?.carryoverCents ?? 0,
+    );
+
+    return [updatedFrom, updatedTo];
+  }
+
   /// Deletes an allocation by ID, verifying ownership.
   static Future<MonthlyAllocation> delete(
     Session session, {

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -1480,6 +1480,49 @@ class _MonthlyAllocationEndpoint {
     });
   }
 
+  _i3.Future<List<_i10.MonthlyAllocation>> moveMoney(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue fromEnvelopeId,
+    _i2.UuidValue toEnvelopeId,
+    _i2.UuidValue budgetId,
+    int year,
+    int month,
+    int amountCents,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'monthlyAllocation',
+            method: 'moveMoney',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'monthlyAllocation',
+          methodName: 'moveMoney',
+          parameters: _i1.testObjectToJson({
+            'fromEnvelopeId': fromEnvelopeId,
+            'toEnvelopeId': toEnvelopeId,
+            'budgetId': budgetId,
+            'year': year,
+            'month': month,
+            'amountCents': amountCents,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<List<_i10.MonthlyAllocation>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
   _i3.Future<_i10.MonthlyAllocation> delete(
     _i1.TestSessionBuilder sessionBuilder,
     _i2.UuidValue allocationId,


### PR DESCRIPTION
## Summary
- Adds `moveMoney` method to MonthlyAllocationService that atomically decreases source and increases target envelope allocations
- Adds `moveMoney` endpoint to MonthlyAllocationEndpoint
- Creates MoveMoneyDialog with from/to envelope dropdowns (grouped by category) and amount field
- Adds move money button (swap icon) to budget detail bottom bar
- Validates same-envelope transfers

## Test plan
- [ ] Verify moving money between two envelopes updates both allocations correctly
- [ ] Verify "Ready to Assign" stays unchanged after a move (budget-neutral operation)
- [ ] Verify same-envelope move shows error
- [ ] Verify move money dialog shows all envelopes grouped by category
- [ ] Verify zero/negative amounts are rejected