### PR TITLE
feat: add auto-posting of due recurring/scheduled transactions

### DIFF
--- a/.changeset/feat-recurring-auto-post.md
+++ b/.changeset/feat-recurring-auto-post.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+feat: add auto-posting of due recurring/scheduled transactions

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -311,6 +311,25 @@
       }
     }
   },
+  "recurringDueBanner": "{count, plural, =1{1 scheduled transaction is due} other{{count} scheduled transactions are due}}",
+  "@recurringDueBanner": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "recurringPostDue": "Post Now",
+  "recurringPosting": "Posting...",
+  "recurringPostSuccess": "{count, plural, =1{1 transaction posted} other{{count} transactions posted}}",
+  "@recurringPostSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "recurringPostError": "Could not post scheduled transactions. Please try again.",
   "autoAssignTitle": "Auto-Assign",
   "autoAssignButton": "Auto-Assign",
   "autoAssignAssigning": "Assigning...",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1540,6 +1540,36 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{...and 1 more row} other{...and {count} more rows}}'**
   String importMoreRows(int count);
 
+  /// No description provided for @recurringDueBanner.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 scheduled transaction is due} other{{count} scheduled transactions are due}}'**
+  String recurringDueBanner(int count);
+
+  /// No description provided for @recurringPostDue.
+  ///
+  /// In en, this message translates to:
+  /// **'Post Now'**
+  String get recurringPostDue;
+
+  /// No description provided for @recurringPosting.
+  ///
+  /// In en, this message translates to:
+  /// **'Posting...'**
+  String get recurringPosting;
+
+  /// No description provided for @recurringPostSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction posted} other{{count} transactions posted}}'**
+  String recurringPostSuccess(int count);
+
+  /// No description provided for @recurringPostError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not post scheduled transactions. Please try again.'**
+  String get recurringPostError;
+
   /// No description provided for @autoAssignTitle.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -824,6 +824,38 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String recurringDueBanner(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count scheduled transactions are due',
+      one: '1 scheduled transaction is due',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringPostDue => 'Post Now';
+
+  @override
+  String get recurringPosting => 'Posting...';
+
+  @override
+  String recurringPostSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions posted',
+      one: '1 transaction posted',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringPostError =>
+      'Could not post scheduled transactions. Please try again.';
+
+  @override
   String get autoAssignTitle => 'Auto-Assign';
 
   @override

--- a/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/auto_assign_provider.g.dart
@@ -74,7 +74,7 @@ final class AutoAssignProposalProvider
 }
 
 String _$autoAssignProposalHash() =>
-    r'bec744d92ce12e8af1b8465bbc5e267d2a7f6ad2';
+    r'1f3cbe112382e1fca9f467d99660eb290ed0718b';
 
 /// Computes an auto-assign proposal that distributes Ready to Assign money
 /// across underfunded envelopes based on their goals.

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
@@ -18,6 +19,7 @@ import 'package:openbudget_app/src/features/budget/screens/quick_budget_dialog.d
 import 'package:openbudget_app/src/features/budget/widgets/budget_header.dart';
 import 'package:openbudget_app/src/features/budget/widgets/category_group.dart';
 import 'package:openbudget_app/src/features/budget/widgets/credit_card_section.dart';
+import 'package:openbudget_app/src/features/recurring/providers/recurring_auto_post_provider.dart';
 import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
@@ -34,6 +36,8 @@ class BudgetDetailScreen extends HookConsumerWidget {
     final summaryAsync = ref.watch(budgetMonthlySummaryProvider(budgetId));
     final ccPayments = ref.watch(creditCardPaymentsProvider(budgetId));
     final goalsAsync = ref.watch(budgetGoalsProvider(budgetId));
+    final dueCountAsync = ref.watch(recurringDueCountProvider(budgetId));
+    final isPosting = useState(false);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -127,6 +131,7 @@ class BudgetDetailScreen extends HookConsumerWidget {
                 ..invalidate(budgetSummaryProvider(budgetId))
                 ..invalidate(budgetMonthlySummaryProvider(budgetId))
                 ..invalidate(budgetGoalsProvider(budgetId))
+                ..invalidate(recurringDueCountProvider(budgetId))
                 ..invalidate(
                   monthlyAllocationsProvider(
                     budgetId,
@@ -154,6 +159,12 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   totalOverspentCents: totalOverspentCents,
                 ),
                 const SizedBox(height: SpacingTokens.md),
+                if (dueCountAsync.hasValue && dueCountAsync.value! > 0)
+                  _DueBanner(
+                    count: dueCountAsync.value!,
+                    isPosting: isPosting.value,
+                    onPost: () => _postDueTransactions(context, ref, isPosting),
+                  ),
                 if (ccPayments.hasValue && ccPayments.value!.isNotEmpty) ...[
                   CreditCardSection(
                     payments: ccPayments.value!,
@@ -447,6 +458,36 @@ class BudgetDetailScreen extends HookConsumerWidget {
     }
   }
 
+  Future<void> _postDueTransactions(
+    BuildContext context,
+    WidgetRef ref,
+    ValueNotifier<bool> isPosting,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    isPosting.value = true;
+    try {
+      final count = await ref
+          .read(recurringAutoPostActionsProvider.notifier)
+          .postDue(budgetId: budgetId);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.recurringPostSuccess(count))),
+        );
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.recurringPostError),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      isPosting.value = false;
+    }
+  }
+
   Future<void> _confirmDeleteEnvelope(
     BuildContext context,
     WidgetRef ref,
@@ -503,5 +544,85 @@ class BudgetDetailScreen extends HookConsumerWidget {
         );
       }
     }
