### PR TITLE
feat: add age of money metric

### DIFF
--- a/.changeset/feat-age-of-money.md
+++ b/.changeset/feat-age-of-money.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Add Age of Money metric showing average days between income and spending using FIFO matching.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -225,5 +225,13 @@
   "recurringCreateSuccess": "Recurring transaction created",
   "recurringCreateError": "Could not create recurring transaction. Please try again.",
   "recurringEditSuccess": "Recurring transaction updated",
-  "recurringEditError": "Could not update recurring transaction. Please try again."
+  "recurringEditError": "Could not update recurring transaction. Please try again.",
+  "ageOfMoneyLabel": "{days, plural, =1{Age of Money: 1 day} other{Age of Money: {days} days}}",
+  "@ageOfMoneyLabel": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1323,6 +1323,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not update recurring transaction. Please try again.'**
   String get recurringEditError;
+
+  /// No description provided for @ageOfMoneyLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{days, plural, =1{Age of Money: 1 day} other{Age of Money: {days} days}}'**
+  String ageOfMoneyLabel(int days);
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -660,4 +660,15 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get recurringEditError =>
       'Could not update recurring transaction. Please try again.';
+
+  @override
+  String ageOfMoneyLabel(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: 'Age of Money: $days days',
+      one: 'Age of Money: 1 day',
+    );
+    return '$_temp0';
+  }
 }

--- a/openbudget_app/lib/src/features/budget/providers/age_of_money_provider.dart
+++ b/openbudget_app/lib/src/features/budget/providers/age_of_money_provider.dart
@@ -1,0 +1,17 @@
+import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'age_of_money_provider.g.dart';
+
+/// Fetches the "Age of Money" metric for a budget.
+///
+/// Returns the average number of days between income receipt and spending,
+/// or null if there is insufficient data.
+@riverpod
+Future<int?> ageOfMoney(Ref ref, String budgetId) async {
+  final client = ref.read(serverpodClientProvider);
+  // Serverpod API requires UuidValue which is experimental in uuid package.
+  // ignore: experimental_member_use
+  return client.transaction.ageOfMoney(UuidValue.fromString(budgetId));
+}

