### PR TITLE
feat: add net worth tracking screen with asset/liability breakdown

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -353,5 +353,11 @@
   },
   "autoAssignError": "Could not auto-assign. Please try again.",
   "envelopeActivityTitle": "Activity",
-  "envelopeNoActivity": "No transactions this month"
+  "envelopeNoActivity": "No transactions this month",
+  "netWorthTitle": "Net Worth",
+  "netWorthAssets": "Assets",
+  "netWorthLiabilities": "Liabilities",
+  "netWorthLoadError": "Could not load net worth data",
+  "netWorthEmptyTitle": "No Accounts Yet",
+  "netWorthEmptySubtitle": "Add accounts to see your net worth breakdown"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1629,6 +1629,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No transactions this month'**
   String get envelopeNoActivity;
+
+  /// No description provided for @netWorthTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Net Worth'**
+  String get netWorthTitle;
+
+  /// No description provided for @netWorthAssets.
+  ///
+  /// In en, this message translates to:
+  /// **'Assets'**
+  String get netWorthAssets;
+
+  /// No description provided for @netWorthLiabilities.
+  ///
+  /// In en, this message translates to:
+  /// **'Liabilities'**
+  String get netWorthLiabilities;
+
+  /// No description provided for @netWorthLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load net worth data'**
+  String get netWorthLoadError;
+
+  /// No description provided for @netWorthEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Accounts Yet'**
+  String get netWorthEmptyTitle;
+
+  /// No description provided for @netWorthEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add accounts to see your net worth breakdown'**
+  String get netWorthEmptySubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -901,4 +901,23 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get envelopeNoActivity => 'No transactions this month';
+
+  @override
+  String get netWorthTitle => 'Net Worth';
+
+  @override
+  String get netWorthAssets => 'Assets';
+
+  @override
+  String get netWorthLiabilities => 'Liabilities';
+
+  @override
+  String get netWorthLoadError => 'Could not load net worth data';
+
+  @override
+  String get netWorthEmptyTitle => 'No Accounts Yet';
+
+  @override
+  String get netWorthEmptySubtitle =>
+      'Add accounts to see your net worth breakdown';
 }

--- a/openbudget_app/lib/src/features/reports/providers/net_worth_provider.dart
+++ b/openbudget_app/lib/src/features/reports/providers/net_worth_provider.dart
@@ -1,0 +1,56 @@
+import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'net_worth_provider.g.dart';
+
+/// Computes net worth from all accounts in a budget.
+@riverpod
+Future<NetWorthData> netWorth(Ref ref, String budgetId) async {
+  final accounts = await ref.watch(accountListProvider(budgetId).future);
+
+  var totalAssets = 0;
+  var totalLiabilities = 0;
+  final assetAccounts = <Account>[];
+  final liabilityAccounts = <Account>[];
+
+  for (final account in accounts) {
+    if (account.isClosed) continue;
+
+    if (account.accountType == 'creditCard') {
+      // Credit card balances are liabilities (typically negative).
+      totalLiabilities += account.balanceCents;
+      liabilityAccounts.add(account);
+    } else {
+      totalAssets += account.balanceCents;
+      assetAccounts.add(account);
+    }
+  }
+
+  return NetWorthData(
+    totalAssets: totalAssets,
+    totalLiabilities: totalLiabilities,
+    netWorth: totalAssets + totalLiabilities,
+    assetAccounts: assetAccounts,
+    liabilityAccounts: liabilityAccounts,
+    currencyCode: accounts.isNotEmpty ? accounts.first.currencyCode : 'USD',
+  );
+}
+
+class NetWorthData {
+  const NetWorthData({
+    required this.totalAssets,
+    required this.totalLiabilities,
+    required this.netWorth,
+    required this.assetAccounts,
+    required this.liabilityAccounts,
+    required this.currencyCode,
+  });
+
+  final int totalAssets;
+  final int totalLiabilities;
+  final int netWorth;
+  final List<Account> assetAccounts;
+  final List<Account> liabilityAccounts;
+  final String currencyCode;
+}

