### PR TITLE
feat: add underfunded envelope indicators

### DIFF
--- a/.changeset/feat-underfunded-indicators.md
+++ b/.changeset/feat-underfunded-indicators.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add underfunded envelope indicators with goal progress bars on the budget dashboard.

--- a/openbudget_app/lib/src/features/budget/providers/budget_goals_provider.dart
+++ b/openbudget_app/lib/src/features/budget/providers/budget_goals_provider.dart
@@ -1,0 +1,106 @@
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/envelope_goal_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'budget_goals_provider.g.dart';
+
+/// Fetches all envelope goals for a budget and returns them as a map
+/// keyed by envelope ID string for quick lookup.
+@riverpod
+Future<Map<String, EnvelopeGoal>> budgetGoals(Ref ref, String budgetId) async {
+  final categories = await ref.watch(categoryListProvider(budgetId).future);
+  final allEnvelopeIds = <String>[];
+
+  for (final category in categories) {
+    final categoryId = category.id?.toString() ?? '';
+    final envelopes = await ref.watch(envelopeListProvider(categoryId).future);
+    for (final envelope in envelopes) {
+      final id = envelope.id?.toString();
+      if (id != null) {
+        allEnvelopeIds.add(id);
+      }
+    }
+  }
+
+  if (allEnvelopeIds.isEmpty) return {};
+
+  final goals = await ref.watch(envelopeGoalsProvider(allEnvelopeIds).future);
+  final map = <String, EnvelopeGoal>{};
+  for (final goal in goals) {
+    map[goal.envelopeId.toString()] = goal;
+  }
+  return map;
+}
+
+/// Computes the underfunded amount in cents for an envelope given its goal.
+///
+/// Returns 0 if fully funded, or a positive number representing how many
+/// cents still need to be assigned.
+int computeUnderfundedCents({
+  required EnvelopeGoal goal,
+  required int budgetedCents,
+  required int availableCents,
+}) {
+  switch (goal.goalType) {
+    case 'target_balance':
+      final needed = goal.targetAmountCents - availableCents;
+      return needed > 0 ? needed : 0;
+
+    case 'monthly_funding':
+      final target = goal.monthlyFundingCents ?? goal.targetAmountCents;
+      final needed = target - budgetedCents;
+      return needed > 0 ? needed : 0;
+
+    case 'target_by_date':
+      if (goal.targetDate == null) {
+        final needed = goal.targetAmountCents - availableCents;
+        return needed > 0 ? needed : 0;
+      }
+      final now = DateTime.now();
+      final target = goal.targetDate!;
+      if (target.isBefore(now)) {
+        final needed = goal.targetAmountCents - availableCents;
+        return needed > 0 ? needed : 0;
+      }
+      final remainingMonths =
+          (target.year - now.year) * 12 + (target.month - now.month);
+      if (remainingMonths <= 0) {
+        final needed = goal.targetAmountCents - availableCents;
+        return needed > 0 ? needed : 0;
+      }
+      final totalNeeded = goal.targetAmountCents - availableCents;
+      if (totalNeeded <= 0) return 0;
+      final monthlyNeeded = (totalNeeded / remainingMonths).ceil();
+      final needed = monthlyNeeded - budgetedCents;
+      return needed > 0 ? needed : 0;
+
+    default:
+      return 0;
+  }
+}
+
+/// Computes the funding progress as a fraction (0.0 to 1.0+).
+double computeFundingProgress({
+  required EnvelopeGoal goal,
+  required int budgetedCents,
+  required int availableCents,
+}) {
+  switch (goal.goalType) {
+    case 'target_balance':
+      if (goal.targetAmountCents <= 0) return 1;
+      return availableCents / goal.targetAmountCents;
+
+    case 'monthly_funding':
+      final target = goal.monthlyFundingCents ?? goal.targetAmountCents;
+      if (target <= 0) return 1;
+      return budgetedCents / target;
+
+    case 'target_by_date':
+      if (goal.targetAmountCents <= 0) return 1;
+      return availableCents / goal.targetAmountCents;
+
+    default:
+      return 1;
+  }
+}