--- a/openbudget_app/lib/src/features/budget/providers/age_of_money_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/age_of_money_provider.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'age_of_money_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches the "Age of Money" metric for a budget.
+///
+/// Returns the average number of days between income receipt and spending,
+/// or null if there is insufficient data.
+
+@ProviderFor(ageOfMoney)
+final ageOfMoneyProvider = AgeOfMoneyFamily._();
+
+/// Fetches the "Age of Money" metric for a budget.
+///
+/// Returns the average number of days between income receipt and spending,
+/// or null if there is insufficient data.
+
+final class AgeOfMoneyProvider
+    extends $FunctionalProvider<AsyncValue<int?>, int?, FutureOr<int?>>
+    with $FutureModifier<int?>, $FutureProvider<int?> {
+  /// Fetches the "Age of Money" metric for a budget.
+  ///
+  /// Returns the average number of days between income receipt and spending,
+  /// or null if there is insufficient data.
+  AgeOfMoneyProvider._({
+    required AgeOfMoneyFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'ageOfMoneyProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$ageOfMoneyHash();
+
+  @override
+  String toString() {
+    return r'ageOfMoneyProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<int?> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<int?> create(Ref ref) {
+    final argument = this.argument as String;
+    return ageOfMoney(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AgeOfMoneyProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$ageOfMoneyHash() => r'39cb7fa90a0efd88133affeaffe2f60b44555dc8';
+
+/// Fetches the "Age of Money" metric for a budget.
+///
+/// Returns the average number of days between income receipt and spending,
+/// or null if there is insufficient data.
+
+final class AgeOfMoneyFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<int?>, String> {
+  AgeOfMoneyFamily._()
+    : super(
+        retry: null,
+        name: r'ageOfMoneyProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches the "Age of Money" metric for a budget.
+  ///
+  /// Returns the average number of days between income receipt and spending,
+  /// or null if there is insufficient data.
+
+  AgeOfMoneyProvider call(String budgetId) =>
+      AgeOfMoneyProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'ageOfMoneyProvider';
+}

--- a/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/age_of_money_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/selected_month_provider.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_core/openbudget_core.dart';
@@ -41,6 +42,7 @@ class BudgetHeader extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final ageOfMoneyAsync = ref.watch(ageOfMoneyProvider(budgetId));
     final color = readyToAssignCents > 0
         ? ColorTokens.secondary
         : readyToAssignCents < 0
@@ -114,6 +116,26 @@ class BudgetHeader extends HookConsumerWidget {
               fontWeight: FontWeight.bold,
             ),
           ),
+          if (ageOfMoneyAsync.hasValue && ageOfMoneyAsync.value != null) ...[
+            const SizedBox(height: SpacingTokens.sm),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.hourglass_bottom_rounded,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: SpacingTokens.xs),
+                Text(
+                  l10n.ageOfMoneyLabel(ageOfMoneyAsync.value!),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ],
         ],
       ),
     );

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -846,6 +846,15 @@ class EndpointTransaction extends _i1.EndpointRef {
     'budgetId': budgetId,
   });
 
+  /// Calculates the "Age of Money" for a budget.
+  ///
+  /// Returns the average days between income and spending, or null if
+  /// there is insufficient data.
+  _i2.Future<int?> ageOfMoney(_i1.UuidValue budgetId) =>
+      caller.callServerEndpoint<int?>('transaction', 'ageOfMoney', {
+        'budgetId': budgetId,
+      });
+
   /// Deletes a transaction by ID.
   _i2.Future<_i13.Transaction> delete(_i1.UuidValue transactionId) =>
       caller.callServerEndpoint<_i13.Transaction>('transaction', 'delete', {

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -1500,6 +1500,21 @@ class Endpoints extends _i1.EndpointDispatch {
                     params['budgetId'],
                   ),
         ),
+        'ageOfMoney': _i1.MethodConnector(
+          name: 'ageOfMoney',
+          params: {
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['transaction'] as _i13.TransactionEndpoint).ageOfMoney(
+                session,
+                params['budgetId'],
+              ),
+        ),
         'delete': _i1.MethodConnector(
           name: 'delete',
           params: {

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -67,4 +67,5 @@ transaction:
   - listByAccount:
   - toggleCleared:
   - reconcileAccount:
+  - ageOfMoney:
   - delete:

--- a/openbudget_server/lib/src/transactions/transaction_endpoint.dart
+++ b/openbudget_server/lib/src/transactions/transaction_endpoint.dart
@@ -138,6 +138,14 @@ class TransactionEndpoint extends Endpoint {
     );
   }
 
+  /// Calculates the "Age of Money" for a budget.
+  ///
+  /// Returns the average days between income and spending, or null if
+  /// there is insufficient data.
+  Future<int?> ageOfMoney(Session session, UuidValue budgetId) async {
+    return TransactionService.ageOfMoney(session, budgetId: budgetId);
+  }
+
   /// Deletes a transaction by ID.
   Future<Transaction> delete(Session session, UuidValue transactionId) async {
     return TransactionService.delete(session, transactionId: transactionId);

--- a/openbudget_server/lib/src/transactions/transaction_service.dart
+++ b/openbudget_server/lib/src/transactions/transaction_service.dart
@@ -208,6 +208,70 @@ class TransactionService {
     return cleared.length;
   }
 
+  /// Calculates the "Age of Money" for a budget using FIFO matching.
+  ///
+  /// Returns the average number of days between income receipt and spending
+  /// for the most recent outflows, or null if insufficient data.
+  static Future<int?> ageOfMoney(
+    Session session, {
+    required UuidValue budgetId,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+
+    final transactions = await Transaction.db.find(
+      session,
+      where: (t) => t.budgetId.equals(budgetId),
+      orderBy: (t) => t.transactionDate,
+    );
+
+    if (transactions.isEmpty) return null;
+
+    // Separate inflows and outflows (exclude transfers), sorted oldest first.
+    final inflows = transactions
+        .where((t) => t.amountCents > 0 && t.transferPairId == null)
+        .toList();
+    final outflows = transactions
+        .where((t) => t.amountCents < 0 && t.transferPairId == null)
+        .toList();
+
+    if (inflows.isEmpty || outflows.isEmpty) return null;
+
+    // FIFO: match each outflow cent to the oldest available inflow cent.
+    final remainingCents = inflows.map((i) => i.amountCents).toList();
+    var inflowIdx = 0;
+    final ages = <int>[];
+
+    for (final outflow in outflows) {
+      var remaining = outflow.amountCents.abs();
+
+      while (remaining > 0 && inflowIdx < remainingCents.length) {
+        final available = remainingCents[inflowIdx];
+        final consumed = remaining < available ? remaining : available;
+        final ageDays = outflow.transactionDate
+            .difference(inflows[inflowIdx].transactionDate)
+            .inDays;
+
+        if (ageDays >= 0) {
+          ages.add(ageDays);
+        }
+
+        remaining -= consumed;
+        remainingCents[inflowIdx] -= consumed;
+
+        if (remainingCents[inflowIdx] <= 0) {
+          inflowIdx++;
+        }
+      }
+    }
+
+    if (ages.isEmpty) return null;
+
+    // Return average of the last 10 ages for recency.
+    final recentAges = ages.length > 10 ? ages.sublist(ages.length - 10) : ages;
+    final sum = recentAges.fold<int>(0, (s, a) => s + a);
+    return (sum / recentAges.length).round();
+  }
+
   /// Deletes a transaction, verifying budget ownership.
   static Future<Transaction> delete(
     Session session, {

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -2285,6 +2285,37 @@ class _TransactionEndpoint {
     });
   }
 
+  _i3.Future<int?> ageOfMoney(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue budgetId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'transaction',
+            method: 'ageOfMoney',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'transaction',
+          methodName: 'ageOfMoney',
+          parameters: _i1.testObjectToJson({'budgetId': budgetId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<int?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
   _i3.Future<_i13.Transaction> delete(
     _i1.TestSessionBuilder sessionBuilder,
     _i2.UuidValue transactionId,


### PR DESCRIPTION
## Summary
- Adds `ageOfMoney` backend endpoint using FIFO income-to-spending matching
- Computes average days between when money enters budget (income) and leaves (spending)
- Excludes transfer transactions from the calculation
- Uses last 10 matched spending events for recency-weighted average
- Displays metric in budget header with hourglass icon
- Gracefully hidden when insufficient transaction data

## Test plan
- [ ] Verify age of money calculates correctly with sample transactions
- [ ] Verify transfers are excluded from calculation
- [ ] Verify metric is hidden when no transactions exist
- [ ] Verify metric displays in budget header below "Ready to Assign"
- [ ] Verify singular/plural "day/days" localization works correctly