### PR TITLE
feat: add payee auto-suggest with last-used envelope

### DIFF
--- a/.changeset/feat-payee-auto-envelope.md
+++ b/.changeset/feat-payee-auto-envelope.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add payee auto-suggest with last-used envelope on expense screen

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -259,5 +259,8 @@
         "type": "int"
       }
     }
-  }
+  },
+  "payeeNone": "No Payee",
+  "payeeLabel": "Payee",
+  "payeeAutoEnvelopeHint": "Envelope auto-suggested from last transaction with this payee"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1443,6 +1443,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{1 split} other{{count} splits}}'**
   String splitCount(int count);
+
+  /// No description provided for @payeeNone.
+  ///
+  /// In en, this message translates to:
+  /// **'No Payee'**
+  String get payeeNone;
+
+  /// No description provided for @payeeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Payee'**
+  String get payeeLabel;
+
+  /// No description provided for @payeeAutoEnvelopeHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Envelope auto-suggested from last transaction with this payee'**
+  String get payeeAutoEnvelopeHint;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -737,4 +737,14 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get payeeNone => 'No Payee';
+
+  @override
+  String get payeeLabel => 'Payee';
+
+  @override
+  String get payeeAutoEnvelopeHint =>
+      'Envelope auto-suggested from last transaction with this payee';
 }

--- a/openbudget_app/lib/src/features/payees/providers/payee_last_envelope_provider.dart
+++ b/openbudget_app/lib/src/features/payees/providers/payee_last_envelope_provider.dart
@@ -1,0 +1,28 @@
+import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'payee_last_envelope_provider.g.dart';
+
+/// Fetches the last-used envelope ID for a payee in a budget.
+///
+/// Returns null if the payee has no previous transactions with an envelope.
+@riverpod
+Future<String?> payeeLastEnvelope(
+  Ref ref,
+  String payeeId,
+  String budgetId,
+) async {
+  final client = ref.read(serverpodClientProvider);
+  // Serverpod API requires UuidValue which is experimental in uuid package.
+  // ignore: experimental_member_use
+  final payeeUuid = UuidValue.fromString(payeeId);
+  // Serverpod API requires UuidValue which is experimental in uuid package.
+  // ignore: experimental_member_use
+  final budgetUuid = UuidValue.fromString(budgetId);
+  final envelopeId = await client.payee.lastUsedEnvelopeId(
+    payeeUuid,
+    budgetUuid,
+  );
+  return envelopeId?.toString();
+}

