### PR TITLE
feat: add auto-assign to distribute money across underfunded envelopes

### DIFF
--- a/.changeset/feat-auto-assign.md
+++ b/.changeset/feat-auto-assign.md
@@ -1,0 +1,5 @@
+---
+openbudget_app: minor
+---
+
+Add auto-assign feature to distribute Ready to Assign money across underfunded envelopes based on their goals

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -310,5 +310,27 @@
         "type": "int"
       }
     }
-  }
+  },
+  "autoAssignTitle": "Auto-Assign",
+  "autoAssignButton": "Auto-Assign",
+  "autoAssignAssigning": "Assigning...",
+  "autoAssignDistributing": "Distributing to underfunded envelopes",
+  "autoAssignNothingToAssign": "All envelopes with goals are fully funded!",
+  "autoAssignEnvelopeCount": "{count, plural, =1{1 envelope} other{{count} envelopes}}",
+  "@autoAssignEnvelopeCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "autoAssignSuccess": "{count, plural, =1{Auto-assigned to 1 envelope} other{Auto-assigned to {count} envelopes}}",
+  "@autoAssignSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "autoAssignError": "Could not auto-assign. Please try again."
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1539,6 +1539,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{...and 1 more row} other{...and {count} more rows}}'**
   String importMoreRows(int count);
+
+  /// No description provided for @autoAssignTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-Assign'**
+  String get autoAssignTitle;
+
+  /// No description provided for @autoAssignButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-Assign'**
+  String get autoAssignButton;
+
+  /// No description provided for @autoAssignAssigning.
+  ///
+  /// In en, this message translates to:
+  /// **'Assigning...'**
+  String get autoAssignAssigning;
+
+  /// No description provided for @autoAssignDistributing.
+  ///
+  /// In en, this message translates to:
+  /// **'Distributing to underfunded envelopes'**
+  String get autoAssignDistributing;
+
+  /// No description provided for @autoAssignNothingToAssign.
+  ///
+  /// In en, this message translates to:
+  /// **'All envelopes with goals are fully funded!'**
+  String get autoAssignNothingToAssign;
+
+  /// No description provided for @autoAssignEnvelopeCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 envelope} other{{count} envelopes}}'**
+  String autoAssignEnvelopeCount(int count);
+
+  /// No description provided for @autoAssignSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Auto-assigned to 1 envelope} other{Auto-assigned to {count} envelopes}}'**
+  String autoAssignSuccess(int count);
+
+  /// No description provided for @autoAssignError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not auto-assign. Please try again.'**
+  String get autoAssignError;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -822,4 +822,45 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get autoAssignTitle => 'Auto-Assign';
+
+  @override
+  String get autoAssignButton => 'Auto-Assign';
+
+  @override
+  String get autoAssignAssigning => 'Assigning...';
+
+  @override
+  String get autoAssignDistributing => 'Distributing to underfunded envelopes';
+
+  @override
+  String get autoAssignNothingToAssign =>
+      'All envelopes with goals are fully funded!';
+
+  @override
+  String autoAssignEnvelopeCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count envelopes',
+      one: '1 envelope',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String autoAssignSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Auto-assigned to $count envelopes',
+      one: 'Auto-assigned to 1 envelope',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get autoAssignError => 'Could not auto-assign. Please try again.';
 }

