### PR TITLE
feat: add CSV transaction import with paste-and-preview

### DIFF
--- a/.changeset/feat-csv-import.md
+++ b/.changeset/feat-csv-import.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add CSV transaction import with paste-and-preview workflow

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -271,5 +271,44 @@
         "type": "String"
       }
     }
+  },
+  "importTitle": "Import Transactions",
+  "importInstructions": "Paste CSV data with columns for date, description, and amount. Headers are auto-detected.",
+  "importCsvLabel": "CSV Data",
+  "importCsvHint": "Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00",
+  "importPreview": "Preview",
+  "importPreviewCount": "{count, plural, =1{1 transaction to import} other{{count} transactions to import}}",
+  "@importPreviewCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "importButton": "{count, plural, =1{Import 1 Transaction} other{Import {count} Transactions}}",
+  "@importButton": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "importImporting": "Importing...",
+  "importSuccess": "{count, plural, =1{1 transaction imported} other{{count} transactions imported}}",
+  "@importSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "importError": "Could not import transactions. Please try again.",
+  "importMoreRows": "{count, plural, =1{...and 1 more row} other{...and {count} more rows}}",
+  "@importMoreRows": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1473,6 +1473,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Overspent: {amount}'**
   String budgetOverspentWarning(String amount);
+
+  /// No description provided for @importTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import Transactions'**
+  String get importTitle;
+
+  /// No description provided for @importInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Paste CSV data with columns for date, description, and amount. Headers are auto-detected.'**
+  String get importInstructions;
+
+  /// No description provided for @importCsvLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'CSV Data'**
+  String get importCsvLabel;
+
+  /// No description provided for @importCsvHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00'**
+  String get importCsvHint;
+
+  /// No description provided for @importPreview.
+  ///
+  /// In en, this message translates to:
+  /// **'Preview'**
+  String get importPreview;
+
+  /// No description provided for @importPreviewCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction to import} other{{count} transactions to import}}'**
+  String importPreviewCount(int count);
+
+  /// No description provided for @importButton.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Import 1 Transaction} other{Import {count} Transactions}}'**
+  String importButton(int count);
+
+  /// No description provided for @importImporting.
+  ///
+  /// In en, this message translates to:
+  /// **'Importing...'**
+  String get importImporting;
+
+  /// No description provided for @importSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction imported} other{{count} transactions imported}}'**
+  String importSuccess(int count);
+
+  /// No description provided for @importError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not import transactions. Please try again.'**
+  String get importError;
+
+  /// No description provided for @importMoreRows.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{...and 1 more row} other{...and {count} more rows}}'**
+  String importMoreRows(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -755,4 +755,71 @@ class AppLocalizationsEn extends AppLocalizations {
   String budgetOverspentWarning(String amount) {
     return 'Overspent: $amount';
   }
+
+  @override
+  String get importTitle => 'Import Transactions';
+
+  @override
+  String get importInstructions =>
+      'Paste CSV data with columns for date, description, and amount. Headers are auto-detected.';
+
+  @override
+  String get importCsvLabel => 'CSV Data';
+
+  @override
+  String get importCsvHint =>
+      'Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00';
+
+  @override
+  String get importPreview => 'Preview';
+
+  @override
+  String importPreviewCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions to import',
+      one: '1 transaction to import',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String importButton(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Import $count Transactions',
+      one: 'Import 1 Transaction',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get importImporting => 'Importing...';
+
+  @override
+  String importSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions imported',
+      one: '1 transaction imported',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get importError => 'Could not import transactions. Please try again.';
+
+  @override
+  String importMoreRows(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '...and $count more rows',
+      one: '...and 1 more row',
+    );
+    return '$_temp0';
+  }
 }

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -285,6 +285,12 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   ),
                   const SizedBox(width: SpacingTokens.sm),
                   IconButton.filled(
+                    onPressed: () => context.go('/budgets/$budgetId/import'),
+                    icon: const Icon(Icons.upload_file_rounded),
+                    tooltip: l10n.importTitle,
+                  ),
+                  const SizedBox(width: SpacingTokens.sm),
+                  IconButton.filled(
                     onPressed: () => _showMoveMoneyDialog(
                       context,
                       summary.categories,

--- a/openbudget_app/lib/src/features/transactions/providers/import_transactions_provider.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/import_transactions_provider.dart
@@ -1,0 +1,171 @@
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'import_transactions_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class ImportTransactions extends _$ImportTransactions {
+  @override
+  AsyncValue<void> build() {
+    return const AsyncValue.data(null);
+  }
+
+  Future<int> importRows({
+    required String budgetId,
+    required String currencyCode,
+    required List<ImportRow> rows,
+    String? accountId,
+  }) async {
+    state = const AsyncValue.loading();
+    final client = ref.read(serverpodClientProvider);
+    try {
+      final count = await client.transaction.bulkImport(
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(budgetId),
+        currencyCode,
+        rows,
+        accountId: accountId != null
+            // Serverpod API requires UuidValue which is experimental in uuid package.
+            // ignore: experimental_member_use
+            ? UuidValue.fromString(accountId)
+            : null,
+      );
+      if (ref.mounted) {
+        ref.invalidate(budgetSummaryProvider(budgetId));
+        state = const AsyncValue.data(null);
+      }
+      return count;
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+}
+
+/// Parses CSV text into a list of [ImportRow] objects.
+///
+/// Expects CSV with columns: date, description, amount (or inflow/outflow).
+/// Supports common bank export formats with header detection.
+List<ImportRow> parseCsvText(String csv, CurrencyCode currency) {
+  final lines = csv
+      .split('\n')
+      .map((l) => l.trim())
+      .where((l) => l.isNotEmpty)
+      .toList();
+  if (lines.length < 2) return [];
+
+  // Parse header to detect column positions.
+  final header = _splitCsvLine(
+    lines.first,
+  ).map((h) => h.toLowerCase()).toList();
+  var dateCol = header.indexWhere((h) => h.contains('date'));
+  var descCol = header.indexWhere(
+    (h) =>
+        h.contains('description') ||
+        h.contains('memo') ||
+        h.contains('payee') ||
+        h.contains('name'),
+  );
+  var amountCol = header.indexWhere((h) => h.contains('amount'));
+
+  // Default column mapping if headers not detected.
+  if (dateCol < 0) dateCol = 0;
+  if (descCol < 0) descCol = 1;
+  if (amountCol < 0) amountCol = 2;
+
+  final rows = <ImportRow>[];
+  for (var i = 1; i < lines.length; i++) {
+    final cols = _splitCsvLine(lines[i]);
+    if (cols.length <= amountCol || cols.length <= dateCol) continue;
+
+    final date = _parseDate(cols[dateCol]);
+    if (date == null) continue;
+
+    final description = descCol < cols.length
+        ? cols[descCol]
+        : 'Imported transaction';
+    final amountText = cols[amountCol].replaceAll(RegExp(r'[^\d.\-]'), '');
+    final amount = double.tryParse(amountText);
+    if (amount == null) continue;
+
+    final amountCents = (amount * _pow10(currency.decimals)).round();
+
+    rows.add(
+      ImportRow(
+        description: description,
+        amountCents: amountCents,
+        transactionDate: date,
+      ),
+    );
+  }
+
+  return rows;
+}
+
+List<String> _splitCsvLine(String line) {
+  final result = <String>[];
+  var inQuotes = false;
+  var current = StringBuffer();
+
+  for (var i = 0; i < line.length; i++) {
+    final char = line[i];
+    if (char == '"') {
+      inQuotes = !inQuotes;
+    } else if (char == ',' && !inQuotes) {
+      result.add(current.toString().trim());
+      current = StringBuffer();
+    } else {
+      current.write(char);
+    }
+  }
+  result.add(current.toString().trim());
+  return result;
+}
+
+DateTime? _parseDate(String text) {
+  // Try common formats: YYYY-MM-DD, MM/DD/YYYY, DD/MM/YYYY.
+  final cleaned = text.trim();
+  final iso = DateTime.tryParse(cleaned);
+  if (iso != null) return iso;
+
+  final slashParts = cleaned.split('/');
+  if (slashParts.length == 3) {
+    final a = int.tryParse(slashParts[0]);
+    final b = int.tryParse(slashParts[1]);
+    final c = int.tryParse(slashParts[2]);
+    if (a != null && b != null && c != null) {
+      // MM/DD/YYYY
+      if (c > 31) {
+        return DateTime.tryParse(
+          '$c-${a.toString().padLeft(2, '0')}-${b.toString().padLeft(2, '0')}',
+        );
+      }
+      // DD/MM/YYYY
+      if (a > 12) {
+        return DateTime.tryParse(
+          '$c-${b.toString().padLeft(2, '0')}-${a.toString().padLeft(2, '0')}',
+        );
+      }
+      // Default to MM/DD/YYYY
+      return DateTime.tryParse(
+        '$c-${a.toString().padLeft(2, '0')}-${b.toString().padLeft(2, '0')}',
+      );
+    }
+  }
+
+  return null;
+}
+
+double _pow10(int exponent) {
+  var result = 1.0;
+  for (var i = 0; i < exponent; i++) {
+    result *= 10;
+  }
+  return result;
+}

--- a/openbudget_app/lib/src/features/transactions/providers/import_transactions_provider.g.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/import_transactions_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'import_transactions_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ImportTransactions)
+final importTransactionsProvider = ImportTransactionsProvider._();
+
+final class ImportTransactionsProvider
+    extends $NotifierProvider<ImportTransactions, AsyncValue<void>> {
+  ImportTransactionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'importTransactionsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$importTransactionsHash();
+
+  @$internal
+  @override
+  ImportTransactions create() => ImportTransactions();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<void> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
+  }
+}
+
+String _$importTransactionsHash() =>
+    r'f18832061bfbd8c9f9ca34e5b0f7c0be53637d47';
+
+abstract class _$ImportTransactions extends $Notifier<AsyncValue<void>> {
+  AsyncValue<void> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<void>, AsyncValue<void>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, AsyncValue<void>>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/openbudget_app/lib/src/features/transactions/screens/import_transactions_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/import_transactions_screen.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/transactions/providers/import_transactions_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class ImportTransactionsScreen extends HookConsumerWidget {
+  const ImportTransactionsScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final csvController = useTextEditingController();
+    final parsedRows = useState<List<ImportRow>>([]);
+    final isSubmitting = useState(false);
+    final budgetAsync = ref.watch(budgetDetailProvider(budgetId));
+
+    final currencyCode = budgetAsync.hasValue
+        ? CurrencyCode.values.firstWhere(
+            (c) => c.code == budgetAsync.value!.currencyCode,
+            orElse: () => CurrencyCode.usd,
+          )
+        : CurrencyCode.usd;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/budgets/$budgetId'),
+        ),
+        title: Text(l10n.importTitle),
+      ),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(SpacingTokens.xl),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(SpacingTokens.lg),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Center(
+                          child: Container(
+                            width: 48,
+                            height: 48,
+                            decoration: BoxDecoration(
+                              color: colorScheme.primaryContainer.withAlpha(80),
+                              borderRadius: BorderRadius.circular(
+                                RadiusTokens.md,
+                              ),
+                            ),
+                            child: Icon(
+                              Icons.upload_file_rounded,
+                              color: colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: SpacingTokens.md),
+                        Text(
+                          l10n.importTitle,
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: SpacingTokens.xs),
+                        Text(
+                          l10n.importInstructions,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: SpacingTokens.lg),
+                        TextField(
+                          controller: csvController,
+                          decoration: InputDecoration(
+                            labelText: l10n.importCsvLabel,
+                            hintText: l10n.importCsvHint,
+                            alignLabelWithHint: true,
+                          ),
+                          maxLines: 8,
+                          textInputAction: TextInputAction.newline,
+                        ),
+                        const SizedBox(height: SpacingTokens.md),
+                        OutlinedButton.icon(
+                          onPressed: () {
+                            final text = csvController.text.trim();
+                            if (text.isEmpty) return;
+                            parsedRows.value = parseCsvText(text, currencyCode);
+                          },
+                          icon: const Icon(Icons.preview_rounded),
+                          label: Text(l10n.importPreview),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                if (parsedRows.value.isNotEmpty) ...[
+                  const SizedBox(height: SpacingTokens.md),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(SpacingTokens.md),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Text(
+                            l10n.importPreviewCount(parsedRows.value.length),
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: SpacingTokens.sm),
+                          const Divider(),
+                          ...parsedRows.value
+                              .take(20)
+                              .map(
+                                (row) => Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: SpacingTokens.xs,
+                                  ),
+                                  child: Row(
+                                    children: [
+                                      Expanded(
+                                        flex: 3,
+                                        child: Text(
+                                          _formatDate(row.transactionDate),
+                                          style: theme.textTheme.bodySmall,
+                                        ),
+                                      ),
+                                      Expanded(
+                                        flex: 5,
+                                        child: Text(
+                                          row.description,
+                                          style: theme.textTheme.bodySmall,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ),
+                                      Expanded(
+                                        flex: 3,
+                                        child: Text(
+                                          _formatAmount(
+                                            row.amountCents,
+                                            currencyCode,
+                                          ),
+                                          textAlign: TextAlign.right,
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                                fontWeight: FontWeight.w600,
+                                                color: row.amountCents >= 0
+                                                    ? ColorTokens.secondary
+                                                    : colorScheme.error,
+                                              ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                          if (parsedRows.value.length > 20) ...[
+                            const Divider(),
+                            Text(
+                              l10n.importMoreRows(parsedRows.value.length - 20),
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                                fontStyle: FontStyle.italic,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                          const SizedBox(height: SpacingTokens.md),
+                          FilledButton.icon(
+                            onPressed: isSubmitting.value
+                                ? null
+                                : () => _import(
+                                    context,
+                                    ref,
+                                    parsedRows.value,
+                                    currencyCode,
+                                    isSubmitting,
+                                  ),
+                            icon: isSubmitting.value
+                                ? const SizedBox(
+                                    height: 18,
+                                    width: 18,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Icon(Icons.file_download_done_rounded),
+                            label: Text(
+                              isSubmitting.value
+                                  ? l10n.importImporting
+                                  : l10n.importButton(parsedRows.value.length),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _import(
+    BuildContext context,
+    WidgetRef ref,
+    List<ImportRow> rows,
+    CurrencyCode currencyCode,
+    ValueNotifier<bool> isSubmitting,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    isSubmitting.value = true;
+    final messenger = ScaffoldMessenger.of(context);
+    final router = GoRouter.of(context);
+    try {
+      final count = await ref
+          .read(importTransactionsProvider.notifier)
+          .importRows(
+            budgetId: budgetId,
+            currencyCode: currencyCode.code,
+            rows: rows,
+          );
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.importSuccess(count))),
+      );
+      router.go('/budgets/$budgetId');
+    } on Exception catch (_) {
+      isSubmitting.value = false;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.importError),
+          backgroundColor: colorScheme.error,
+        ),
+      );
+    }
+  }
+
+  static String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  static String _formatAmount(int cents, CurrencyCode currency) {
+    final sign = cents < 0 ? '-' : '';
+    final absCents = cents.abs();
+    final decimals = currency.decimals;
+    final divisor = _pow10(decimals);
+    final whole = absCents ~/ divisor;
+    final frac = (absCents % divisor).toString().padLeft(decimals, '0');
+    return '$sign${currency.symbol}$whole.$frac';
+  }
+
+  static int _pow10(int exponent) {
+    var result = 1;
+    for (var i = 0; i < exponent; i++) {
+      result *= 10;
+    }
+    return result;
+  }
+}

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -15,6 +15,7 @@ import 'package:openbudget_app/src/features/recurring/screens/recurring_list_scr
 import 'package:openbudget_app/src/features/reports/screens/reports_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_expense_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_income_screen.dart';
+import 'package:openbudget_app/src/features/transactions/screens/import_transactions_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/split_expense_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/transaction_list_screen.dart';
 import 'package:openbudget_app/src/features/transfers/screens/create_transfer_screen.dart';
@@ -158,6 +159,14 @@ GoRouter appRouter(Ref ref) {
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return SplitExpenseScreen(budgetId: id);
+        },
+      ),
+      GoRoute(
+        name: importTransactionsRoute,
+        path: importTransactionsPath,
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return ImportTransactionsScreen(budgetId: id);
         },
       ),
     ],

--- a/openbudget_app/lib/src/routing/app_router.g.dart
+++ b/openbudget_app/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'17fd1c2a505526dc54e8a6dfa2aa14f13fc127bc';
+String _$appRouterHash() => r'8a1931be65313274a78a64d60fb971c469000cf9';

--- a/openbudget_app/lib/src/routing/route_names.dart
+++ b/openbudget_app/lib/src/routing/route_names.dart
@@ -30,3 +30,5 @@ const recurringListRoute = 'recurringList';
 const recurringListPath = '/budgets/:id/recurring';
 const splitExpenseRoute = 'splitExpense';
 const splitExpensePath = '/budgets/:id/expenses/split';
+const importTransactionsRoute = 'importTransactions';
+const importTransactionsPath = '/budgets/:id/import';

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -31,7 +31,9 @@ import 'package:openbudget_client/src/protocol/transactions/transaction.dart'
     as _i13;
 import 'package:openbudget_client/src/protocol/transactions/split_item.dart'
     as _i14;
-import 'protocol.dart' as _i15;
+import 'package:openbudget_client/src/protocol/transactions/import_row.dart'
+    as _i15;
+import 'protocol.dart' as _i16;
 
 /// API surface for account operations.
 ///
@@ -901,6 +903,21 @@ class EndpointTransaction extends _i1.EndpointRef {
     {'parentTransactionId': parentTransactionId},
   );
 
+  /// Bulk creates transactions from imported data.
+  ///
+  /// Returns the count of successfully created transactions.
+  _i2.Future<int> bulkImport(
+    _i1.UuidValue budgetId,
+    String currencyCode,
+    List<_i15.ImportRow> rows, {
+    _i1.UuidValue? accountId,
+  }) => caller.callServerEndpoint<int>('transaction', 'bulkImport', {
+    'budgetId': budgetId,
+    'currencyCode': currencyCode,
+    'rows': rows,
+    'accountId': accountId,
+  });
+
   /// Deletes a transaction by ID.
   _i2.Future<_i13.Transaction> delete(_i1.UuidValue transactionId) =>
       caller.callServerEndpoint<_i13.Transaction>('transaction', 'delete', {
@@ -934,7 +951,7 @@ class Client extends _i1.ServerpodClientShared {
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(
          host,
-         _i15.Protocol(),
+         _i16.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,

--- a/openbudget_client/lib/src/protocol/protocol.dart
+++ b/openbudget_client/lib/src/protocol/protocol.dart
@@ -19,28 +19,31 @@ import 'envelopes/envelope.dart' as _i6;
 import 'monthly_allocations/monthly_allocation.dart' as _i7;
 import 'payees/payee.dart' as _i8;
 import 'recurring_transactions/recurring_transaction.dart' as _i9;
-import 'transactions/split_item.dart' as _i10;
-import 'transactions/transaction.dart' as _i11;
-import 'package:openbudget_client/src/protocol/accounts/account.dart' as _i12;
-import 'package:openbudget_client/src/protocol/budgets/budget.dart' as _i13;
+import 'transactions/import_row.dart' as _i10;
+import 'transactions/split_item.dart' as _i11;
+import 'transactions/transaction.dart' as _i12;
+import 'package:openbudget_client/src/protocol/accounts/account.dart' as _i13;
+import 'package:openbudget_client/src/protocol/budgets/budget.dart' as _i14;
 import 'package:openbudget_client/src/protocol/categories/category.dart'
-    as _i14;
-import 'package:openbudget_client/src/protocol/envelope_goals/envelope_goal.dart'
     as _i15;
-import 'package:openbudget_client/src/protocol/envelopes/envelope.dart' as _i16;
+import 'package:openbudget_client/src/protocol/envelope_goals/envelope_goal.dart'
+    as _i16;
+import 'package:openbudget_client/src/protocol/envelopes/envelope.dart' as _i17;
 import 'package:openbudget_client/src/protocol/monthly_allocations/monthly_allocation.dart'
-    as _i17;
-import 'package:openbudget_client/src/protocol/payees/payee.dart' as _i18;
+    as _i18;
+import 'package:openbudget_client/src/protocol/payees/payee.dart' as _i19;
 import 'package:openbudget_client/src/protocol/recurring_transactions/recurring_transaction.dart'
-    as _i19;
-import 'package:openbudget_client/src/protocol/transactions/transaction.dart'
     as _i20;
-import 'package:openbudget_client/src/protocol/transactions/split_item.dart'
+import 'package:openbudget_client/src/protocol/transactions/transaction.dart'
     as _i21;
-import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
+import 'package:openbudget_client/src/protocol/transactions/split_item.dart'
     as _i22;
-import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
+import 'package:openbudget_client/src/protocol/transactions/import_row.dart'
     as _i23;
+import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
+    as _i24;
+import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
+    as _i25;
 export 'accounts/account.dart';
 export 'budgets/budget.dart';
 export 'categories/category.dart';
@@ -49,6 +52,7 @@ export 'envelopes/envelope.dart';
 export 'monthly_allocations/monthly_allocation.dart';
 export 'payees/payee.dart';
 export 'recurring_transactions/recurring_transaction.dart';
+export 'transactions/import_row.dart';
 export 'transactions/split_item.dart';
 export 'transactions/transaction.dart';
 export 'client.dart';
@@ -108,11 +112,14 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i9.RecurringTransaction) {
       return _i9.RecurringTransaction.fromJson(data) as T;
     }
-    if (t == _i10.SplitItem) {
-      return _i10.SplitItem.fromJson(data) as T;
+    if (t == _i10.ImportRow) {
+      return _i10.ImportRow.fromJson(data) as T;
     }
-    if (t == _i11.Transaction) {
-      return _i11.Transaction.fromJson(data) as T;
+    if (t == _i11.SplitItem) {
+      return _i11.SplitItem.fromJson(data) as T;
+    }
+    if (t == _i12.Transaction) {
+      return _i12.Transaction.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.Account?>()) {
       return (data != null ? _i2.Account.fromJson(data) : null) as T;
@@ -139,27 +146,30 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i9.RecurringTransaction.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i10.SplitItem?>()) {
-      return (data != null ? _i10.SplitItem.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i10.ImportRow?>()) {
+      return (data != null ? _i10.ImportRow.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i11.Transaction?>()) {
-      return (data != null ? _i11.Transaction.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i11.SplitItem?>()) {
+      return (data != null ? _i11.SplitItem.fromJson(data) : null) as T;
     }
-    if (t == List<_i12.Account>) {
-      return (data as List).map((e) => deserialize<_i12.Account>(e)).toList()
+    if (t == _i1.getType<_i12.Transaction?>()) {
+      return (data != null ? _i12.Transaction.fromJson(data) : null) as T;
+    }
+    if (t == List<_i13.Account>) {
+      return (data as List).map((e) => deserialize<_i13.Account>(e)).toList()
           as T;
     }
-    if (t == List<_i13.Budget>) {
-      return (data as List).map((e) => deserialize<_i13.Budget>(e)).toList()
+    if (t == List<_i14.Budget>) {
+      return (data as List).map((e) => deserialize<_i14.Budget>(e)).toList()
           as T;
     }
-    if (t == List<_i14.Category>) {
-      return (data as List).map((e) => deserialize<_i14.Category>(e)).toList()
+    if (t == List<_i15.Category>) {
+      return (data as List).map((e) => deserialize<_i15.Category>(e)).toList()
           as T;
     }
-    if (t == List<_i15.EnvelopeGoal>) {
+    if (t == List<_i16.EnvelopeGoal>) {
       return (data as List)
-              .map((e) => deserialize<_i15.EnvelopeGoal>(e))
+              .map((e) => deserialize<_i16.EnvelopeGoal>(e))
               .toList()
           as T;
     }
@@ -167,41 +177,45 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           as T;
     }
-    if (t == List<_i16.Envelope>) {
-      return (data as List).map((e) => deserialize<_i16.Envelope>(e)).toList()
+    if (t == List<_i17.Envelope>) {
+      return (data as List).map((e) => deserialize<_i17.Envelope>(e)).toList()
           as T;
     }
-    if (t == List<_i17.MonthlyAllocation>) {
+    if (t == List<_i18.MonthlyAllocation>) {
       return (data as List)
-              .map((e) => deserialize<_i17.MonthlyAllocation>(e))
+              .map((e) => deserialize<_i18.MonthlyAllocation>(e))
               .toList()
           as T;
     }
-    if (t == List<_i18.Payee>) {
-      return (data as List).map((e) => deserialize<_i18.Payee>(e)).toList()
+    if (t == List<_i19.Payee>) {
+      return (data as List).map((e) => deserialize<_i19.Payee>(e)).toList()
           as T;
     }
-    if (t == List<_i19.RecurringTransaction>) {
+    if (t == List<_i20.RecurringTransaction>) {
       return (data as List)
-              .map((e) => deserialize<_i19.RecurringTransaction>(e))
+              .map((e) => deserialize<_i20.RecurringTransaction>(e))
               .toList()
           as T;
     }
-    if (t == List<_i20.Transaction>) {
+    if (t == List<_i21.Transaction>) {
       return (data as List)
-              .map((e) => deserialize<_i20.Transaction>(e))
+              .map((e) => deserialize<_i21.Transaction>(e))
               .toList()
           as T;
     }
-    if (t == List<_i21.SplitItem>) {
-      return (data as List).map((e) => deserialize<_i21.SplitItem>(e)).toList()
+    if (t == List<_i22.SplitItem>) {
+      return (data as List).map((e) => deserialize<_i22.SplitItem>(e)).toList()
+          as T;
+    }
+    if (t == List<_i23.ImportRow>) {
+      return (data as List).map((e) => deserialize<_i23.ImportRow>(e)).toList()
           as T;
     }
     try {
-      return _i22.Protocol().deserialize<T>(data, t);
+      return _i24.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i23.Protocol().deserialize<T>(data, t);
+      return _i25.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -216,8 +230,9 @@ class Protocol extends _i1.SerializationManager {
       _i7.MonthlyAllocation => 'MonthlyAllocation',
       _i8.Payee => 'Payee',
       _i9.RecurringTransaction => 'RecurringTransaction',
-      _i10.SplitItem => 'SplitItem',
-      _i11.Transaction => 'Transaction',
+      _i10.ImportRow => 'ImportRow',
+      _i11.SplitItem => 'SplitItem',
+      _i12.Transaction => 'Transaction',
       _ => null,
     };
   }
@@ -248,16 +263,18 @@ class Protocol extends _i1.SerializationManager {
         return 'Payee';
       case _i9.RecurringTransaction():
         return 'RecurringTransaction';
-      case _i10.SplitItem():
+      case _i10.ImportRow():
+        return 'ImportRow';
+      case _i11.SplitItem():
         return 'SplitItem';
-      case _i11.Transaction():
+      case _i12.Transaction():
         return 'Transaction';
     }
-    className = _i22.Protocol().getClassNameForObject(data);
+    className = _i24.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_idp.$className';
     }
-    className = _i23.Protocol().getClassNameForObject(data);
+    className = _i25.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_core.$className';
     }
@@ -294,19 +311,22 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'RecurringTransaction') {
       return deserialize<_i9.RecurringTransaction>(data['data']);
     }
+    if (dataClassName == 'ImportRow') {
+      return deserialize<_i10.ImportRow>(data['data']);
+    }
     if (dataClassName == 'SplitItem') {
-      return deserialize<_i10.SplitItem>(data['data']);
+      return deserialize<_i11.SplitItem>(data['data']);
     }
     if (dataClassName == 'Transaction') {
-      return deserialize<_i11.Transaction>(data['data']);
+      return deserialize<_i12.Transaction>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i22.Protocol().deserializeByClassName(data);
+      return _i24.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
-      return _i23.Protocol().deserializeByClassName(data);
+      return _i25.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }
@@ -321,10 +341,10 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     try {
-      return _i22.Protocol().mapRecordToJson(record);
+      return _i24.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
-      return _i23.Protocol().mapRecordToJson(record);
+      return _i25.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }

--- a/openbudget_client/lib/src/protocol/transactions/import_row.dart
+++ b/openbudget_client/lib/src/protocol/transactions/import_row.dart
@@ -1,0 +1,95 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+/// A single row of data for bulk transaction import.
+abstract class ImportRow implements _i1.SerializableModel {
+  ImportRow._({
+    required this.description,
+    required this.amountCents,
+    required this.transactionDate,
+  });
+
+  factory ImportRow({
+    required String description,
+    required int amountCents,
+    required DateTime transactionDate,
+  }) = _ImportRowImpl;
+
+  factory ImportRow.fromJson(Map<String, dynamic> jsonSerialization) {
+    return ImportRow(
+      description: jsonSerialization['description'] as String,
+      amountCents: jsonSerialization['amountCents'] as int,
+      transactionDate: _i1.DateTimeJsonExtension.fromJson(
+        jsonSerialization['transactionDate'],
+      ),
+    );
+  }
+
+  String description;
+
+  int amountCents;
+
+  DateTime transactionDate;
+
+  /// Returns a shallow copy of this [ImportRow]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ImportRow copyWith({
+    String? description,
+    int? amountCents,
+    DateTime? transactionDate,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'ImportRow',
+      'description': description,
+      'amountCents': amountCents,
+      'transactionDate': transactionDate.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ImportRowImpl extends ImportRow {
+  _ImportRowImpl({
+    required String description,
+    required int amountCents,
+    required DateTime transactionDate,
+  }) : super._(
+         description: description,
+         amountCents: amountCents,
+         transactionDate: transactionDate,
+       );
+
+  /// Returns a shallow copy of this [ImportRow]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ImportRow copyWith({
+    String? description,
+    int? amountCents,
+    DateTime? transactionDate,
+  }) {
+    return ImportRow(
+      description: description ?? this.description,
+      amountCents: amountCents ?? this.amountCents,
+      transactionDate: transactionDate ?? this.transactionDate,
+    );
+  }
+}

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -25,10 +25,12 @@ import '../recurring_transactions/recurring_transaction_endpoint.dart' as _i12;
 import '../transactions/transaction_endpoint.dart' as _i13;
 import 'package:openbudget_server/src/generated/transactions/split_item.dart'
     as _i14;
-import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
+import 'package:openbudget_server/src/generated/transactions/import_row.dart'
     as _i15;
-import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
     as _i16;
+import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i17;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -1611,6 +1613,39 @@ class Endpoints extends _i1.EndpointDispatch {
                 params['parentTransactionId'],
               ),
         ),
+        'bulkImport': _i1.MethodConnector(
+          name: 'bulkImport',
+          params: {
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'currencyCode': _i1.ParameterDescription(
+              name: 'currencyCode',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+            'rows': _i1.ParameterDescription(
+              name: 'rows',
+              type: _i1.getType<List<_i15.ImportRow>>(),
+              nullable: false,
+            ),
+            'accountId': _i1.ParameterDescription(
+              name: 'accountId',
+              type: _i1.getType<_i1.UuidValue?>(),
+              nullable: true,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['transaction'] as _i13.TransactionEndpoint).bulkImport(
+                session,
+                params['budgetId'],
+                params['currencyCode'],
+                params['rows'],
+                accountId: params['accountId'],
+              ),
+        ),
         'delete': _i1.MethodConnector(
           name: 'delete',
           params: {
@@ -1628,9 +1663,9 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
-    modules['serverpod_auth_idp'] = _i15.Endpoints()
+    modules['serverpod_auth_idp'] = _i16.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_core'] = _i16.Endpoints()
+    modules['serverpod_auth_core'] = _i17.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/openbudget_server/lib/src/generated/protocol.dart
+++ b/openbudget_server/lib/src/generated/protocol.dart
@@ -24,25 +24,28 @@ import 'envelopes/envelope.dart' as _i9;
 import 'monthly_allocations/monthly_allocation.dart' as _i10;
 import 'payees/payee.dart' as _i11;
 import 'recurring_transactions/recurring_transaction.dart' as _i12;
-import 'transactions/split_item.dart' as _i13;
-import 'transactions/transaction.dart' as _i14;
-import 'package:openbudget_server/src/generated/accounts/account.dart' as _i15;
-import 'package:openbudget_server/src/generated/budgets/budget.dart' as _i16;
+import 'transactions/import_row.dart' as _i13;
+import 'transactions/split_item.dart' as _i14;
+import 'transactions/transaction.dart' as _i15;
+import 'package:openbudget_server/src/generated/accounts/account.dart' as _i16;
+import 'package:openbudget_server/src/generated/budgets/budget.dart' as _i17;
 import 'package:openbudget_server/src/generated/categories/category.dart'
-    as _i17;
-import 'package:openbudget_server/src/generated/envelope_goals/envelope_goal.dart'
     as _i18;
-import 'package:openbudget_server/src/generated/envelopes/envelope.dart'
+import 'package:openbudget_server/src/generated/envelope_goals/envelope_goal.dart'
     as _i19;
-import 'package:openbudget_server/src/generated/monthly_allocations/monthly_allocation.dart'
+import 'package:openbudget_server/src/generated/envelopes/envelope.dart'
     as _i20;
-import 'package:openbudget_server/src/generated/payees/payee.dart' as _i21;
+import 'package:openbudget_server/src/generated/monthly_allocations/monthly_allocation.dart'
+    as _i21;
+import 'package:openbudget_server/src/generated/payees/payee.dart' as _i22;
 import 'package:openbudget_server/src/generated/recurring_transactions/recurring_transaction.dart'
-    as _i22;
-import 'package:openbudget_server/src/generated/transactions/transaction.dart'
     as _i23;
-import 'package:openbudget_server/src/generated/transactions/split_item.dart'
+import 'package:openbudget_server/src/generated/transactions/transaction.dart'
     as _i24;
+import 'package:openbudget_server/src/generated/transactions/split_item.dart'
+    as _i25;
+import 'package:openbudget_server/src/generated/transactions/import_row.dart'
+    as _i26;
 export 'accounts/account.dart';
 export 'budgets/budget.dart';
 export 'categories/category.dart';
@@ -51,6 +54,7 @@ export 'envelopes/envelope.dart';
 export 'monthly_allocations/monthly_allocation.dart';
 export 'payees/payee.dart';
 export 'recurring_transactions/recurring_transaction.dart';
+export 'transactions/import_row.dart';
 export 'transactions/split_item.dart';
 export 'transactions/transaction.dart';
 
@@ -1247,11 +1251,14 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i12.RecurringTransaction) {
       return _i12.RecurringTransaction.fromJson(data) as T;
     }
-    if (t == _i13.SplitItem) {
-      return _i13.SplitItem.fromJson(data) as T;
+    if (t == _i13.ImportRow) {
+      return _i13.ImportRow.fromJson(data) as T;
     }
-    if (t == _i14.Transaction) {
-      return _i14.Transaction.fromJson(data) as T;
+    if (t == _i14.SplitItem) {
+      return _i14.SplitItem.fromJson(data) as T;
+    }
+    if (t == _i15.Transaction) {
+      return _i15.Transaction.fromJson(data) as T;
     }
     if (t == _i1.getType<_i5.Account?>()) {
       return (data != null ? _i5.Account.fromJson(data) : null) as T;
@@ -1278,27 +1285,30 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i12.RecurringTransaction.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i13.SplitItem?>()) {
-      return (data != null ? _i13.SplitItem.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i13.ImportRow?>()) {
+      return (data != null ? _i13.ImportRow.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i14.Transaction?>()) {
-      return (data != null ? _i14.Transaction.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i14.SplitItem?>()) {
+      return (data != null ? _i14.SplitItem.fromJson(data) : null) as T;
     }
-    if (t == List<_i15.Account>) {
-      return (data as List).map((e) => deserialize<_i15.Account>(e)).toList()
+    if (t == _i1.getType<_i15.Transaction?>()) {
+      return (data != null ? _i15.Transaction.fromJson(data) : null) as T;
+    }
+    if (t == List<_i16.Account>) {
+      return (data as List).map((e) => deserialize<_i16.Account>(e)).toList()
           as T;
     }
-    if (t == List<_i16.Budget>) {
-      return (data as List).map((e) => deserialize<_i16.Budget>(e)).toList()
+    if (t == List<_i17.Budget>) {
+      return (data as List).map((e) => deserialize<_i17.Budget>(e)).toList()
           as T;
     }
-    if (t == List<_i17.Category>) {
-      return (data as List).map((e) => deserialize<_i17.Category>(e)).toList()
+    if (t == List<_i18.Category>) {
+      return (data as List).map((e) => deserialize<_i18.Category>(e)).toList()
           as T;
     }
-    if (t == List<_i18.EnvelopeGoal>) {
+    if (t == List<_i19.EnvelopeGoal>) {
       return (data as List)
-              .map((e) => deserialize<_i18.EnvelopeGoal>(e))
+              .map((e) => deserialize<_i19.EnvelopeGoal>(e))
               .toList()
           as T;
     }
@@ -1306,34 +1316,38 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           as T;
     }
-    if (t == List<_i19.Envelope>) {
-      return (data as List).map((e) => deserialize<_i19.Envelope>(e)).toList()
+    if (t == List<_i20.Envelope>) {
+      return (data as List).map((e) => deserialize<_i20.Envelope>(e)).toList()
           as T;
     }
-    if (t == List<_i20.MonthlyAllocation>) {
+    if (t == List<_i21.MonthlyAllocation>) {
       return (data as List)
-              .map((e) => deserialize<_i20.MonthlyAllocation>(e))
+              .map((e) => deserialize<_i21.MonthlyAllocation>(e))
               .toList()
           as T;
     }
-    if (t == List<_i21.Payee>) {
-      return (data as List).map((e) => deserialize<_i21.Payee>(e)).toList()
+    if (t == List<_i22.Payee>) {
+      return (data as List).map((e) => deserialize<_i22.Payee>(e)).toList()
           as T;
     }
-    if (t == List<_i22.RecurringTransaction>) {
+    if (t == List<_i23.RecurringTransaction>) {
       return (data as List)
-              .map((e) => deserialize<_i22.RecurringTransaction>(e))
+              .map((e) => deserialize<_i23.RecurringTransaction>(e))
               .toList()
           as T;
     }
-    if (t == List<_i23.Transaction>) {
+    if (t == List<_i24.Transaction>) {
       return (data as List)
-              .map((e) => deserialize<_i23.Transaction>(e))
+              .map((e) => deserialize<_i24.Transaction>(e))
               .toList()
           as T;
     }
-    if (t == List<_i24.SplitItem>) {
-      return (data as List).map((e) => deserialize<_i24.SplitItem>(e)).toList()
+    if (t == List<_i25.SplitItem>) {
+      return (data as List).map((e) => deserialize<_i25.SplitItem>(e)).toList()
+          as T;
+    }
+    if (t == List<_i26.ImportRow>) {
+      return (data as List).map((e) => deserialize<_i26.ImportRow>(e)).toList()
           as T;
     }
     try {
@@ -1358,8 +1372,9 @@ class Protocol extends _i1.SerializationManagerServer {
       _i10.MonthlyAllocation => 'MonthlyAllocation',
       _i11.Payee => 'Payee',
       _i12.RecurringTransaction => 'RecurringTransaction',
-      _i13.SplitItem => 'SplitItem',
-      _i14.Transaction => 'Transaction',
+      _i13.ImportRow => 'ImportRow',
+      _i14.SplitItem => 'SplitItem',
+      _i15.Transaction => 'Transaction',
       _ => null,
     };
   }
@@ -1390,9 +1405,11 @@ class Protocol extends _i1.SerializationManagerServer {
         return 'Payee';
       case _i12.RecurringTransaction():
         return 'RecurringTransaction';
-      case _i13.SplitItem():
+      case _i13.ImportRow():
+        return 'ImportRow';
+      case _i14.SplitItem():
         return 'SplitItem';
-      case _i14.Transaction():
+      case _i15.Transaction():
         return 'Transaction';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -1440,11 +1457,14 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'RecurringTransaction') {
       return deserialize<_i12.RecurringTransaction>(data['data']);
     }
+    if (dataClassName == 'ImportRow') {
+      return deserialize<_i13.ImportRow>(data['data']);
+    }
     if (dataClassName == 'SplitItem') {
-      return deserialize<_i13.SplitItem>(data['data']);
+      return deserialize<_i14.SplitItem>(data['data']);
     }
     if (dataClassName == 'Transaction') {
-      return deserialize<_i14.Transaction>(data['data']);
+      return deserialize<_i15.Transaction>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -1498,8 +1518,8 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i11.Payee.t;
       case _i12.RecurringTransaction:
         return _i12.RecurringTransaction.t;
-      case _i14.Transaction:
-        return _i14.Transaction.t;
+      case _i15.Transaction:
+        return _i15.Transaction.t;
     }
     return null;
   }

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -71,4 +71,5 @@ transaction:
   - ageOfMoney:
   - createSplit:
   - listSplits:
+  - bulkImport:
   - delete:

--- a/openbudget_server/lib/src/generated/transactions/import_row.dart
+++ b/openbudget_server/lib/src/generated/transactions/import_row.dart
@@ -1,0 +1,106 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+/// A single row of data for bulk transaction import.
+abstract class ImportRow
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  ImportRow._({
+    required this.description,
+    required this.amountCents,
+    required this.transactionDate,
+  });
+
+  factory ImportRow({
+    required String description,
+    required int amountCents,
+    required DateTime transactionDate,
+  }) = _ImportRowImpl;
+
+  factory ImportRow.fromJson(Map<String, dynamic> jsonSerialization) {
+    return ImportRow(
+      description: jsonSerialization['description'] as String,
+      amountCents: jsonSerialization['amountCents'] as int,
+      transactionDate: _i1.DateTimeJsonExtension.fromJson(
+        jsonSerialization['transactionDate'],
+      ),
+    );
+  }
+
+  String description;
+
+  int amountCents;
+
+  DateTime transactionDate;
+
+  /// Returns a shallow copy of this [ImportRow]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ImportRow copyWith({
+    String? description,
+    int? amountCents,
+    DateTime? transactionDate,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'ImportRow',
+      'description': description,
+      'amountCents': amountCents,
+      'transactionDate': transactionDate.toJson(),
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'ImportRow',
+      'description': description,
+      'amountCents': amountCents,
+      'transactionDate': transactionDate.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ImportRowImpl extends ImportRow {
+  _ImportRowImpl({
+    required String description,
+    required int amountCents,
+    required DateTime transactionDate,
+  }) : super._(
+         description: description,
+         amountCents: amountCents,
+         transactionDate: transactionDate,
+       );
+
+  /// Returns a shallow copy of this [ImportRow]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ImportRow copyWith({
+    String? description,
+    int? amountCents,
+    DateTime? transactionDate,
+  }) {
+    return ImportRow(
+      description: description ?? this.description,
+      amountCents: amountCents ?? this.amountCents,
+      transactionDate: transactionDate ?? this.transactionDate,
+    );
+  }
+}

--- a/openbudget_server/lib/src/transactions/import_row.spy.yaml
+++ b/openbudget_server/lib/src/transactions/import_row.spy.yaml
@@ -1,0 +1,6 @@
+### A single row of data for bulk transaction import.
+class: ImportRow
+fields:
+  description: String
+  amountCents: int
+  transactionDate: DateTime

--- a/openbudget_server/lib/src/transactions/transaction_endpoint.dart
+++ b/openbudget_server/lib/src/transactions/transaction_endpoint.dart
@@ -182,6 +182,25 @@ class TransactionEndpoint extends Endpoint {
     );
   }
 
+  /// Bulk creates transactions from imported data.
+  ///
+  /// Returns the count of successfully created transactions.
+  Future<int> bulkImport(
+    Session session,
+    UuidValue budgetId,
+    String currencyCode,
+    List<ImportRow> rows, {
+    UuidValue? accountId,
+  }) async {
+    return TransactionService.bulkCreate(
+      session,
+      budgetId: budgetId,
+      currencyCode: currencyCode,
+      rows: rows,
+      accountId: accountId,
+    );
+  }
+
   /// Deletes a transaction by ID.
   Future<Transaction> delete(Session session, UuidValue transactionId) async {
     return TransactionService.delete(session, transactionId: transactionId);

--- a/openbudget_server/lib/src/transactions/transaction_service.dart
+++ b/openbudget_server/lib/src/transactions/transaction_service.dart
@@ -348,6 +348,37 @@ class TransactionService {
     );
   }
 
+  /// Bulk creates transactions from import data.
+  ///
+  /// All transactions are created within a single budget, verified once.
+  /// Returns the count of successfully created transactions.
+  static Future<int> bulkCreate(
+    Session session, {
+    required UuidValue budgetId,
+    required String currencyCode,
+    required List<ImportRow> rows,
+    UuidValue? accountId,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+
+    var count = 0;
+    for (final row in rows) {
+      final transaction = Transaction(
+        description: row.description,
+        amountCents: row.amountCents,
+        currencyCode: currencyCode,
+        budgetId: budgetId,
+        accountId: accountId,
+        transactionDate: row.transactionDate,
+        createdAt: DateTime.now(),
+      );
+      await Transaction.db.insertRow(session, transaction);
+      count++;
+    }
+
+    return count;
+  }
+
   /// Deletes a transaction, verifying budget ownership.
   static Future<Transaction> delete(
     Session session, {

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -32,6 +32,8 @@ import 'package:openbudget_server/src/generated/transactions/transaction.dart'
     as _i13;
 import 'package:openbudget_server/src/generated/transactions/split_item.dart'
     as _i14;
+import 'package:openbudget_server/src/generated/transactions/import_row.dart'
+    as _i15;
 import 'package:openbudget_server/src/generated/protocol.dart';
 import 'package:openbudget_server/src/generated/endpoints.dart';
 export 'package:serverpod_test/serverpod_test_public_exports.dart';
@@ -2426,6 +2428,45 @@ class _TransactionEndpoint {
                   _localCallContext.arguments,
                 )
                 as _i3.Future<List<_i13.Transaction>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<int> bulkImport(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue budgetId,
+    String currencyCode,
+    List<_i15.ImportRow> rows, {
+    _i2.UuidValue? accountId,
+  }) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'transaction',
+            method: 'bulkImport',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'transaction',
+          methodName: 'bulkImport',
+          parameters: _i1.testObjectToJson({
+            'budgetId': budgetId,
+            'currencyCode': currencyCode,
+            'rows': rows,
+            'accountId': accountId,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<int>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();


### PR DESCRIPTION
## Summary
- Adds `ImportRow` Serverpod model for bulk transaction data
- Adds `TransactionEndpoint.bulkImport()` endpoint that creates multiple transactions at once
- Creates import screen with CSV paste area, auto-header detection, and transaction preview
- Supports common date formats (YYYY-MM-DD, MM/DD/YYYY, DD/MM/YYYY)
- Shows first 20 parsed rows with color-coded amounts before importing
- Adds import button to the budget detail bottom navigation bar

## Test plan
- [ ] Navigate to import screen from budget detail
- [ ] Paste CSV with headers (Date,Description,Amount) and click Preview
- [ ] Verify parsed transactions show in preview with correct amounts and dates
- [ ] Click Import and verify transactions are created
- [ ] Test CSV without standard headers (defaults to columns 0,1,2)
- [ ] Test with different date formats (2026-01-15, 01/15/2026)