### PR TITLE
feat: add envelope activity bottom sheet with transaction list

### DIFF
--- a/.changeset/feat-envelope-activity.md
+++ b/.changeset/feat-envelope-activity.md
@@ -1,0 +1,5 @@
+---
+openbudget_app: minor
+---
+
+Add envelope activity bottom sheet showing transactions, goal progress, and budget breakdown when tapping an envelope

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -332,5 +332,7 @@
       }
     }
   },
-  "autoAssignError": "Could not auto-assign. Please try again."
+  "autoAssignError": "Could not auto-assign. Please try again.",
+  "envelopeActivityTitle": "Activity",
+  "envelopeNoActivity": "No transactions this month"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1587,6 +1587,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not auto-assign. Please try again.'**
   String get autoAssignError;
+
+  /// No description provided for @envelopeActivityTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Activity'**
+  String get envelopeActivityTitle;
+
+  /// No description provided for @envelopeNoActivity.
+  ///
+  /// In en, this message translates to:
+  /// **'No transactions this month'**
+  String get envelopeNoActivity;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -863,4 +863,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get autoAssignError => 'Could not auto-assign. Please try again.';
+
+  @override
+  String get envelopeActivityTitle => 'Activity';
+
+  @override
+  String get envelopeNoActivity => 'No transactions this month';
 }

--- a/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.g.dart
@@ -74,7 +74,7 @@ final class AutoAssignProposalProvider
 }
 
 String _$autoAssignProposalHash() =>
-    r'bec744d92ce12e8af1b8465bbc5e267d2a7f6ad2';
+    r'1f3cbe112382e1fca9f467d99660eb290ed0718b';
 
 /// Computes an auto-assign proposal that distributes Ready to Assign money
 /// across underfunded envelopes based on their goals.

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -13,6 +13,7 @@ import 'package:openbudget_app/src/features/budget/providers/selected_month_prov
 import 'package:openbudget_app/src/features/budget/screens/add_category_dialog.dart';
 import 'package:openbudget_app/src/features/budget/screens/add_envelope_dialog.dart';
 import 'package:openbudget_app/src/features/budget/screens/edit_envelope_dialog.dart';
+import 'package:openbudget_app/src/features/budget/screens/envelope_activity_sheet.dart';
 import 'package:openbudget_app/src/features/budget/screens/move_money_dialog.dart';
 import 'package:openbudget_app/src/features/budget/screens/quick_budget_dialog.dart';
 import 'package:openbudget_app/src/features/budget/widgets/budget_header.dart';
@@ -233,6 +234,14 @@ class BudgetDetailScreen extends HookConsumerWidget {
                         year: summary.year,
                         month: summary.month,
                       ),
+                      onShowActivity: (envelope, monthlyData, goal) =>
+                          _showEnvelopeActivity(
+                            context,
+                            envelope,
+                            currencyCode,
+                            monthlyData: monthlyData,
+                            goal: goal,
+                          ),
                     ),
                   ),
                 ),
@@ -306,6 +315,32 @@ class BudgetDetailScreen extends HookConsumerWidget {
           ),
         );
       },
+    );
+  }
+
+  void _showEnvelopeActivity(
+    BuildContext context,
+    Envelope envelope,
+    CurrencyCode currencyCode, {
+    MonthlyEnvelopeData? monthlyData,
+    EnvelopeGoal? goal,
+  }) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(RadiusTokens.lg),
+        ),
+      ),
+      builder: (_) => EnvelopeActivitySheet(
+        envelope: envelope,
+        budgetId: budgetId,
+        currencyCode: currencyCode,
+        monthlyData: monthlyData,
+        goal: goal,
+      ),
     );
   }
 