--- a/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.dart
+++ b/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.dart
@@ -1,0 +1,160 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_goals_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/monthly_allocation_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/selected_month_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_assign_provider.freezed.dart';
+part 'auto_assign_provider.g.dart';
+
+@freezed
+sealed class AutoAssignItem with _$AutoAssignItem {
+  const factory AutoAssignItem({
+    required String envelopeId,
+    required String envelopeName,
+    required int currentAllocatedCents,
+    required int proposedAllocatedCents,
+    required int addedCents,
+  }) = _AutoAssignItem;
+}
+
+@freezed
+sealed class AutoAssignProposal with _$AutoAssignProposal {
+  const factory AutoAssignProposal({
+    required List<AutoAssignItem> items,
+    required int totalToAssignCents,
+    required int totalAssignedCents,
+  }) = _AutoAssignProposal;
+}
+
+/// Computes an auto-assign proposal that distributes Ready to Assign money
+/// across underfunded envelopes based on their goals.
+@riverpod
+Future<AutoAssignProposal> autoAssignProposal(Ref ref, String budgetId) async {
+  final summary = await ref.watch(
+    budgetMonthlySummaryProvider(budgetId).future,
+  );
+  final goals = await ref.watch(budgetGoalsProvider(budgetId).future);
+
+  final readyToAssign = summary.readyToAssignCents;
+  if (readyToAssign <= 0 || goals.isEmpty) {
+    return const AutoAssignProposal(
+      items: [],
+      totalToAssignCents: 0,
+      totalAssignedCents: 0,
+    );
+  }
+
+  // Build list of underfunded envelopes with their needed amounts.
+  final underfunded =
+      <({String envelopeId, String name, int needed, int current})>[];
+
+  for (final cat in summary.categories) {
+    for (final envData in cat.monthlyEnvelopes) {
+      final envelopeId = envData.envelope.id?.toString() ?? '';
+      final goal = goals[envelopeId];
+      if (goal == null) continue;
+
+      final needed = computeUnderfundedCents(
+        goal: goal,
+        budgetedCents: envData.allocatedCents,
+        availableCents: envData.availableCents,
+      );
+
+      if (needed > 0) {
+        underfunded.add((
+          envelopeId: envelopeId,
+          name: envData.envelope.name,
+          needed: needed,
+          current: envData.allocatedCents,
+        ));
+      }
+    }
+  }
+
+  if (underfunded.isEmpty) {
+    return AutoAssignProposal(
+      items: const [],
+      totalToAssignCents: readyToAssign,
+      totalAssignedCents: 0,
+    );
+  }
+
+  // Distribute money: fund each envelope up to its needed amount until we
+  // run out of Ready to Assign money.
+  var remaining = readyToAssign;
+  final items = <AutoAssignItem>[];
+
+  for (final entry in underfunded) {
+    if (remaining <= 0) break;
+
+    final toAdd = remaining < entry.needed ? remaining : entry.needed;
+    items.add(
+      AutoAssignItem(
+        envelopeId: entry.envelopeId,
+        envelopeName: entry.name,
+        currentAllocatedCents: entry.current,
+        proposedAllocatedCents: entry.current + toAdd,
+        addedCents: toAdd,
+      ),
+    );
+    remaining -= toAdd;
+  }
+
+  final totalAssigned = items.fold<int>(
+    0,
+    (sum, item) => sum + item.addedCents,
+  );
+
+  return AutoAssignProposal(
+    items: items,
+    totalToAssignCents: readyToAssign,
+    totalAssignedCents: totalAssigned,
+  );
+}
+
+@Riverpod(keepAlive: true)
+class AutoAssignActions extends _$AutoAssignActions {
+  @override
+  AsyncValue<void> build() {
+    return const AsyncValue.data(null);
+  }
+
+  /// Executes the auto-assign proposal by upserting allocations for each item.
+  Future<int> execute({
+    required String budgetId,
+    required List<AutoAssignItem> items,
+  }) async {
+    state = const AsyncValue.loading();
+    try {
+      final selectedMonth = ref.read(selectedMonthProvider(budgetId));
+      final year = selectedMonth.year;
+      final month = selectedMonth.month;
+      final actions = ref.read(monthlyAllocationActionsProvider.notifier);
+
+      var count = 0;
+      for (final item in items) {
+        await actions.upsertAllocation(
+          envelopeId: item.envelopeId,
+          budgetId: budgetId,
+          year: year,
+          month: month,
+          allocatedCents: item.proposedAllocatedCents,
+        );
+        count++;
+      }
+
+      if (ref.mounted) {
+        ref.invalidate(budgetMonthlySummaryProvider(budgetId));
+        state = const AsyncValue.data(null);
+      }
+      return count;
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+}

--- a/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.freezed.dart
+++ b/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.freezed.dart
@@ -1,0 +1,540 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'auto_assign_provider.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$AutoAssignItem {
+
+ String get envelopeId; String get envelopeName; int get currentAllocatedCents; int get proposedAllocatedCents; int get addedCents;
+/// Create a copy of AutoAssignItem
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AutoAssignItemCopyWith<AutoAssignItem> get copyWith => _$AutoAssignItemCopyWithImpl<AutoAssignItem>(this as AutoAssignItem, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AutoAssignItem&&(identical(other.envelopeId, envelopeId) || other.envelopeId == envelopeId)&&(identical(other.envelopeName, envelopeName) || other.envelopeName == envelopeName)&&(identical(other.currentAllocatedCents, currentAllocatedCents) || other.currentAllocatedCents == currentAllocatedCents)&&(identical(other.proposedAllocatedCents, proposedAllocatedCents) || other.proposedAllocatedCents == proposedAllocatedCents)&&(identical(other.addedCents, addedCents) || other.addedCents == addedCents));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,envelopeId,envelopeName,currentAllocatedCents,proposedAllocatedCents,addedCents);
+
+@override
+String toString() {
+  return 'AutoAssignItem(envelopeId: $envelopeId, envelopeName: $envelopeName, currentAllocatedCents: $currentAllocatedCents, proposedAllocatedCents: $proposedAllocatedCents, addedCents: $addedCents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AutoAssignItemCopyWith<$Res>  {
+  factory $AutoAssignItemCopyWith(AutoAssignItem value, $Res Function(AutoAssignItem) _then) = _$AutoAssignItemCopyWithImpl;
+@useResult
+$Res call({
+ String envelopeId, String envelopeName, int currentAllocatedCents, int proposedAllocatedCents, int addedCents
+});
+
+
+
+
+}
+/// @nodoc
+class _$AutoAssignItemCopyWithImpl<$Res>
+    implements $AutoAssignItemCopyWith<$Res> {
+  _$AutoAssignItemCopyWithImpl(this._self, this._then);
+
+  final AutoAssignItem _self;
+  final $Res Function(AutoAssignItem) _then;
+
+/// Create a copy of AutoAssignItem
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? envelopeId = null,Object? envelopeName = null,Object? currentAllocatedCents = null,Object? proposedAllocatedCents = null,Object? addedCents = null,}) {
+  return _then(_self.copyWith(
+envelopeId: null == envelopeId ? _self.envelopeId : envelopeId // ignore: cast_nullable_to_non_nullable
+as String,envelopeName: null == envelopeName ? _self.envelopeName : envelopeName // ignore: cast_nullable_to_non_nullable
+as String,currentAllocatedCents: null == currentAllocatedCents ? _self.currentAllocatedCents : currentAllocatedCents // ignore: cast_nullable_to_non_nullable
+as int,proposedAllocatedCents: null == proposedAllocatedCents ? _self.proposedAllocatedCents : proposedAllocatedCents // ignore: cast_nullable_to_non_nullable
+as int,addedCents: null == addedCents ? _self.addedCents : addedCents // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AutoAssignItem].
+extension AutoAssignItemPatterns on AutoAssignItem {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AutoAssignItem value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AutoAssignItem() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AutoAssignItem value)  $default,){
+final _that = this;
+switch (_that) {
+case _AutoAssignItem():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AutoAssignItem value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AutoAssignItem() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String envelopeId,  String envelopeName,  int currentAllocatedCents,  int proposedAllocatedCents,  int addedCents)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AutoAssignItem() when $default != null:
+return $default(_that.envelopeId,_that.envelopeName,_that.currentAllocatedCents,_that.proposedAllocatedCents,_that.addedCents);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String envelopeId,  String envelopeName,  int currentAllocatedCents,  int proposedAllocatedCents,  int addedCents)  $default,) {final _that = this;
+switch (_that) {
+case _AutoAssignItem():
+return $default(_that.envelopeId,_that.envelopeName,_that.currentAllocatedCents,_that.proposedAllocatedCents,_that.addedCents);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String envelopeId,  String envelopeName,  int currentAllocatedCents,  int proposedAllocatedCents,  int addedCents)?  $default,) {final _that = this;
+switch (_that) {
+case _AutoAssignItem() when $default != null:
+return $default(_that.envelopeId,_that.envelopeName,_that.currentAllocatedCents,_that.proposedAllocatedCents,_that.addedCents);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _AutoAssignItem implements AutoAssignItem {
+  const _AutoAssignItem({required this.envelopeId, required this.envelopeName, required this.currentAllocatedCents, required this.proposedAllocatedCents, required this.addedCents});
+  
+
+@override final  String envelopeId;
+@override final  String envelopeName;
+@override final  int currentAllocatedCents;
+@override final  int proposedAllocatedCents;
+@override final  int addedCents;
+
+/// Create a copy of AutoAssignItem
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AutoAssignItemCopyWith<_AutoAssignItem> get copyWith => __$AutoAssignItemCopyWithImpl<_AutoAssignItem>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AutoAssignItem&&(identical(other.envelopeId, envelopeId) || other.envelopeId == envelopeId)&&(identical(other.envelopeName, envelopeName) || other.envelopeName == envelopeName)&&(identical(other.currentAllocatedCents, currentAllocatedCents) || other.currentAllocatedCents == currentAllocatedCents)&&(identical(other.proposedAllocatedCents, proposedAllocatedCents) || other.proposedAllocatedCents == proposedAllocatedCents)&&(identical(other.addedCents, addedCents) || other.addedCents == addedCents));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,envelopeId,envelopeName,currentAllocatedCents,proposedAllocatedCents,addedCents);
+
+@override
+String toString() {
+  return 'AutoAssignItem(envelopeId: $envelopeId, envelopeName: $envelopeName, currentAllocatedCents: $currentAllocatedCents, proposedAllocatedCents: $proposedAllocatedCents, addedCents: $addedCents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AutoAssignItemCopyWith<$Res> implements $AutoAssignItemCopyWith<$Res> {
+  factory _$AutoAssignItemCopyWith(_AutoAssignItem value, $Res Function(_AutoAssignItem) _then) = __$AutoAssignItemCopyWithImpl;
+@override @useResult
+$Res call({
+ String envelopeId, String envelopeName, int currentAllocatedCents, int proposedAllocatedCents, int addedCents
+});
+
+
+
+
+}
+/// @nodoc
+class __$AutoAssignItemCopyWithImpl<$Res>
+    implements _$AutoAssignItemCopyWith<$Res> {
+  __$AutoAssignItemCopyWithImpl(this._self, this._then);
+
+  final _AutoAssignItem _self;
+  final $Res Function(_AutoAssignItem) _then;
+
+/// Create a copy of AutoAssignItem
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? envelopeId = null,Object? envelopeName = null,Object? currentAllocatedCents = null,Object? proposedAllocatedCents = null,Object? addedCents = null,}) {
+  return _then(_AutoAssignItem(
+envelopeId: null == envelopeId ? _self.envelopeId : envelopeId // ignore: cast_nullable_to_non_nullable
+as String,envelopeName: null == envelopeName ? _self.envelopeName : envelopeName // ignore: cast_nullable_to_non_nullable
+as String,currentAllocatedCents: null == currentAllocatedCents ? _self.currentAllocatedCents : currentAllocatedCents // ignore: cast_nullable_to_non_nullable
+as int,proposedAllocatedCents: null == proposedAllocatedCents ? _self.proposedAllocatedCents : proposedAllocatedCents // ignore: cast_nullable_to_non_nullable
+as int,addedCents: null == addedCents ? _self.addedCents : addedCents // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$AutoAssignProposal {
+
+ List<AutoAssignItem> get items; int get totalToAssignCents; int get totalAssignedCents;
+/// Create a copy of AutoAssignProposal
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AutoAssignProposalCopyWith<AutoAssignProposal> get copyWith => _$AutoAssignProposalCopyWithImpl<AutoAssignProposal>(this as AutoAssignProposal, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AutoAssignProposal&&const DeepCollectionEquality().equals(other.items, items)&&(identical(other.totalToAssignCents, totalToAssignCents) || other.totalToAssignCents == totalToAssignCents)&&(identical(other.totalAssignedCents, totalAssignedCents) || other.totalAssignedCents == totalAssignedCents));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(items),totalToAssignCents,totalAssignedCents);
+
+@override
+String toString() {
+  return 'AutoAssignProposal(items: $items, totalToAssignCents: $totalToAssignCents, totalAssignedCents: $totalAssignedCents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AutoAssignProposalCopyWith<$Res>  {
+  factory $AutoAssignProposalCopyWith(AutoAssignProposal value, $Res Function(AutoAssignProposal) _then) = _$AutoAssignProposalCopyWithImpl;
+@useResult
+$Res call({
+ List<AutoAssignItem> items, int totalToAssignCents, int totalAssignedCents
+});
+
+
+
+
+}
+/// @nodoc
+class _$AutoAssignProposalCopyWithImpl<$Res>
+    implements $AutoAssignProposalCopyWith<$Res> {
+  _$AutoAssignProposalCopyWithImpl(this._self, this._then);
+
+  final AutoAssignProposal _self;
+  final $Res Function(AutoAssignProposal) _then;
+
+/// Create a copy of AutoAssignProposal
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? items = null,Object? totalToAssignCents = null,Object? totalAssignedCents = null,}) {
+  return _then(_self.copyWith(
+items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+as List<AutoAssignItem>,totalToAssignCents: null == totalToAssignCents ? _self.totalToAssignCents : totalToAssignCents // ignore: cast_nullable_to_non_nullable
+as int,totalAssignedCents: null == totalAssignedCents ? _self.totalAssignedCents : totalAssignedCents // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AutoAssignProposal].
+extension AutoAssignProposalPatterns on AutoAssignProposal {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AutoAssignProposal value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AutoAssignProposal() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AutoAssignProposal value)  $default,){
+final _that = this;
+switch (_that) {
+case _AutoAssignProposal():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AutoAssignProposal value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AutoAssignProposal() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<AutoAssignItem> items,  int totalToAssignCents,  int totalAssignedCents)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AutoAssignProposal() when $default != null:
+return $default(_that.items,_that.totalToAssignCents,_that.totalAssignedCents);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<AutoAssignItem> items,  int totalToAssignCents,  int totalAssignedCents)  $default,) {final _that = this;
+switch (_that) {
+case _AutoAssignProposal():
+return $default(_that.items,_that.totalToAssignCents,_that.totalAssignedCents);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<AutoAssignItem> items,  int totalToAssignCents,  int totalAssignedCents)?  $default,) {final _that = this;
+switch (_that) {
+case _AutoAssignProposal() when $default != null:
+return $default(_that.items,_that.totalToAssignCents,_that.totalAssignedCents);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _AutoAssignProposal implements AutoAssignProposal {
+  const _AutoAssignProposal({required final  List<AutoAssignItem> items, required this.totalToAssignCents, required this.totalAssignedCents}): _items = items;
+  
+
+ final  List<AutoAssignItem> _items;
+@override List<AutoAssignItem> get items {
+  if (_items is EqualUnmodifiableListView) return _items;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_items);
+}
+
+@override final  int totalToAssignCents;
+@override final  int totalAssignedCents;
+
+/// Create a copy of AutoAssignProposal
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AutoAssignProposalCopyWith<_AutoAssignProposal> get copyWith => __$AutoAssignProposalCopyWithImpl<_AutoAssignProposal>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AutoAssignProposal&&const DeepCollectionEquality().equals(other._items, _items)&&(identical(other.totalToAssignCents, totalToAssignCents) || other.totalToAssignCents == totalToAssignCents)&&(identical(other.totalAssignedCents, totalAssignedCents) || other.totalAssignedCents == totalAssignedCents));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_items),totalToAssignCents,totalAssignedCents);
+
+@override
+String toString() {
+  return 'AutoAssignProposal(items: $items, totalToAssignCents: $totalToAssignCents, totalAssignedCents: $totalAssignedCents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AutoAssignProposalCopyWith<$Res> implements $AutoAssignProposalCopyWith<$Res> {
+  factory _$AutoAssignProposalCopyWith(_AutoAssignProposal value, $Res Function(_AutoAssignProposal) _then) = __$AutoAssignProposalCopyWithImpl;
+@override @useResult
+$Res call({
+ List<AutoAssignItem> items, int totalToAssignCents, int totalAssignedCents
+});
+
+
+
+
+}
+/// @nodoc
+class __$AutoAssignProposalCopyWithImpl<$Res>
+    implements _$AutoAssignProposalCopyWith<$Res> {
+  __$AutoAssignProposalCopyWithImpl(this._self, this._then);
+
+  final _AutoAssignProposal _self;
+  final $Res Function(_AutoAssignProposal) _then;
+
+/// Create a copy of AutoAssignProposal
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? items = null,Object? totalToAssignCents = null,Object? totalAssignedCents = null,}) {
+  return _then(_AutoAssignProposal(
+items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
+as List<AutoAssignItem>,totalToAssignCents: null == totalToAssignCents ? _self.totalToAssignCents : totalToAssignCents // ignore: cast_nullable_to_non_nullable
+as int,totalAssignedCents: null == totalAssignedCents ? _self.totalAssignedCents : totalAssignedCents // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.g.dart
@@ -1,0 +1,153 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auto_assign_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Computes an auto-assign proposal that distributes Ready to Assign money
+/// across underfunded envelopes based on their goals.
+
+@ProviderFor(autoAssignProposal)
+final autoAssignProposalProvider = AutoAssignProposalFamily._();
+
+/// Computes an auto-assign proposal that distributes Ready to Assign money
+/// across underfunded envelopes based on their goals.
+
+final class AutoAssignProposalProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AutoAssignProposal>,
+          AutoAssignProposal,
+          FutureOr<AutoAssignProposal>
+        >
+    with
+        $FutureModifier<AutoAssignProposal>,
+        $FutureProvider<AutoAssignProposal> {
+  /// Computes an auto-assign proposal that distributes Ready to Assign money
+  /// across underfunded envelopes based on their goals.
+  AutoAssignProposalProvider._({
+    required AutoAssignProposalFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'autoAssignProposalProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoAssignProposalHash();
+
+  @override
+  String toString() {
+    return r'autoAssignProposalProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<AutoAssignProposal> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<AutoAssignProposal> create(Ref ref) {
+    final argument = this.argument as String;
+    return autoAssignProposal(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AutoAssignProposalProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$autoAssignProposalHash() =>
+    r'bec744d92ce12e8af1b8465bbc5e267d2a7f6ad2';
+
+/// Computes an auto-assign proposal that distributes Ready to Assign money
+/// across underfunded envelopes based on their goals.
+
+final class AutoAssignProposalFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<AutoAssignProposal>, String> {
+  AutoAssignProposalFamily._()
+    : super(
+        retry: null,
+        name: r'autoAssignProposalProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Computes an auto-assign proposal that distributes Ready to Assign money
+  /// across underfunded envelopes based on their goals.
+
+  AutoAssignProposalProvider call(String budgetId) =>
+      AutoAssignProposalProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'autoAssignProposalProvider';
+}
+
+@ProviderFor(AutoAssignActions)
+final autoAssignActionsProvider = AutoAssignActionsProvider._();
+
+final class AutoAssignActionsProvider
+    extends $NotifierProvider<AutoAssignActions, AsyncValue<void>> {
+  AutoAssignActionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoAssignActionsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoAssignActionsHash();
+
+  @$internal
+  @override
+  AutoAssignActions create() => AutoAssignActions();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<void> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
+  }
+}
+
+String _$autoAssignActionsHash() => r'b541e2fcd4eb4b864fca1dc1f5c4a779db158ba6';
+
+abstract class _$AutoAssignActions extends $Notifier<AsyncValue<void>> {
+  AsyncValue<void> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<void>, AsyncValue<void>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, AsyncValue<void>>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/openbudget_app/lib/src/features/budget/screens/auto_assign_dialog.dart
+++ b/openbudget_app/lib/src/features/budget/screens/auto_assign_dialog.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/auto_assign_provider.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class AutoAssignDialog extends HookConsumerWidget {
+  const AutoAssignDialog({
+    required this.budgetId,
+    required this.currencyCode,
+    super.key,
+  });
+
+  final String budgetId;
+  final CurrencyCode currencyCode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final proposalAsync = ref.watch(autoAssignProposalProvider(budgetId));
+    final isAssigning = useState(false);
+
+    return AlertDialog(
+      title: Row(
+        children: [
+          const Icon(
+            Icons.auto_fix_high_rounded,
+            color: ColorTokens.primary,
+            size: 24,
+          ),
+          const SizedBox(width: SpacingTokens.sm),
+          Expanded(child: Text(l10n.autoAssignTitle)),
+        ],
+      ),
+      content: proposalAsync.when(
+        loading: () => const SizedBox(
+          height: 120,
+          child: Center(child: CircularProgressIndicator()),
+        ),
+        error: (_, __) => Text(l10n.autoAssignError),
+        data: (proposal) {
+          if (proposal.items.isEmpty) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.check_circle_outline_rounded,
+                  size: 48,
+                  color: ColorTokens.secondary,
+                ),
+                const SizedBox(height: SpacingTokens.md),
+                Text(
+                  l10n.autoAssignNothingToAssign,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            );
+          }
+
+          return SizedBox(
+            width: double.maxFinite,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(SpacingTokens.sm),
+                  decoration: BoxDecoration(
+                    color: ColorTokens.secondary.withAlpha(20),
+                    borderRadius: BorderRadius.circular(RadiusTokens.sm),
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          l10n.autoAssignDistributing,
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ),
+                      Text(
+                        formatCents(proposal.totalAssignedCents, currencyCode),
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: ColorTokens.secondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: SpacingTokens.md),
+                Text(
+                  l10n.autoAssignEnvelopeCount(proposal.items.length),
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: SpacingTokens.sm),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 300),
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: proposal.items.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final item = proposal.items[index];
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: SpacingTokens.sm,
+                        ),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                item.envelopeName,
+                                style: theme.textTheme.bodyMedium,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(width: SpacingTokens.sm),
+                            Text(
+                              '+${formatCents(item.addedCents, currencyCode)}',
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: ColorTokens.secondary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+      actions: [
+        TextButton(
+          onPressed: isAssigning.value
+              ? null
+              : () => Navigator.of(context).pop(),
+          child: Text(l10n.dialogCancel),
+        ),
+        if (proposalAsync.hasValue && proposalAsync.value!.items.isNotEmpty)
+          FilledButton.icon(
+            onPressed: isAssigning.value
+                ? null
+                : () => _executeAssign(
+                    context,
+                    ref,
+                    proposalAsync.value!,
+                    isAssigning,
+                  ),
+            icon: isAssigning.value
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.auto_fix_high_rounded, size: 18),
+            label: Text(
+              isAssigning.value
+                  ? l10n.autoAssignAssigning
+                  : l10n.autoAssignButton,
+            ),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _executeAssign(
+    BuildContext context,
+    WidgetRef ref,
+    AutoAssignProposal proposal,
+    ValueNotifier<bool> isAssigning,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    isAssigning.value = true;
+    try {
+      final count = await ref
+          .read(autoAssignActionsProvider.notifier)
+          .execute(budgetId: budgetId, items: proposal.items);
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.autoAssignSuccess(count))),
+        );
+        Navigator.of(context).pop();
+      }
+    } on Exception catch (_) {
+      isAssigning.value = false;
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.autoAssignError),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/age_of_money_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/selected_month_provider.dart';
+import 'package:openbudget_app/src/features/budget/screens/auto_assign_dialog.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
@@ -151,6 +152,26 @@ class BudgetHeader extends HookConsumerWidget {
               ),
             ),
           ],
+          if (readyToAssignCents > 0) ...[
+            const SizedBox(height: SpacingTokens.sm),
+            FilledButton.icon(
+              onPressed: () => _showAutoAssignDialog(context),
+              icon: const Icon(Icons.auto_fix_high_rounded, size: 16),
+              label: Text(l10n.autoAssignButton),
+              style: FilledButton.styleFrom(
+                backgroundColor: ColorTokens.secondary,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SpacingTokens.md,
+                  vertical: SpacingTokens.xs,
+                ),
+                minimumSize: Size.zero,
+                textStyle: theme.textTheme.labelMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
           if (ageOfMoneyAsync.hasValue && ageOfMoneyAsync.value != null) ...[
             const SizedBox(height: SpacingTokens.sm),
             Row(
@@ -173,6 +194,14 @@ class BudgetHeader extends HookConsumerWidget {
           ],
         ],
       ),
+    );
+  }
+
+  void _showAutoAssignDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (_) =>
+          AutoAssignDialog(budgetId: budgetId, currencyCode: currencyCode),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Adds YNAB's signature "Auto-Assign" feature to the budget header
- When Ready to Assign is positive, an "Auto-Assign" button appears below the amount
- Clicking it shows a dialog with a preview of proposed allocations for all underfunded envelopes based on their goals
- Distributes money to each underfunded envelope (up to its needed amount) until Ready to Assign is depleted

## Changes
- **New**: `auto_assign_provider.dart` - computes auto-assign proposals and executes batch allocations
- **New**: `auto_assign_dialog.dart` - preview dialog showing proposed allocation changes
- **Modified**: `budget_header.dart` - added Auto-Assign button when Ready to Assign > 0
- **Modified**: `app_en.arb` - added 7 l10n strings for auto-assign UI

## Test plan
- [ ] Verify Auto-Assign button appears only when Ready to Assign > 0
- [ ] Set goals on multiple envelopes, verify dialog shows correct underfunded amounts
- [ ] Execute auto-assign, verify allocations are updated correctly
- [ ] Verify button disappears after all money is assigned
- [ ] Verify "fully funded" message when no envelopes are underfunded