### PR TITLE
feat: add overspending indicators with warning icons

### DIFF
--- a/.changeset/feat-overspending-indicators.md
+++ b/.changeset/feat-overspending-indicators.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add overspending indicators with warning icons on envelopes, categories, and budget header

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -263,5 +263,13 @@
   "payeeNone": "No Payee",
   "payeeLabel": "Payee",
   "payeeAutoEnvelopeHint": "Envelope auto-suggested from last transaction with this payee",
-  "accountRunningBalance": "Running Balance"
+  "accountRunningBalance": "Running Balance",
+  "budgetOverspentWarning": "Overspent: {amount}",
+  "@budgetOverspentWarning": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1467,6 +1467,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Running Balance'**
   String get accountRunningBalance;
+
+  /// No description provided for @budgetOverspentWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'Overspent: {amount}'**
+  String budgetOverspentWarning(String amount);
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -750,4 +750,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get accountRunningBalance => 'Running Balance';
+
+  @override
+  String budgetOverspentWarning(String amount) {
+    return 'Overspent: $amount';
+  }
 }

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -79,6 +79,14 @@ class BudgetDetailScreen extends HookConsumerWidget {
             ? goalsAsync.value!
             : <String, EnvelopeGoal>{};
 
+        // Compute total overspent cents across all categories.
+        var totalOverspentCents = 0;
+        for (final cat in summary.categories) {
+          if (cat.totalAvailableCents < 0) {
+            totalOverspentCents += cat.totalAvailableCents.abs();
+          }
+        }
+
         return Scaffold(
           appBar: AppBar(
             leading: IconButton(
@@ -143,6 +151,7 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   budgetId: budgetId,
                   year: summary.year,
                   month: summary.month,
+                  totalOverspentCents: totalOverspentCents,
                 ),
                 const SizedBox(height: SpacingTokens.md),
                 if (ccPayments.hasValue && ccPayments.value!.isNotEmpty) ...[

--- a/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
@@ -14,6 +14,7 @@ class BudgetHeader extends HookConsumerWidget {
     required this.budgetId,
     required this.year,
     required this.month,
+    this.totalOverspentCents = 0,
     super.key,
   });
 
@@ -22,6 +23,7 @@ class BudgetHeader extends HookConsumerWidget {
   final String budgetId;
   final int year;
   final int month;
+  final int totalOverspentCents;
 
   static const _monthNames = [
     'January',
@@ -116,6 +118,39 @@ class BudgetHeader extends HookConsumerWidget {
               fontWeight: FontWeight.bold,
             ),
           ),
+          if (totalOverspentCents > 0) ...[
+            const SizedBox(height: SpacingTokens.sm),
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: SpacingTokens.sm,
+                vertical: SpacingTokens.xs,
+              ),
+              decoration: BoxDecoration(
+                color: ColorTokens.error.withAlpha(20),
+                borderRadius: BorderRadius.circular(RadiusTokens.sm),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.warning_amber_rounded,
+                    size: 16,
+                    color: ColorTokens.error,
+                  ),
+                  const SizedBox(width: SpacingTokens.xs),
+                  Text(
+                    l10n.budgetOverspentWarning(
+                      formatCents(totalOverspentCents, currencyCode),
+                    ),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: ColorTokens.error,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
           if (ageOfMoneyAsync.hasValue && ageOfMoneyAsync.value != null) ...[
             const SizedBox(height: SpacingTokens.sm),
             Row(

--- a/openbudget_app/lib/src/features/budget/widgets/category_group.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/category_group.dart
@@ -175,17 +175,45 @@ class CategoryGroup extends HookConsumerWidget {
                   ),
                 ),
                 const SizedBox(width: SpacingTokens.xs),
-                Text(
-                  formatCents(
-                    categoryWithEnvelopes.totalAvailableCents,
-                    currencyCode,
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
                   ),
-                  maxLines: 1,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    fontWeight: FontWeight.bold,
+                  decoration: BoxDecoration(
                     color: _availableColor(
                       categoryWithEnvelopes.totalAvailableCents,
-                    ),
+                    ).withAlpha(20),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (categoryWithEnvelopes.totalAvailableCents < 0)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 3),
+                          child: Icon(
+                            Icons.warning_amber_rounded,
+                            size: 12,
+                            color: _availableColor(
+                              categoryWithEnvelopes.totalAvailableCents,
+                            ),
+                          ),
+                        ),
+                      Text(
+                        formatCents(
+                          categoryWithEnvelopes.totalAvailableCents,
+                          currencyCode,
+                        ),
+                        maxLines: 1,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: _availableColor(
+                            categoryWithEnvelopes.totalAvailableCents,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ],

--- a/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
@@ -108,13 +108,27 @@ class EnvelopeRow extends HookConsumerWidget {
                     color: availableColor.withAlpha(25),
                     borderRadius: BorderRadius.circular(4),
                   ),
-                  child: Text(
-                    formatCents(available, currencyCode),
-                    maxLines: 1,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: availableColor,
-                      fontWeight: FontWeight.w600,
-                    ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (available < 0)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 3),
+                          child: Icon(
+                            Icons.warning_amber_rounded,
+                            size: 12,
+                            color: availableColor,
+                          ),
+                        ),
+                      Text(
+                        formatCents(available, currencyCode),
+                        maxLines: 1,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: availableColor,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- Envelope rows now show a warning icon when the available balance is negative (overspent)
- Category group total rows display a warning icon + red pill when overspent
- Budget header shows total overspent amount with a warning banner when any categories are overspent
- Adds `budgetOverspentWarning` l10n string with parameterized amount

## Test plan
- [ ] Create an envelope with spending exceeding the budgeted amount
- [ ] Verify the warning icon appears on the envelope row's available balance
- [ ] Verify the category total row shows the warning icon when negative
- [ ] Verify the budget header shows the "Overspent: $X.XX" warning banner
- [ ] Verify no warning icons appear when all envelopes are funded