--- a/openbudget_app/lib/src/features/budget/screens/envelope_activity_sheet.dart
+++ b/openbudget_app/lib/src/features/budget/screens/envelope_activity_sheet.dart
@@ -1,0 +1,370 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_goals_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/monthly_allocation_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/selected_month_provider.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class EnvelopeActivitySheet extends HookConsumerWidget {
+  const EnvelopeActivitySheet({
+    required this.envelope,
+    required this.budgetId,
+    required this.currencyCode,
+    this.monthlyData,
+    this.goal,
+    super.key,
+  });
+
+  final Envelope envelope;
+  final String budgetId;
+  final CurrencyCode currencyCode;
+  final MonthlyEnvelopeData? monthlyData;
+  final EnvelopeGoal? goal;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final selectedMonth = ref.watch(selectedMonthProvider(budgetId));
+    final transactionsAsync = ref.watch(
+      monthlyTransactionsProvider(
+        budgetId,
+        selectedMonth.year,
+        selectedMonth.month,
+      ),
+    );
+
+    final budgeted =
+        monthlyData?.allocatedCents ?? envelope.budgetedAmountCents;
+    final spent = monthlyData?.spentCents ?? envelope.spentAmountCents;
+    final available = monthlyData?.availableCents ?? (budgeted - spent);
+    final availableColor = available > 0
+        ? ColorTokens.secondary
+        : available < 0
+        ? ColorTokens.error
+        : ColorTokens.tertiary;
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.6,
+      minChildSize: 0.3,
+      maxChildSize: 0.9,
+      expand: false,
+      builder: (context, scrollController) {
+        return Column(
+          children: [
+            // Drag handle
+            Container(
+              margin: const EdgeInsets.only(top: SpacingTokens.sm),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            // Header
+            Padding(
+              padding: const EdgeInsets.all(SpacingTokens.md),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    envelope.name,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  if (goal != null) ...[
+                    const SizedBox(height: SpacingTokens.xs),
+                    _GoalSummary(
+                      goal: goal!,
+                      budgetedCents: budgeted,
+                      availableCents: available,
+                      currencyCode: currencyCode,
+                    ),
+                  ],
+                  const SizedBox(height: SpacingTokens.md),
+                  // Budget summary row
+                  Row(
+                    children: [
+                      _SummaryChip(
+                        label: l10n.budgetColumnBudgeted,
+                        amount: formatCents(budgeted, currencyCode),
+                        color: ColorTokens.primary,
+                      ),
+                      const SizedBox(width: SpacingTokens.sm),
+                      _SummaryChip(
+                        label: l10n.budgetColumnSpent,
+                        amount: formatCents(spent, currencyCode),
+                        color: ColorTokens.error,
+                      ),
+                      const SizedBox(width: SpacingTokens.sm),
+                      _SummaryChip(
+                        label: l10n.budgetColumnAvailable,
+                        amount: formatCents(available, currencyCode),
+                        color: availableColor,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: SpacingTokens.md),
+                  Text(
+                    l10n.envelopeActivityTitle,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            // Transaction list
+            Expanded(
+              child: transactionsAsync.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (_, __) =>
+                    Center(child: Text(l10n.transactionLoadError)),
+                data: (allTransactions) {
+                  final envelopeId = envelope.id?.toString();
+                  final transactions =
+                      allTransactions
+                          .where((t) => t.envelopeId?.toString() == envelopeId)
+                          .toList()
+                        ..sort(
+                          (a, b) =>
+                              b.transactionDate.compareTo(a.transactionDate),
+                        );
+
+                  if (transactions.isEmpty) {
+                    return Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.receipt_long_rounded,
+                            size: 40,
+                            color: colorScheme.outlineVariant,
+                          ),
+                          const SizedBox(height: SpacingTokens.sm),
+                          Text(
+                            l10n.envelopeNoActivity,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  return ListView.builder(
+                    controller: scrollController,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: SpacingTokens.md,
+                    ),
+                    itemCount: transactions.length,
+                    itemBuilder: (context, index) {
+                      final tx = transactions[index];
+                      final isIncome = tx.amountCents > 0;
+                      final color = isIncome
+                          ? ColorTokens.secondary
+                          : ColorTokens.error;
+
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: SpacingTokens.xs,
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(
+                              isIncome
+                                  ? Icons.arrow_downward_rounded
+                                  : Icons.arrow_upward_rounded,
+                              color: color,
+                              size: 16,
+                            ),
+                            const SizedBox(width: SpacingTokens.sm),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    tx.description,
+                                    style: theme.textTheme.bodyMedium,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  Text(
+                                    _formatDate(tx.transactionDate),
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: colorScheme.onSurfaceVariant,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            Text(
+                              formatCents(tx.amountCents, currencyCode),
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: color,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class _GoalSummary extends HookWidget {
+  const _GoalSummary({
+    required this.goal,
+    required this.budgetedCents,
+    required this.availableCents,
+    required this.currencyCode,
+  });
+
+  final EnvelopeGoal goal;
+  final int budgetedCents;
+  final int availableCents;
+  final CurrencyCode currencyCode;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final progress = computeFundingProgress(
+      goal: goal,
+      budgetedCents: budgetedCents,
+      availableCents: availableCents,
+    );
+    final clampedProgress = progress.clamp(0.0, 1.0);
+    final underfunded = computeUnderfundedCents(
+      goal: goal,
+      budgetedCents: budgetedCents,
+      availableCents: availableCents,
+    );
+
+    final Color barColor;
+    if (progress >= 1.0) {
+      barColor = ColorTokens.secondary;
+    } else if (progress >= 0.5) {
+      barColor = ColorTokens.tertiary;
+    } else {
+      barColor = ColorTokens.error;
+    }
+
+    final goalLabel = switch (goal.goalType) {
+      'target_balance' =>
+        'Target: ${formatCents(goal.targetAmountCents, currencyCode)}',
+      'monthly_funding' =>
+        'Monthly: ${formatCents(goal.monthlyFundingCents ?? goal.targetAmountCents, currencyCode)}',
+      'target_by_date' =>
+        'Target: ${formatCents(goal.targetAmountCents, currencyCode)}${goal.targetDate != null ? ' by ${goal.targetDate!.year}-${goal.targetDate!.month.toString().padLeft(2, '0')}' : ''}',
+      _ => '',
+    };
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.flag_rounded, size: 14, color: barColor),
+            const SizedBox(width: 4),
+            Text(
+              goalLabel,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: barColor,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            if (underfunded > 0) ...[
+              const Spacer(),
+              Text(
+                '${formatCents(underfunded, currencyCode)} needed',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: ColorTokens.error,
+                ),
+              ),
+            ],
+          ],
+        ),
+        const SizedBox(height: 4),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(3),
+          child: LinearProgressIndicator(
+            value: clampedProgress,
+            minHeight: 6,
+            backgroundColor: barColor.withAlpha(30),
+            valueColor: AlwaysStoppedAnimation<Color>(barColor),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SummaryChip extends HookWidget {
+  const _SummaryChip({
+    required this.label,
+    required this.amount,
+    required this.color,
+  });
+
+  final String label;
+  final String amount;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          vertical: SpacingTokens.xs,
+          horizontal: SpacingTokens.sm,
+        ),
+        decoration: BoxDecoration(
+          color: color.withAlpha(15),
+          borderRadius: BorderRadius.circular(RadiusTokens.sm),
+          border: Border.all(color: color.withAlpha(40)),
+        ),
+        child: Column(
+          children: [
+            Text(
+              label,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: color.withAlpha(180),
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              amount,
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/openbudget_app/lib/src/features/budget/widgets/category_group.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/category_group.dart
@@ -17,6 +17,7 @@ class CategoryGroup extends HookConsumerWidget {
     required this.onEditEnvelope,
     required this.onDeleteEnvelope,
     this.onQuickBudget,
+    this.onShowActivity,
     this.goalsMap = const {},
     super.key,
   });
@@ -28,6 +29,8 @@ class CategoryGroup extends HookConsumerWidget {
   final void Function(Envelope envelope) onEditEnvelope;
   final void Function(Envelope envelope) onDeleteEnvelope;
   final void Function(Envelope envelope)? onQuickBudget;
+  final void Function(Envelope envelope, MonthlyEnvelopeData?, EnvelopeGoal?)?
+  onShowActivity;
   final Map<String, EnvelopeGoal> goalsMap;
 
   @override
@@ -111,13 +114,16 @@ class CategoryGroup extends HookConsumerWidget {
                     entry.key < categoryWithEnvelopes.monthlyEnvelopes.length
                 ? categoryWithEnvelopes.monthlyEnvelopes[entry.key]
                 : null;
+            final envelopeGoal = goalsMap[envelopeId];
             return EnvelopeRow(
               envelope: envelope,
               currencyCode: currencyCode,
               monthlyData: monthlyData,
-              goal: goalsMap[envelopeId],
-              onTap: () => onEditEnvelope(envelope),
-              onLongPress: () => onDeleteEnvelope(envelope),
+              goal: envelopeGoal,
+              onTap: onShowActivity != null
+                  ? () => onShowActivity!(envelope, monthlyData, envelopeGoal)
+                  : () => onEditEnvelope(envelope),
+              onLongPress: () => onEditEnvelope(envelope),
               onQuickBudget: onQuickBudget != null
                   ? () => onQuickBudget!(envelope)
                   : null,


### PR DESCRIPTION
## Summary
- Tapping an envelope now shows a bottom sheet with its activity for the selected month
- Shows goal progress bar and target info (type, amount, needed)
- Displays budget/spent/available summary chips
- Lists all transactions assigned to the envelope, sorted by date
- Long press still opens the edit envelope dialog

## Changes
- **New**: `envelope_activity_sheet.dart` - draggable bottom sheet with envelope details and transaction list
- **Modified**: `category_group.dart` - added `onShowActivity` callback, tap shows activity, long press edits
- **Modified**: `budget_detail_screen.dart` - passes `onShowActivity` to show bottom sheet
- **Modified**: `app_en.arb` - added 2 l10n strings for envelope activity

## Test plan
- [ ] Tap envelope to see activity bottom sheet
- [ ] Verify goal progress shows correctly for different goal types
- [ ] Verify budget/spent/available chips show correct values
- [ ] Verify transaction list shows only this envelope's transactions
- [ ] Long press envelope to open edit dialog (previous behavior preserved)
- [ ] Drag bottom sheet to expand/collapse