--- a/openbudget_app/lib/src/features/reports/providers/net_worth_provider.g.dart
+++ b/openbudget_app/lib/src/features/reports/providers/net_worth_provider.g.dart
@@ -1,0 +1,93 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'net_worth_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Computes net worth from all accounts in a budget.
+
+@ProviderFor(netWorth)
+final netWorthProvider = NetWorthFamily._();
+
+/// Computes net worth from all accounts in a budget.
+
+final class NetWorthProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<NetWorthData>,
+          NetWorthData,
+          FutureOr<NetWorthData>
+        >
+    with $FutureModifier<NetWorthData>, $FutureProvider<NetWorthData> {
+  /// Computes net worth from all accounts in a budget.
+  NetWorthProvider._({
+    required NetWorthFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'netWorthProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$netWorthHash();
+
+  @override
+  String toString() {
+    return r'netWorthProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<NetWorthData> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<NetWorthData> create(Ref ref) {
+    final argument = this.argument as String;
+    return netWorth(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is NetWorthProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$netWorthHash() => r'7ee1748312a6a639531f44c81d8c5fb1672b6d21';
+
+/// Computes net worth from all accounts in a budget.
+
+final class NetWorthFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<NetWorthData>, String> {
+  NetWorthFamily._()
+    : super(
+        retry: null,
+        name: r'netWorthProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Computes net worth from all accounts in a budget.
+
+  NetWorthProvider call(String budgetId) =>
+      NetWorthProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'netWorthProvider';
+}

--- a/openbudget_app/lib/src/features/reports/screens/net_worth_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/net_worth_screen.dart
@@ -1,0 +1,306 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/reports/providers/net_worth_provider.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class NetWorthScreen extends HookConsumerWidget {
+  const NetWorthScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final dataAsync = ref.watch(netWorthProvider(budgetId));
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.netWorthTitle)),
+      body: dataAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline_rounded,
+                size: 48,
+                color: colorScheme.error,
+              ),
+              const SizedBox(height: SpacingTokens.md),
+              Text(
+                l10n.netWorthLoadError,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.error,
+                ),
+              ),
+            ],
+          ),
+        ),
+        data: (data) {
+          final currency = CurrencyCode.values.firstWhere(
+            (c) => c.code == data.currencyCode,
+            orElse: () => CurrencyCode.usd,
+          );
+          final netWorthColor = data.netWorth >= 0
+              ? ColorTokens.secondary
+              : ColorTokens.error;
+
+          return ListView(
+            padding: const EdgeInsets.all(SpacingTokens.md),
+            children: [
+              // Net worth hero card
+              Container(
+                padding: const EdgeInsets.all(SpacingTokens.lg),
+                decoration: BoxDecoration(
+                  color: netWorthColor.withAlpha(15),
+                  borderRadius: BorderRadius.circular(RadiusTokens.md),
+                  border: Border.all(color: netWorthColor.withAlpha(60)),
+                ),
+                child: Column(
+                  children: [
+                    Text(
+                      l10n.netWorthTitle,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: netWorthColor.withAlpha(200),
+                      ),
+                    ),
+                    const SizedBox(height: SpacingTokens.xs),
+                    Text(
+                      formatCents(data.netWorth, currency),
+                      style: theme.textTheme.headlineLarge?.copyWith(
+                        color: netWorthColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: SpacingTokens.md),
+
+              // Assets vs Liabilities summary row
+              Row(
+                children: [
+                  Expanded(
+                    child: _SummaryChip(
+                      label: l10n.netWorthAssets,
+                      amount: formatCents(data.totalAssets, currency),
+                      color: ColorTokens.secondary,
+                    ),
+                  ),
+                  const SizedBox(width: SpacingTokens.sm),
+                  Expanded(
+                    child: _SummaryChip(
+                      label: l10n.netWorthLiabilities,
+                      amount: formatCents(data.totalLiabilities, currency),
+                      color: ColorTokens.error,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: SpacingTokens.lg),
+
+              // Asset accounts
+              if (data.assetAccounts.isNotEmpty) ...[
+                Text(
+                  l10n.netWorthAssets,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: SpacingTokens.sm),
+                Card(
+                  child: Column(
+                    children: [
+                      for (var i = 0; i < data.assetAccounts.length; i++) ...[
+                        _AccountTile(
+                          account: data.assetAccounts[i],
+                          currency: currency,
+                        ),
+                        if (i < data.assetAccounts.length - 1)
+                          const Divider(height: 1),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(height: SpacingTokens.md),
+              ],
+
+              // Liability accounts
+              if (data.liabilityAccounts.isNotEmpty) ...[
+                Text(
+                  l10n.netWorthLiabilities,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: SpacingTokens.sm),
+                Card(
+                  child: Column(
+                    children: [
+                      for (
+                        var i = 0;
+                        i < data.liabilityAccounts.length;
+                        i++
+                      ) ...[
+                        _AccountTile(
+                          account: data.liabilityAccounts[i],
+                          currency: currency,
+                        ),
+                        if (i < data.liabilityAccounts.length - 1)
+                          const Divider(height: 1),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(height: SpacingTokens.md),
+              ],
+
+              // Empty state
+              if (data.assetAccounts.isEmpty && data.liabilityAccounts.isEmpty)
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: SpacingTokens.xl,
+                    ),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Icons.account_balance_wallet_rounded,
+                          size: 48,
+                          color: colorScheme.outlineVariant,
+                        ),
+                        const SizedBox(height: SpacingTokens.md),
+                        Text(
+                          l10n.netWorthEmptyTitle,
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: SpacingTokens.sm),
+                        Text(
+                          l10n.netWorthEmptySubtitle,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SummaryChip extends HookWidget {
+  const _SummaryChip({
+    required this.label,
+    required this.amount,
+    required this.color,
+  });
+
+  final String label;
+  final String amount;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SpacingTokens.md,
+        vertical: SpacingTokens.sm,
+      ),
+      decoration: BoxDecoration(
+        color: color.withAlpha(15),
+        borderRadius: BorderRadius.circular(RadiusTokens.sm),
+        border: Border.all(color: color.withAlpha(40)),
+      ),
+      child: Column(
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: color.withAlpha(180),
+            ),
+          ),
+          const SizedBox(height: SpacingTokens.xs),
+          Text(
+            amount,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: color,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AccountTile extends HookWidget {
+  const _AccountTile({required this.account, required this.currency});
+
+  final Account account;
+  final CurrencyCode currency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final balanceColor = account.balanceCents >= 0
+        ? ColorTokens.secondary
+        : ColorTokens.error;
+
+    return ListTile(
+      leading: Icon(
+        _accountIcon(account.accountType),
+        color: theme.colorScheme.primary,
+      ),
+      title: Text(account.name),
+      subtitle: Text(
+        _accountTypeLabel(account.accountType),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing: Text(
+        formatCents(account.balanceCents, currency),
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: balanceColor,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  IconData _accountIcon(String type) {
+    return switch (type) {
+      'checking' => Icons.account_balance_rounded,
+      'savings' => Icons.savings_rounded,
+      'creditCard' => Icons.credit_card_rounded,
+      'cash' => Icons.money_rounded,
+      'investment' => Icons.trending_up_rounded,
+      _ => Icons.account_balance_wallet_rounded,
+    };
+  }
+
+  String _accountTypeLabel(String type) {
+    return switch (type) {
+      'checking' => 'Checking',
+      'savings' => 'Savings',
+      'creditCard' => 'Credit Card',
+      'cash' => 'Cash',
+      'investment' => 'Investment',
+      _ => 'Other',
+    };
+  }
+}

--- a/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/reports/providers/spending_report_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -25,7 +27,19 @@ class ReportsScreen extends HookConsumerWidget {
     );
 
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.reportsTitle)),
+      appBar: AppBar(
+        title: Text(l10n.reportsTitle),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.account_balance_wallet_rounded),
+            tooltip: l10n.netWorthTitle,
+            onPressed: () => context.pushNamed(
+              netWorthRoute,
+              pathParameters: {'id': budgetId},
+            ),
+          ),
+        ],
+      ),
       body: Column(
         children: [
           Padding(

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -12,6 +12,7 @@ import 'package:openbudget_app/src/features/budget/screens/create_budget_screen.
 import 'package:openbudget_app/src/features/home/screens/home_screen.dart';
 import 'package:openbudget_app/src/features/payees/screens/payee_list_screen.dart';
 import 'package:openbudget_app/src/features/recurring/screens/recurring_list_screen.dart';
+import 'package:openbudget_app/src/features/reports/screens/net_worth_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/reports_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_expense_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_income_screen.dart';
@@ -167,6 +168,14 @@ GoRouter appRouter(Ref ref) {
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return ImportTransactionsScreen(budgetId: id);
+        },
+      ),
+      GoRoute(
+        name: netWorthRoute,
+        path: netWorthPath,
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return NetWorthScreen(budgetId: id);
         },
       ),
     ],

--- a/openbudget_app/lib/src/routing/app_router.g.dart
+++ b/openbudget_app/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'8a1931be65313274a78a64d60fb971c469000cf9';
+String _$appRouterHash() => r'0f540d14d499ffcb44e520e518e154cf22d729c6';

--- a/openbudget_app/lib/src/routing/route_names.dart
+++ b/openbudget_app/lib/src/routing/route_names.dart
@@ -32,3 +32,5 @@ const splitExpenseRoute = 'splitExpense';
 const splitExpensePath = '/budgets/:id/expenses/split';
 const importTransactionsRoute = 'importTransactions';
 const importTransactionsPath = '/budgets/:id/import';
+const netWorthRoute = 'netWorth';
+const netWorthPath = '/budgets/:id/net-worth';


### PR DESCRIPTION
## Summary
- Adds a **Net Worth** screen that computes total assets, total liabilities, and net worth from all open accounts in a budget
- Credit card accounts are classified as liabilities; all other account types as assets
- Accessible from the Reports screen via a wallet icon button in the app bar
- Includes hero card with net worth amount, summary chips for assets/liabilities, and grouped account lists with type-specific icons

## Changes
- `net_worth_provider.dart` — Riverpod provider that fetches accounts and computes net worth data
- `net_worth_screen.dart` — Full UI with hero card, summary chips, asset/liability account lists, and empty state
- `route_names.dart` / `app_router.dart` — New route at `/budgets/:id/net-worth`
- `reports_screen.dart` — Added navigation button to net worth screen
- `app_en.arb` — Added 6 l10n strings for net worth feature

## Test plan
- [ ] Navigate to Reports → tap wallet icon → verify Net Worth screen loads
- [ ] Verify assets and liabilities are correctly separated
- [ ] Verify net worth = assets + liabilities
- [ ] Verify empty state when no accounts exist
- [ ] Verify correct currency formatting