### PR TITLE
feat: add running balance column to account transactions

### DIFF
--- a/.changeset/feat-running-balance.md
+++ b/.changeset/feat-running-balance.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add running balance column to account transaction list

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -262,5 +262,6 @@
   },
   "payeeNone": "No Payee",
   "payeeLabel": "Payee",
-  "payeeAutoEnvelopeHint": "Envelope auto-suggested from last transaction with this payee"
+  "payeeAutoEnvelopeHint": "Envelope auto-suggested from last transaction with this payee",
+  "accountRunningBalance": "Running Balance"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1461,6 +1461,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Envelope auto-suggested from last transaction with this payee'**
   String get payeeAutoEnvelopeHint;
+
+  /// No description provided for @accountRunningBalance.
+  ///
+  /// In en, this message translates to:
+  /// **'Running Balance'**
+  String get accountRunningBalance;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -747,4 +747,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get payeeAutoEnvelopeHint =>
       'Envelope auto-suggested from last transaction with this payee';
+
+  @override
+  String get accountRunningBalance => 'Running Balance';
 }

--- a/openbudget_app/lib/src/features/accounts/screens/account_detail_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/account_detail_screen.dart
@@ -132,6 +132,21 @@ class AccountDetailScreen extends HookConsumerWidget {
                   );
                 }
 
+                // Compute running balances. Transactions are newest-first.
+                // Current balance = starting balance + sum of all txn amounts.
+                final startingBalance = accountData?.balanceCents ?? 0;
+                final totalTxnAmount = transactions.fold<int>(
+                  0,
+                  (sum, t) => sum + t.amountCents,
+                );
+                final currentBalance = startingBalance + totalTxnAmount;
+                final runningBalances = <int>[];
+                var balance = currentBalance;
+                for (var i = 0; i < transactions.length; i++) {
+                  runningBalances.add(balance);
+                  balance -= transactions[i].amountCents;
+                }
+
                 return RefreshIndicator(
                   onRefresh: () async {
                     ref.invalidate(
@@ -148,6 +163,7 @@ class AccountDetailScreen extends HookConsumerWidget {
                       return _TransactionRow(
                         transaction: txn,
                         currencyCode: currencyCode,
+                        runningBalanceCents: runningBalances[index],
                         onToggleCleared: txn.reconciled
                             ? null
                             : () => _toggleCleared(context, ref, txn),
@@ -260,11 +276,13 @@ class _TransactionRow extends HookWidget {
   const _TransactionRow({
     required this.transaction,
     required this.currencyCode,
+    required this.runningBalanceCents,
     this.onToggleCleared,
   });
 
   final Transaction transaction;
   final CurrencyCode currencyCode;
+  final int runningBalanceCents;
   final VoidCallback? onToggleCleared;
 
   @override
@@ -313,12 +331,25 @@ class _TransactionRow extends HookWidget {
                 ],
               ),
             ),
-            Text(
-              formatCents(transaction.amountCents, currencyCode),
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-                color: isInflow ? ColorTokens.secondary : colorScheme.error,
-              ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  formatCents(transaction.amountCents, currencyCode),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: isInflow ? ColorTokens.secondary : colorScheme.error,
+                  ),
+                ),
+                Text(
+                  formatCents(runningBalanceCents, currencyCode),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: runningBalanceCents >= 0
+                        ? colorScheme.onSurfaceVariant
+                        : colorScheme.error,
+                  ),
+                ),
+              ],
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- Computes running balance for each transaction in the account detail screen
- Balance calculated from starting account balance + cumulative transaction amounts
- Shows running balance below each transaction amount, color-coded (red when negative)
- Adds `accountRunningBalance` l10n string

## Test plan
- [ ] Open an account detail screen with multiple transactions
- [ ] Verify each row shows the transaction amount and running balance below it
- [ ] Verify running balance is red when negative
- [ ] Verify the topmost (newest) transaction's running balance matches the account balance header