--- a/openbudget_app/lib/src/features/payees/providers/payee_last_envelope_provider.g.dart
+++ b/openbudget_app/lib/src/features/payees/providers/payee_last_envelope_provider.g.dart
@@ -1,0 +1,97 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'payee_last_envelope_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches the last-used envelope ID for a payee in a budget.
+///
+/// Returns null if the payee has no previous transactions with an envelope.
+
+@ProviderFor(payeeLastEnvelope)
+final payeeLastEnvelopeProvider = PayeeLastEnvelopeFamily._();
+
+/// Fetches the last-used envelope ID for a payee in a budget.
+///
+/// Returns null if the payee has no previous transactions with an envelope.
+
+final class PayeeLastEnvelopeProvider
+    extends $FunctionalProvider<AsyncValue<String?>, String?, FutureOr<String?>>
+    with $FutureModifier<String?>, $FutureProvider<String?> {
+  /// Fetches the last-used envelope ID for a payee in a budget.
+  ///
+  /// Returns null if the payee has no previous transactions with an envelope.
+  PayeeLastEnvelopeProvider._({
+    required PayeeLastEnvelopeFamily super.from,
+    required (String, String) super.argument,
+  }) : super(
+         retry: null,
+         name: r'payeeLastEnvelopeProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$payeeLastEnvelopeHash();
+
+  @override
+  String toString() {
+    return r'payeeLastEnvelopeProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<String?> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<String?> create(Ref ref) {
+    final argument = this.argument as (String, String);
+    return payeeLastEnvelope(ref, argument.$1, argument.$2);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is PayeeLastEnvelopeProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$payeeLastEnvelopeHash() => r'b987f3d9d79be1eafd5999d26e0715a86add8710';
+
+/// Fetches the last-used envelope ID for a payee in a budget.
+///
+/// Returns null if the payee has no previous transactions with an envelope.
+
+final class PayeeLastEnvelopeFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<String?>, (String, String)> {
+  PayeeLastEnvelopeFamily._()
+    : super(
+        retry: null,
+        name: r'payeeLastEnvelopeProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches the last-used envelope ID for a payee in a budget.
+  ///
+  /// Returns null if the payee has no previous transactions with an envelope.
+
+  PayeeLastEnvelopeProvider call(String payeeId, String budgetId) =>
+      PayeeLastEnvelopeProvider._(argument: (payeeId, budgetId), from: this);
+
+  @override
+  String toString() => r'payeeLastEnvelopeProvider';
+}

--- a/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
@@ -119,6 +119,7 @@ class TransactionActions extends _$TransactionActions {
     required DateTime date,
     String? envelopeId,
     String? categoryId,
+    String? payeeId,
   }) async {
     state = const AsyncValue.loading();
     final client = ref.read(serverpodClientProvider);
@@ -135,6 +136,11 @@ class TransactionActions extends _$TransactionActions {
             // Serverpod API requires UuidValue which is experimental in uuid package.
             // ignore: experimental_member_use
             ? UuidValue.fromString(envelopeId)
+            : null,
+        payeeId: payeeId != null
+            // Serverpod API requires UuidValue which is experimental in uuid package.
+            // ignore: experimental_member_use
+            ? UuidValue.fromString(payeeId)
             : null,
       );
 

--- a/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.g.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.g.dart
@@ -42,7 +42,7 @@ final class TransactionActionsProvider
 }
 
 String _$transactionActionsHash() =>
-    r'f97ecbcf4498f665b80f42966dcd70ebfd0c202c';
+    r'c91633922a47ece5e9e702d52371dbae44ae0563';
 
 abstract class _$TransactionActions extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
@@ -5,6 +5,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/payees/providers/payee_last_envelope_provider.dart';
+import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/transaction_actions_provider.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
@@ -22,18 +24,35 @@ class AddExpenseScreen extends HookConsumerWidget {
     final isSubmitting = useState(false);
     final selectedEnvelopeId = useState<String?>(null);
     final selectedCategoryId = useState<String?>(null);
+    final selectedPayeeId = useState<String?>(null);
     final budgetAsync = ref.watch(budgetDetailProvider(budgetId));
     final summaryAsync = ref.watch(budgetSummaryProvider(budgetId));
+    final payeesAsync = ref.watch(payeeListProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
+    // Build payee dropdown items.
+    final payeeItems = <DropdownMenuItem<String>>[
+      DropdownMenuItem<String>(value: '', child: Text(l10n.payeeNone)),
+    ];
+    if (payeesAsync.hasValue) {
+      for (final payee in payeesAsync.value!) {
+        payeeItems.add(
+          DropdownMenuItem<String>(
+            value: payee.id?.toString() ?? '',
+            child: Text(payee.name),
+          ),
+        );
+      }
+    }
+
+    // Build envelope dropdown items.
     final envelopeItems = <DropdownMenuItem<String>>[
       DropdownMenuItem<String>(
         value: '',
         child: Text(l10n.transactionUnassigned),
       ),
     ];
-
     if (summaryAsync.hasValue) {
       for (final catEnv in summaryAsync.value!.categories) {
         for (final envelope in catEnv.envelopes) {
@@ -45,6 +64,21 @@ class AddExpenseScreen extends HookConsumerWidget {
           );
         }
       }
+    }
+
+    // Helper to update selectedCategoryId when envelope changes.
+    void updateCategoryForEnvelope(String envId) {
+      if (envId.isNotEmpty && summaryAsync.hasValue) {
+        for (final catEnv in summaryAsync.value!.categories) {
+          for (final envelope in catEnv.envelopes) {
+            if (envelope.id?.toString() == envId) {
+              selectedCategoryId.value = catEnv.category.id?.toString();
+              return;
+            }
+          }
+        }
+      }
+      selectedCategoryId.value = null;
     }
 
     return Scaffold(
@@ -111,24 +145,37 @@ class AddExpenseScreen extends HookConsumerWidget {
                     ),
                     const SizedBox(height: SpacingTokens.md),
                     DropdownButtonFormField<String>(
+                      initialValue: selectedPayeeId.value ?? '',
+                      items: payeeItems,
+                      onChanged: (value) async {
+                        final payId = value ?? '';
+                        selectedPayeeId.value = payId.isEmpty ? null : payId;
+
+                        // Auto-suggest last-used envelope for this payee.
+                        if (payId.isNotEmpty) {
+                          final lastEnvelope = await ref.read(
+                            payeeLastEnvelopeProvider(payId, budgetId).future,
+                          );
+                          if (lastEnvelope != null) {
+                            selectedEnvelopeId.value = lastEnvelope;
+                            updateCategoryForEnvelope(lastEnvelope);
+                          }
+                        }
+                      },
+                      decoration: InputDecoration(
+                        prefixIcon: const Icon(Icons.store_rounded),
+                        labelText: l10n.payeeLabel,
+                      ),
+                      isExpanded: true,
+                    ),
+                    const SizedBox(height: SpacingTokens.md),
+                    DropdownButtonFormField<String>(
                       initialValue: selectedEnvelopeId.value ?? '',
                       items: envelopeItems,
                       onChanged: (value) {
                         final envId = value ?? '';
                         selectedEnvelopeId.value = envId.isEmpty ? null : envId;
-
-                        if (envId.isNotEmpty && summaryAsync.hasValue) {
-                          for (final catEnv in summaryAsync.value!.categories) {
-                            for (final envelope in catEnv.envelopes) {
-                              if (envelope.id?.toString() == envId) {
-                                selectedCategoryId.value = catEnv.category.id
-                                    ?.toString();
-                              }
-                            }
-                          }
-                        } else {
-                          selectedCategoryId.value = null;
-                        }
+                        updateCategoryForEnvelope(envId);
                       },
                       decoration: InputDecoration(
                         prefixIcon: const Icon(Icons.mail_outlined),
@@ -136,6 +183,18 @@ class AddExpenseScreen extends HookConsumerWidget {
                       ),
                       isExpanded: true,
                     ),
+                    if (selectedPayeeId.value != null &&
+                        selectedEnvelopeId.value != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: SpacingTokens.xs),
+                        child: Text(
+                          l10n.payeeAutoEnvelopeHint,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                            fontStyle: FontStyle.italic,
+                          ),
+                        ),
+                      ),
                     const SizedBox(height: SpacingTokens.lg),
                     FilledButton(
                       onPressed: isSubmitting.value
@@ -173,6 +232,7 @@ class AddExpenseScreen extends HookConsumerWidget {
                                       date: DateTime.now(),
                                       envelopeId: selectedEnvelopeId.value,
                                       categoryId: selectedCategoryId.value,
+                                      payeeId: selectedPayeeId.value,
                                     );
                                 messenger.showSnackBar(
                                   SnackBar(

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -630,6 +630,16 @@ class EndpointPayee extends _i1.EndpointRef {
         'name': name,
       });
 
+  /// Returns the envelope ID from the most recent transaction for a payee.
+  _i2.Future<_i1.UuidValue?> lastUsedEnvelopeId(
+    _i1.UuidValue payeeId,
+    _i1.UuidValue budgetId,
+  ) => caller.callServerEndpoint<_i1.UuidValue?>(
+    'payee',
+    'lastUsedEnvelopeId',
+    {'payeeId': payeeId, 'budgetId': budgetId},
+  );
+
   /// Deletes a payee by ID.
   _i2.Future<_i11.Payee> delete(_i1.UuidValue payeeId) => caller
       .callServerEndpoint<_i11.Payee>('payee', 'delete', {'payeeId': payeeId});

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -1020,6 +1020,27 @@ class Endpoints extends _i1.EndpointDispatch {
                 name: params['name'],
               ),
         ),
+        'lastUsedEnvelopeId': _i1.MethodConnector(
+          name: 'lastUsedEnvelopeId',
+          params: {
+            'payeeId': _i1.ParameterDescription(
+              name: 'payeeId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['payee'] as _i11.PayeeEndpoint).lastUsedEnvelopeId(
+                session,
+                params['payeeId'],
+                params['budgetId'],
+              ),
+        ),
         'delete': _i1.MethodConnector(
           name: 'delete',
           params: {

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -50,6 +50,7 @@ payee:
   - list:
   - get:
   - update:
+  - lastUsedEnvelopeId:
   - delete:
 recurringTransaction:
   - create:

--- a/openbudget_server/lib/src/payees/payee_endpoint.dart
+++ b/openbudget_server/lib/src/payees/payee_endpoint.dart
@@ -33,6 +33,19 @@ class PayeeEndpoint extends Endpoint {
     return PayeeService.update(session, payeeId: payeeId, name: name);
   }
 
+  /// Returns the envelope ID from the most recent transaction for a payee.
+  Future<UuidValue?> lastUsedEnvelopeId(
+    Session session,
+    UuidValue payeeId,
+    UuidValue budgetId,
+  ) async {
+    return PayeeService.lastUsedEnvelopeId(
+      session,
+      payeeId: payeeId,
+      budgetId: budgetId,
+    );
+  }
+
   /// Deletes a payee by ID.
   Future<Payee> delete(Session session, UuidValue payeeId) async {
     return PayeeService.delete(session, payeeId: payeeId);

--- a/openbudget_server/lib/src/payees/payee_service.dart
+++ b/openbudget_server/lib/src/payees/payee_service.dart
@@ -1,7 +1,7 @@
 import 'package:openbudget_server/src/budgets/budget_service.dart';
 import 'package:openbudget_server/src/exceptions/exceptions.dart';
 import 'package:openbudget_server/src/generated/protocol.dart';
-import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/serverpod.dart' hide Transaction;
 
 /// Business logic for managing payees within a budget.
 ///
@@ -61,6 +61,30 @@ class PayeeService {
 
     final updated = payee.copyWith(name: name ?? payee.name);
     return Payee.db.updateRow(session, updated);
+  }
+
+  /// Returns the envelope ID from the most recent transaction for a payee,
+  /// or null if no transactions exist for the payee.
+  static Future<UuidValue?> lastUsedEnvelopeId(
+    Session session, {
+    required UuidValue payeeId,
+    required UuidValue budgetId,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+
+    final transactions = await Transaction.db.find(
+      session,
+      where: (t) =>
+          t.payeeId.equals(payeeId) &
+          t.budgetId.equals(budgetId) &
+          t.envelopeId.notEquals(null),
+      orderBy: (t) => t.transactionDate,
+      orderDescending: true,
+      limit: 1,
+    );
+
+    if (transactions.isEmpty) return null;
+    return transactions.first.envelopeId;
   }
 
   /// Deletes a payee, verifying ownership.

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -1701,6 +1701,41 @@ class _PayeeEndpoint {
     });
   }
 
+  _i3.Future<_i2.UuidValue?> lastUsedEnvelopeId(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue payeeId,
+    _i2.UuidValue budgetId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'payee',
+            method: 'lastUsedEnvelopeId',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'payee',
+          methodName: 'lastUsedEnvelopeId',
+          parameters: _i1.testObjectToJson({
+            'payeeId': payeeId,
+            'budgetId': budgetId,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<_i2.UuidValue?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
   _i3.Future<_i11.Payee> delete(
     _i1.TestSessionBuilder sessionBuilder,
     _i2.UuidValue payeeId,


### PR DESCRIPTION
## Summary
- Adds backend endpoint `PayeeEndpoint.lastUsedEnvelopeId()` that queries the most recent transaction for a payee to find its last-used envelope
- Creates `payeeLastEnvelopeProvider` on the frontend to fetch this data
- Updates the Add Expense screen with a payee dropdown that auto-fills the envelope when a payee is selected
- Passes `payeeId` through to the transaction creation API

## Test plan
- [ ] Select a payee on the Add Expense screen and verify the envelope dropdown auto-fills with the last-used envelope
- [ ] Verify the hint text appears when auto-suggest is active
- [ ] Verify saving an expense with a payee works correctly
- [ ] Verify selecting "No Payee" clears the auto-suggest