+  }
+}
+
+class _DueBanner extends HookWidget {
+  const _DueBanner({
+    required this.count,
+    required this.isPosting,
+    required this.onPost,
+  });
+
+  final int count;
+  final bool isPosting;
+  final VoidCallback onPost;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SpacingTokens.md),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: SpacingTokens.md,
+          vertical: SpacingTokens.sm,
+        ),
+        decoration: BoxDecoration(
+          color: ColorTokens.primary.withAlpha(15),
+          borderRadius: BorderRadius.circular(RadiusTokens.md),
+          border: Border.all(color: ColorTokens.primary.withAlpha(60)),
+        ),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.schedule_rounded,
+              size: 20,
+              color: ColorTokens.primary,
+            ),
+            const SizedBox(width: SpacingTokens.sm),
+            Expanded(
+              child: Text(
+                l10n.recurringDueBanner(count),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: ColorTokens.primary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            const SizedBox(width: SpacingTokens.sm),
+            FilledButton.icon(
+              onPressed: isPosting ? null : onPost,
+              icon: isPosting
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Icon(Icons.play_arrow_rounded, size: 16),
+              label: Text(
+                isPosting ? l10n.recurringPosting : l10n.recurringPostDue,
+              ),
+              style: FilledButton.styleFrom(
+                backgroundColor: ColorTokens.primary,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SpacingTokens.md,
+                  vertical: SpacingTokens.xs,
+                ),
+                textStyle: theme.textTheme.labelSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/openbudget_app/lib/src/features/recurring/providers/recurring_auto_post_provider.dart
+++ b/openbudget_app/lib/src/features/recurring/providers/recurring_auto_post_provider.dart
@@ -1,0 +1,56 @@
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/recurring/providers/recurring_list_provider.dart';
+import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'recurring_auto_post_provider.g.dart';
+
+/// Fetches the count of due recurring transactions for a budget.
+@riverpod
+Future<int> recurringDueCount(Ref ref, String budgetId) async {
+  final client = ref.watch(serverpodClientProvider);
+  return client.recurringTransaction.countDue(
+    // UuidValue is experimental in the uuid package.
+    // ignore: experimental_member_use
+    UuidValue.fromString(budgetId),
+  );
+}
+
+/// Posts all due recurring transactions and returns the count posted.
+@Riverpod(keepAlive: true)
+class RecurringAutoPostActions extends _$RecurringAutoPostActions {
+  @override
+  AsyncValue<void> build() => const AsyncValue.data(null);
+
+  Future<int> postDue({required String budgetId}) async {
+    state = const AsyncValue.loading();
+    try {
+      final client = ref.read(serverpodClientProvider);
+      final count = await client.recurringTransaction.postDue(
+        // UuidValue is experimental in the uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(budgetId),
+      );
+
+      // Invalidate relevant providers to refresh data.
+      ref
+        ..invalidate(recurringDueCountProvider(budgetId))
+        ..invalidate(recurringListProvider(budgetId))
+        ..invalidate(transactionListProvider(budgetId))
+        ..invalidate(budgetSummaryProvider(budgetId))
+        ..invalidate(budgetMonthlySummaryProvider(budgetId));
+
+      if (ref.mounted) {
+        state = const AsyncValue.data(null);
+      }
+      return count;
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+}

--- a/openbudget_app/lib/src/features/recurring/providers/recurring_auto_post_provider.g.dart
+++ b/openbudget_app/lib/src/features/recurring/providers/recurring_auto_post_provider.g.dart
@@ -1,0 +1,146 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recurring_auto_post_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches the count of due recurring transactions for a budget.
+
+@ProviderFor(recurringDueCount)
+final recurringDueCountProvider = RecurringDueCountFamily._();
+
+/// Fetches the count of due recurring transactions for a budget.
+
+final class RecurringDueCountProvider
+    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
+    with $FutureModifier<int>, $FutureProvider<int> {
+  /// Fetches the count of due recurring transactions for a budget.
+  RecurringDueCountProvider._({
+    required RecurringDueCountFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'recurringDueCountProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringDueCountHash();
+
+  @override
+  String toString() {
+    return r'recurringDueCountProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<int> create(Ref ref) {
+    final argument = this.argument as String;
+    return recurringDueCount(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is RecurringDueCountProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$recurringDueCountHash() => r'b80a0324a1ac47b7cb1225133da4cc50d9ab1797';
+
+/// Fetches the count of due recurring transactions for a budget.
+
+final class RecurringDueCountFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<int>, String> {
+  RecurringDueCountFamily._()
+    : super(
+        retry: null,
+        name: r'recurringDueCountProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches the count of due recurring transactions for a budget.
+
+  RecurringDueCountProvider call(String budgetId) =>
+      RecurringDueCountProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'recurringDueCountProvider';
+}
+
+/// Posts all due recurring transactions and returns the count posted.
+
+@ProviderFor(RecurringAutoPostActions)
+final recurringAutoPostActionsProvider = RecurringAutoPostActionsProvider._();
+
+/// Posts all due recurring transactions and returns the count posted.
+final class RecurringAutoPostActionsProvider
+    extends $NotifierProvider<RecurringAutoPostActions, AsyncValue<void>> {
+  /// Posts all due recurring transactions and returns the count posted.
+  RecurringAutoPostActionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringAutoPostActionsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringAutoPostActionsHash();
+
+  @$internal
+  @override
+  RecurringAutoPostActions create() => RecurringAutoPostActions();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<void> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
+  }
+}
+
+String _$recurringAutoPostActionsHash() =>
+    r'b424c733c8b6fb867d912dcce4393ba71956269c';
+
+/// Posts all due recurring transactions and returns the count posted.
+
+abstract class _$RecurringAutoPostActions extends $Notifier<AsyncValue<void>> {
+  AsyncValue<void> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<void>, AsyncValue<void>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, AsyncValue<void>>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -742,6 +742,20 @@ class EndpointRecurringTransaction extends _i1.EndpointRef {
     'delete',
     {'recurringTransactionId': recurringTransactionId},
   );
+
+  /// Posts all due recurring transactions for a budget, creating actual
+  /// transactions and advancing the schedule. Returns the count of created
+  /// transactions.
+  _i2.Future<int> postDue(_i1.UuidValue budgetId) =>
+      caller.callServerEndpoint<int>('recurringTransaction', 'postDue', {
+        'budgetId': budgetId,
+      });
+
+  /// Returns the count of active recurring transactions that are currently due.
+  _i2.Future<int> countDue(_i1.UuidValue budgetId) =>
+      caller.callServerEndpoint<int>('recurringTransaction', 'countDue', {
+        'budgetId': budgetId,
+      });
 }
 
 /// API surface for transaction operations.

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -1257,6 +1257,34 @@ class Endpoints extends _i1.EndpointDispatch {
                       as _i12.RecurringTransactionEndpoint)
                   .delete(session, params['recurringTransactionId']),
         ),
+        'postDue': _i1.MethodConnector(
+          name: 'postDue',
+          params: {
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['recurringTransaction']
+                      as _i12.RecurringTransactionEndpoint)
+                  .postDue(session, params['budgetId']),
+        ),
+        'countDue': _i1.MethodConnector(
+          name: 'countDue',
+          params: {
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['recurringTransaction']
+                      as _i12.RecurringTransactionEndpoint)
+                  .countDue(session, params['budgetId']),
+        ),
       },
     );
     connectors['transaction'] = _i1.EndpointConnector(

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -58,6 +58,8 @@ recurringTransaction:
   - get:
   - update:
   - delete:
+  - postDue:
+  - countDue:
 transaction:
   - create:
   - list:

--- a/openbudget_server/lib/src/recurring_transactions/recurring_transaction_endpoint.dart
+++ b/openbudget_server/lib/src/recurring_transactions/recurring_transaction_endpoint.dart
@@ -101,4 +101,16 @@ class RecurringTransactionEndpoint extends Endpoint {
       recurringTransactionId: recurringTransactionId,
     );
   }
+
+  /// Posts all due recurring transactions for a budget, creating actual
+  /// transactions and advancing the schedule. Returns the count of created
+  /// transactions.
+  Future<int> postDue(Session session, UuidValue budgetId) async {
+    return RecurringTransactionService.postDue(session, budgetId: budgetId);
+  }
+
+  /// Returns the count of active recurring transactions that are currently due.
+  Future<int> countDue(Session session, UuidValue budgetId) async {
+    return RecurringTransactionService.countDue(session, budgetId: budgetId);
+  }
 }

--- a/openbudget_server/lib/src/recurring_transactions/recurring_transaction_service.dart
+++ b/openbudget_server/lib/src/recurring_transactions/recurring_transaction_service.dart
@@ -1,7 +1,7 @@
 import 'package:openbudget_server/src/budgets/budget_service.dart';
 import 'package:openbudget_server/src/exceptions/exceptions.dart';
 import 'package:openbudget_server/src/generated/protocol.dart';
-import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/serverpod.dart' hide Transaction;
 
 /// Business logic for managing recurring transactions within a budget.
 ///
@@ -125,6 +125,86 @@ class RecurringTransactionService {
       recurringTransactionId: recurringTransactionId,
     );
     return RecurringTransaction.db.deleteRow(session, recurring);
+  }
+
+  /// Posts all due recurring transactions for a budget.
+  ///
+  /// Finds active recurring transactions where `nextOccurrence <= now`,
+  /// creates actual transactions for each, advances `nextOccurrence`, and
+  /// deactivates any that have passed their `endDate`.
+  ///
+  /// Returns the number of transactions created.
+  static Future<int> postDue(
+    Session session, {
+    required UuidValue budgetId,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+
+    final now = DateTime.now();
+    final dueRecurrings = await RecurringTransaction.db.find(
+      session,
+      where: (r) =>
+          r.budgetId.equals(budgetId) &
+          r.isActive.equals(true) &
+          (r.nextOccurrence <= now),
+      orderBy: (r) => r.nextOccurrence,
+    );
+
+    var count = 0;
+
+    for (final recurring in dueRecurrings) {
+      // Create the actual transaction from the recurring template.
+      final transaction = Transaction(
+        description: recurring.description,
+        amountCents: recurring.amountCents,
+        currencyCode: recurring.currencyCode,
+        budgetId: recurring.budgetId,
+        envelopeId: recurring.envelopeId,
+        accountId: recurring.accountId,
+        payeeId: recurring.payeeId,
+        transactionDate: recurring.nextOccurrence,
+        createdAt: DateTime.now(),
+      );
+      await Transaction.db.insertRow(session, transaction);
+      count++;
+
+      // Advance to next occurrence.
+      final nextDate = calculateNextOccurrence(
+        recurring.frequency,
+        recurring.nextOccurrence,
+      );
+
+      // Deactivate if past endDate.
+      final shouldDeactivate =
+          recurring.endDate != null && nextDate.isAfter(recurring.endDate!);
+
+      final updated = recurring.copyWith(
+        nextOccurrence: nextDate,
+        isActive: !shouldDeactivate,
+        updatedAt: DateTime.now(),
+      );
+      await RecurringTransaction.db.updateRow(session, updated);
+    }
+
+    return count;
+  }
+
+  /// Counts active recurring transactions that are due (nextOccurrence <= now).
+  static Future<int> countDue(
+    Session session, {
+    required UuidValue budgetId,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+
+    final now = DateTime.now();
+    final count = await RecurringTransaction.db.count(
+      session,
+      where: (r) =>
+          r.budgetId.equals(budgetId) &
+          r.isActive.equals(true) &
+          (r.nextOccurrence <= now),
+    );
+    return count;
   }
 
   /// Calculates the next occurrence based on frequency and current date.

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -1982,6 +1982,68 @@ class _RecurringTransactionEndpoint {
       }
     });
   }
+
+  _i3.Future<int> postDue(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue budgetId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'recurringTransaction',
+            method: 'postDue',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'recurringTransaction',
+          methodName: 'postDue',
+          parameters: _i1.testObjectToJson({'budgetId': budgetId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<int> countDue(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue budgetId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'recurringTransaction',
+            method: 'countDue',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'recurringTransaction',
+          methodName: 'countDue',
+          parameters: _i1.testObjectToJson({'budgetId': budgetId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
 }
 
 class _TransactionEndpoint {


### PR DESCRIPTION
## Summary
- Adds `postDue` and `countDue` backend endpoints to the recurring transaction API
- When active recurring transactions have `nextOccurrence <= now`, `postDue` creates actual transactions and advances the schedule
- Deactivates recurring transactions that exceed their `endDate`
- Budget detail screen shows a blue banner when scheduled transactions are due with a "Post Now" button
- Banner disappears after posting; all relevant providers are invalidated to refresh data

## Test plan
- [ ] Create a recurring transaction with `nextOccurrence` in the past
- [ ] Navigate to the budget detail screen and verify the blue "due" banner appears
- [ ] Tap "Post Now" and verify the transaction is created
- [ ] Verify the banner disappears after posting
- [ ] Verify the recurring transaction's `nextOccurrence` has advanced
- [ ] Test with `endDate` set - verify deactivation after posting