--- a/openbudget_app/lib/src/features/budget/providers/budget_goals_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/budget_goals_provider.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budget_goals_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches all envelope goals for a budget and returns them as a map
+/// keyed by envelope ID string for quick lookup.
+
+@ProviderFor(budgetGoals)
+final budgetGoalsProvider = BudgetGoalsFamily._();
+
+/// Fetches all envelope goals for a budget and returns them as a map
+/// keyed by envelope ID string for quick lookup.
+
+final class BudgetGoalsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<Map<String, EnvelopeGoal>>,
+          Map<String, EnvelopeGoal>,
+          FutureOr<Map<String, EnvelopeGoal>>
+        >
+    with
+        $FutureModifier<Map<String, EnvelopeGoal>>,
+        $FutureProvider<Map<String, EnvelopeGoal>> {
+  /// Fetches all envelope goals for a budget and returns them as a map
+  /// keyed by envelope ID string for quick lookup.
+  BudgetGoalsProvider._({
+    required BudgetGoalsFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'budgetGoalsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetGoalsHash();
+
+  @override
+  String toString() {
+    return r'budgetGoalsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<Map<String, EnvelopeGoal>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<Map<String, EnvelopeGoal>> create(Ref ref) {
+    final argument = this.argument as String;
+    return budgetGoals(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BudgetGoalsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$budgetGoalsHash() => r'b5ac89cdc7c29235195212d8f82d8d38118c9bbf';
+
+/// Fetches all envelope goals for a budget and returns them as a map
+/// keyed by envelope ID string for quick lookup.
+
+final class BudgetGoalsFamily extends $Family
+    with
+        $FunctionalFamilyOverride<FutureOr<Map<String, EnvelopeGoal>>, String> {
+  BudgetGoalsFamily._()
+    : super(
+        retry: null,
+        name: r'budgetGoalsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches all envelope goals for a budget and returns them as a map
+  /// keyed by envelope ID string for quick lookup.
+
+  BudgetGoalsProvider call(String budgetId) =>
+      BudgetGoalsProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'budgetGoalsProvider';
+}

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_goals_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/category_actions_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/credit_card_provider.dart';
@@ -32,6 +33,7 @@ class BudgetDetailScreen extends HookConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final summaryAsync = ref.watch(budgetMonthlySummaryProvider(budgetId));
     final ccPayments = ref.watch(creditCardPaymentsProvider(budgetId));
+    final goalsAsync = ref.watch(budgetGoalsProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -73,6 +75,9 @@ class BudgetDetailScreen extends HookConsumerWidget {
           (c) => c.code == summary.budget.currencyCode,
           orElse: () => CurrencyCode.usd,
         );
+        final goalsMap = goalsAsync.hasValue
+            ? goalsAsync.value!
+            : <String, EnvelopeGoal>{};
 
         return Scaffold(
           appBar: AppBar(
@@ -113,6 +118,7 @@ class BudgetDetailScreen extends HookConsumerWidget {
                 ..invalidate(transactionListProvider(budgetId))
                 ..invalidate(budgetSummaryProvider(budgetId))
                 ..invalidate(budgetMonthlySummaryProvider(budgetId))
+                ..invalidate(budgetGoalsProvider(budgetId))
                 ..invalidate(
                   monthlyAllocationsProvider(
                     budgetId,
@@ -182,6 +188,7 @@ class BudgetDetailScreen extends HookConsumerWidget {
                     child: CategoryGroup(
                       categoryWithEnvelopes: catWithEnvelopes,
                       currencyCode: currencyCode,
+                      goalsMap: goalsMap,
                       onAddEnvelope: () => _showAddEnvelopeDialog(
                         context,
                         catWithEnvelopes.category.id?.toString() ?? '',

--- a/openbudget_app/lib/src/features/budget/widgets/category_group.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/category_group.dart
@@ -17,6 +17,7 @@ class CategoryGroup extends HookConsumerWidget {
     required this.onEditEnvelope,
     required this.onDeleteEnvelope,
     this.onQuickBudget,
+    this.goalsMap = const {},
     super.key,
   });
 
@@ -27,6 +28,7 @@ class CategoryGroup extends HookConsumerWidget {
   final void Function(Envelope envelope) onEditEnvelope;
   final void Function(Envelope envelope) onDeleteEnvelope;
   final void Function(Envelope envelope)? onQuickBudget;
+  final Map<String, EnvelopeGoal> goalsMap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -103,6 +105,7 @@ class CategoryGroup extends HookConsumerWidget {
           const Divider(),
           ...envelopes.asMap().entries.map((entry) {
             final envelope = entry.value;
+            final envelopeId = envelope.id?.toString() ?? '';
             final monthlyData =
                 categoryWithEnvelopes.monthlyEnvelopes.isNotEmpty &&
                     entry.key < categoryWithEnvelopes.monthlyEnvelopes.length
@@ -112,6 +115,7 @@ class CategoryGroup extends HookConsumerWidget {
               envelope: envelope,
               currencyCode: currencyCode,
               monthlyData: monthlyData,
+              goal: goalsMap[envelopeId],
               onTap: () => onEditEnvelope(envelope),
               onLongPress: () => onDeleteEnvelope(envelope),
               onQuickBudget: onQuickBudget != null

--- a/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_goals_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
@@ -14,6 +16,7 @@ class EnvelopeRow extends HookConsumerWidget {
     required this.onLongPress,
     this.monthlyData,
     this.onQuickBudget,
+    this.goal,
     super.key,
   });
 
@@ -23,6 +26,7 @@ class EnvelopeRow extends HookConsumerWidget {
   final VoidCallback onLongPress;
   final MonthlyEnvelopeData? monthlyData;
   final VoidCallback? onQuickBudget;
+  final EnvelopeGoal? goal;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -45,70 +49,144 @@ class EnvelopeRow extends HookConsumerWidget {
           horizontal: SpacingTokens.sm + SpacingTokens.xs,
           vertical: SpacingTokens.sm,
         ),
-        child: Row(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            if (onQuickBudget != null)
-              GestureDetector(
-                onTap: onQuickBudget,
-                child: Padding(
-                  padding: const EdgeInsets.only(right: SpacingTokens.xs),
-                  child: Icon(
-                    Icons.bolt_rounded,
-                    size: 16,
-                    color: theme.colorScheme.primary.withAlpha(150),
+            Row(
+              children: [
+                if (onQuickBudget != null)
+                  GestureDetector(
+                    onTap: onQuickBudget,
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: SpacingTokens.xs),
+                      child: Icon(
+                        Icons.bolt_rounded,
+                        size: 16,
+                        color: theme.colorScheme.primary.withAlpha(150),
+                      ),
+                    ),
+                  )
+                else
+                  const SizedBox(width: SpacingTokens.xs),
+                Expanded(
+                  flex: 4,
+                  child: Text(
+                    envelope.name,
+                    style: theme.textTheme.bodyMedium,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
-              )
-            else
-              const SizedBox(width: SpacingTokens.xs),
-            Expanded(
-              flex: 4,
-              child: Text(
-                envelope.name,
-                style: theme.textTheme.bodyMedium,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            Expanded(
-              flex: 3,
-              child: Text(
-                formatCents(budgeted, currencyCode),
-                textAlign: TextAlign.right,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.bodySmall,
-              ),
-            ),
-            Expanded(
-              flex: 3,
-              child: Text(
-                formatCents(spent, currencyCode),
-                textAlign: TextAlign.right,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: spent > 0 ? ColorTokens.error : null,
+                Expanded(
+                  flex: 3,
+                  child: Text(
+                    formatCents(budgeted, currencyCode),
+                    textAlign: TextAlign.right,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall,
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(width: SpacingTokens.xs),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: availableColor.withAlpha(25),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                formatCents(available, currencyCode),
-                maxLines: 1,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: availableColor,
-                  fontWeight: FontWeight.w600,
+                Expanded(
+                  flex: 3,
+                  child: Text(
+                    formatCents(spent, currencyCode),
+                    textAlign: TextAlign.right,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: spent > 0 ? ColorTokens.error : null,
+                    ),
+                  ),
                 ),
-              ),
+                const SizedBox(width: SpacingTokens.xs),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: availableColor.withAlpha(25),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    formatCents(available, currencyCode),
+                    maxLines: 1,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: availableColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
             ),
+            if (goal != null)
+              _GoalProgressBar(
+                goal: goal!,
+                budgetedCents: budgeted,
+                availableCents: available,
+              ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _GoalProgressBar extends HookWidget {
+  const _GoalProgressBar({
+    required this.goal,
+    required this.budgetedCents,
+    required this.availableCents,
+  });
+
+  final EnvelopeGoal goal;
+  final int budgetedCents;
+  final int availableCents;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = computeFundingProgress(
+      goal: goal,
+      budgetedCents: budgetedCents,
+      availableCents: availableCents,
+    );
+    final clampedProgress = progress.clamp(0.0, 1.0);
+    final underfunded = computeUnderfundedCents(
+      goal: goal,
+      budgetedCents: budgetedCents,
+      availableCents: availableCents,
+    );
+
+    final Color barColor;
+    if (progress >= 1.0) {
+      barColor = ColorTokens.secondary;
+    } else if (progress >= 0.5) {
+      barColor = ColorTokens.tertiary;
+    } else {
+      barColor = ColorTokens.error;
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        children: [
+          const SizedBox(width: SpacingTokens.xs),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                value: clampedProgress,
+                minHeight: 3,
+                backgroundColor: barColor.withAlpha(30),
+                valueColor: AlwaysStoppedAnimation<Color>(barColor),
+              ),
+            ),
+          ),
+          if (underfunded > 0) ...[
+            const SizedBox(width: SpacingTokens.xs),
+            Icon(Icons.warning_amber_rounded, size: 12, color: barColor),
+          ],
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Add a `budgetGoalsProvider` that fetches all envelope goals for a budget and returns them as a map keyed by envelope ID
- Add `computeUnderfundedCents()` and `computeFundingProgress()` utility functions that calculate funding status for all three goal types (target_balance, monthly_funding, target_by_date)
- Show a thin progress bar below each envelope row when a goal is set, color-coded: green (fully funded), amber (partially funded), red (underfunded)
- Display a small warning icon next to the progress bar when the envelope is underfunded

## Test plan
- [ ] Verify envelopes without goals show no progress bar
- [ ] Set a target_balance goal and verify the progress bar reflects available vs target
- [ ] Set a monthly_funding goal and verify progress reflects budgeted vs monthly target
- [ ] Set a target_by_date goal and verify progress reflects available vs overall target
- [ ] Verify color transitions: red (<50%), amber (50-99%), green (100%+)
- [ ] Verify warning icon appears only when underfunded
- [ ] Pull-to-refresh reloads goal data