### PR TITLE
feat: add spending trends screen with 6-month comparison

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -359,5 +359,13 @@
   "netWorthLiabilities": "Liabilities",
   "netWorthLoadError": "Could not load net worth data",
   "netWorthEmptyTitle": "No Accounts Yet",
-  "netWorthEmptySubtitle": "Add accounts to see your net worth breakdown"
+  "netWorthEmptySubtitle": "Add accounts to see your net worth breakdown",
+  "spendingTrendsTitle": "Spending Trends",
+  "spendingTrendsLoadError": "Could not load spending trends",
+  "spendingTrendsEmptyTitle": "No Spending Data",
+  "spendingTrendsEmptySubtitle": "Add transactions to see spending trends over time",
+  "spendingTrendsAvgIncome": "Avg. Income",
+  "spendingTrendsAvgExpenses": "Avg. Expenses",
+  "spendingTrendsMonthly": "Monthly Comparison",
+  "spendingTrendsBreakdown": "Monthly Breakdown"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1665,6 +1665,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Add accounts to see your net worth breakdown'**
   String get netWorthEmptySubtitle;
+
+  /// No description provided for @spendingTrendsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending Trends'**
+  String get spendingTrendsTitle;
+
+  /// No description provided for @spendingTrendsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load spending trends'**
+  String get spendingTrendsLoadError;
+
+  /// No description provided for @spendingTrendsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Spending Data'**
+  String get spendingTrendsEmptyTitle;
+
+  /// No description provided for @spendingTrendsEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add transactions to see spending trends over time'**
+  String get spendingTrendsEmptySubtitle;
+
+  /// No description provided for @spendingTrendsAvgIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Avg. Income'**
+  String get spendingTrendsAvgIncome;
+
+  /// No description provided for @spendingTrendsAvgExpenses.
+  ///
+  /// In en, this message translates to:
+  /// **'Avg. Expenses'**
+  String get spendingTrendsAvgExpenses;
+
+  /// No description provided for @spendingTrendsMonthly.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly Comparison'**
+  String get spendingTrendsMonthly;
+
+  /// No description provided for @spendingTrendsBreakdown.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly Breakdown'**
+  String get spendingTrendsBreakdown;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -920,4 +920,29 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get netWorthEmptySubtitle =>
       'Add accounts to see your net worth breakdown';
+
+  @override
+  String get spendingTrendsTitle => 'Spending Trends';
+
+  @override
+  String get spendingTrendsLoadError => 'Could not load spending trends';
+
+  @override
+  String get spendingTrendsEmptyTitle => 'No Spending Data';
+
+  @override
+  String get spendingTrendsEmptySubtitle =>
+      'Add transactions to see spending trends over time';
+
+  @override
+  String get spendingTrendsAvgIncome => 'Avg. Income';
+
+  @override
+  String get spendingTrendsAvgExpenses => 'Avg. Expenses';
+
+  @override
+  String get spendingTrendsMonthly => 'Monthly Comparison';
+
+  @override
+  String get spendingTrendsBreakdown => 'Monthly Breakdown';
 }

--- a/openbudget_app/lib/src/features/reports/providers/spending_trends_provider.dart
+++ b/openbudget_app/lib/src/features/reports/providers/spending_trends_provider.dart
@@ -1,0 +1,88 @@
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/reports/providers/spending_report_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'spending_trends_provider.g.dart';
+
+/// Fetches spending reports for the last [months] months.
+@riverpod
+Future<SpendingTrendsData> spendingTrends(
+  Ref ref,
+  String budgetId, {
+  int months = 6,
+}) async {
+  final now = DateTime.now();
+  final reports = <MonthlyTrend>[];
+
+  for (var i = months - 1; i >= 0; i--) {
+    var year = now.year;
+    var month = now.month - i;
+    while (month <= 0) {
+      month += 12;
+      year--;
+    }
+
+    final report = await ref.watch(
+      spendingReportProvider(budgetId, year, month).future,
+    );
+
+    reports.add(
+      MonthlyTrend(
+        year: year,
+        month: month,
+        totalIncome: report.totalIncome,
+        totalExpenses: report.totalExpenses,
+        netIncome: report.netIncome,
+        transactionCount: report.transactionCount,
+      ),
+    );
+  }
+
+  final avgIncome = reports.isEmpty
+      ? 0
+      : reports.fold<int>(0, (s, r) => s + r.totalIncome) ~/ reports.length;
+  final avgExpenses = reports.isEmpty
+      ? 0
+      : reports.fold<int>(0, (s, r) => s + r.totalExpenses) ~/ reports.length;
+
+  final summary = await ref.watch(budgetSummaryProvider(budgetId).future);
+
+  return SpendingTrendsData(
+    months: reports,
+    averageIncome: avgIncome,
+    averageExpenses: avgExpenses,
+    currencyCode: summary.budget.currencyCode,
+  );
+}
+
+class SpendingTrendsData {
+  const SpendingTrendsData({
+    required this.months,
+    required this.averageIncome,
+    required this.averageExpenses,
+    required this.currencyCode,
+  });
+
+  final List<MonthlyTrend> months;
+  final int averageIncome;
+  final int averageExpenses;
+  final String currencyCode;
+}
+
+class MonthlyTrend {
+  const MonthlyTrend({
+    required this.year,
+    required this.month,
+    required this.totalIncome,
+    required this.totalExpenses,
+    required this.netIncome,
+    required this.transactionCount,
+  });
+
+  final int year;
+  final int month;
+  final int totalIncome;
+  final int totalExpenses;
+  final int netIncome;
+  final int transactionCount;
+}

--- a/openbudget_app/lib/src/features/reports/providers/spending_trends_provider.g.dart
+++ b/openbudget_app/lib/src/features/reports/providers/spending_trends_provider.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'spending_trends_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches spending reports for the last [months] months.
+
+@ProviderFor(spendingTrends)
+final spendingTrendsProvider = SpendingTrendsFamily._();
+
+/// Fetches spending reports for the last [months] months.
+
+final class SpendingTrendsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<SpendingTrendsData>,
+          SpendingTrendsData,
+          FutureOr<SpendingTrendsData>
+        >
+    with
+        $FutureModifier<SpendingTrendsData>,
+        $FutureProvider<SpendingTrendsData> {
+  /// Fetches spending reports for the last [months] months.
+  SpendingTrendsProvider._({
+    required SpendingTrendsFamily super.from,
+    required (String, {int months}) super.argument,
+  }) : super(
+         retry: null,
+         name: r'spendingTrendsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$spendingTrendsHash();
+
+  @override
+  String toString() {
+    return r'spendingTrendsProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<SpendingTrendsData> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<SpendingTrendsData> create(Ref ref) {
+    final argument = this.argument as (String, {int months});
+    return spendingTrends(ref, argument.$1, months: argument.months);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is SpendingTrendsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$spendingTrendsHash() => r'04c4cb10da2d0885578893833f4ab897c707946b';
+
+/// Fetches spending reports for the last [months] months.
+
+final class SpendingTrendsFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<SpendingTrendsData>,
+          (String, {int months})
+        > {
+  SpendingTrendsFamily._()
+    : super(
+        retry: null,
+        name: r'spendingTrendsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches spending reports for the last [months] months.
+
+  SpendingTrendsProvider call(String budgetId, {int months = 6}) =>
+      SpendingTrendsProvider._(
+        argument: (budgetId, months: months),
+        from: this,
+      );
+
+  @override
+  String toString() => r'spendingTrendsProvider';
+}

--- a/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
@@ -38,6 +38,14 @@ class ReportsScreen extends HookConsumerWidget {
               pathParameters: {'id': budgetId},
             ),
           ),
+          IconButton(
+            icon: const Icon(Icons.trending_up_rounded),
+            tooltip: l10n.spendingTrendsTitle,
+            onPressed: () => context.pushNamed(
+              spendingTrendsRoute,
+              pathParameters: {'id': budgetId},
+            ),
+          ),
         ],
       ),
       body: Column(

--- a/openbudget_app/lib/src/features/reports/screens/spending_trends_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/spending_trends_screen.dart
@@ -1,0 +1,442 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/reports/providers/spending_trends_provider.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class SpendingTrendsScreen extends HookConsumerWidget {
+  const SpendingTrendsScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final trendsAsync = ref.watch(spendingTrendsProvider(budgetId));
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.spendingTrendsTitle)),
+      body: trendsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline_rounded,
+                size: 48,
+                color: colorScheme.error,
+              ),
+              const SizedBox(height: SpacingTokens.md),
+              Text(
+                l10n.spendingTrendsLoadError,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.error,
+                ),
+              ),
+            ],
+          ),
+        ),
+        data: (data) {
+          final currency = CurrencyCode.values.firstWhere(
+            (c) => c.code == data.currencyCode,
+            orElse: () => CurrencyCode.usd,
+          );
+
+          if (data.months.every((m) => m.transactionCount == 0)) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(SpacingTokens.xl),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.trending_up_rounded,
+                      size: 48,
+                      color: colorScheme.outlineVariant,
+                    ),
+                    const SizedBox(height: SpacingTokens.md),
+                    Text(
+                      l10n.spendingTrendsEmptyTitle,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: SpacingTokens.sm),
+                    Text(
+                      l10n.spendingTrendsEmptySubtitle,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(SpacingTokens.md),
+            children: [
+              // Averages card
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(SpacingTokens.md),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: _AverageTile(
+                          label: l10n.spendingTrendsAvgIncome,
+                          value: formatCents(data.averageIncome, currency),
+                          color: colorScheme.primary,
+                        ),
+                      ),
+                      Expanded(
+                        child: _AverageTile(
+                          label: l10n.spendingTrendsAvgExpenses,
+                          value: formatCents(data.averageExpenses, currency),
+                          color: colorScheme.error,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: SpacingTokens.lg),
+
+              // Monthly chart
+              Text(
+                l10n.spendingTrendsMonthly,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: SpacingTokens.sm),
+              _MonthlyChart(months: data.months, currency: currency),
+              const SizedBox(height: SpacingTokens.lg),
+
+              // Monthly breakdown list
+              Text(
+                l10n.spendingTrendsBreakdown,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: SpacingTokens.sm),
+              ...data.months.reversed.map(
+                (month) => _MonthSummaryTile(month: month, currency: currency),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AverageTile extends HookWidget {
+  const _AverageTile({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: SpacingTokens.xs),
+        Text(
+          value,
+          style: theme.textTheme.titleLarge?.copyWith(
+            color: color,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MonthlyChart extends HookWidget {
+  const _MonthlyChart({required this.months, required this.currency});
+
+  final List<MonthlyTrend> months;
+  final CurrencyCode currency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final maxValue = months.fold<int>(
+      0,
+      (max, m) => math.max(max, math.max(m.totalIncome, m.totalExpenses)),
+    );
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(SpacingTokens.md),
+        child: Column(
+          children: [
+            for (final month in months) ...[
+              _ChartRow(
+                label: _shortMonthName(month.month),
+                incomeValue: month.totalIncome,
+                expenseValue: month.totalExpenses,
+                maxValue: maxValue,
+                currency: currency,
+                colorScheme: colorScheme,
+              ),
+              if (month != months.last)
+                const SizedBox(height: SpacingTokens.sm),
+            ],
+            const SizedBox(height: SpacingTokens.md),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _LegendDot(
+                  color: colorScheme.primary,
+                  label: AppLocalizations.of(context).reportsIncome,
+                ),
+                const SizedBox(width: SpacingTokens.lg),
+                _LegendDot(
+                  color: colorScheme.error,
+                  label: AppLocalizations.of(context).reportsExpenses,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _shortMonthName(int month) {
+    const names = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return names[month - 1];
+  }
+}
+
+class _ChartRow extends HookWidget {
+  const _ChartRow({
+    required this.label,
+    required this.incomeValue,
+    required this.expenseValue,
+    required this.maxValue,
+    required this.currency,
+    required this.colorScheme,
+  });
+
+  final String label;
+  final int incomeValue;
+  final int expenseValue;
+  final int maxValue;
+  final CurrencyCode currency;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final incomeFraction = maxValue > 0 ? incomeValue / maxValue : 0.0;
+    final expenseFraction = maxValue > 0 ? expenseValue / maxValue : 0.0;
+
+    return Row(
+      children: [
+        SizedBox(
+          width: 36,
+          child: Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Column(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(3),
+                child: LinearProgressIndicator(
+                  value: incomeFraction,
+                  minHeight: 10,
+                  backgroundColor: colorScheme.surfaceContainerHighest,
+                  valueColor: AlwaysStoppedAnimation(colorScheme.primary),
+                ),
+              ),
+              const SizedBox(height: 2),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(3),
+                child: LinearProgressIndicator(
+                  value: expenseFraction,
+                  minHeight: 10,
+                  backgroundColor: colorScheme.surfaceContainerHighest,
+                  valueColor: AlwaysStoppedAnimation(colorScheme.error),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _LegendDot extends HookWidget {
+  const _LegendDot({required this.color, required this.label});
+
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+        const SizedBox(width: SpacingTokens.xs),
+        Text(label, style: theme.textTheme.labelSmall),
+      ],
+    );
+  }
+}
+
+class _MonthSummaryTile extends HookWidget {
+  const _MonthSummaryTile({required this.month, required this.currency});
+
+  final MonthlyTrend month;
+  final CurrencyCode currency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final netColor = month.netIncome >= 0
+        ? colorScheme.primary
+        : colorScheme.error;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: SpacingTokens.md,
+          vertical: SpacingTokens.sm,
+        ),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 60,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _monthName(month.month),
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    month.year.toString(),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(
+                        '+${formatCents(month.totalIncome, currency)}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(width: SpacingTokens.sm),
+                      Text(
+                        '-${formatCents(month.totalExpenses, currency)}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.error,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${month.netIncome >= 0 ? '+' : ''}${formatCents(month.netIncome, currency)}',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: netColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _monthName(int month) {
+    const names = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return names[month - 1];
+  }
+}

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -14,6 +14,7 @@ import 'package:openbudget_app/src/features/payees/screens/payee_list_screen.dar
 import 'package:openbudget_app/src/features/recurring/screens/recurring_list_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/net_worth_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/reports_screen.dart';
+import 'package:openbudget_app/src/features/reports/screens/spending_trends_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_expense_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_income_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/import_transactions_screen.dart';
@@ -176,6 +177,14 @@ GoRouter appRouter(Ref ref) {
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return NetWorthScreen(budgetId: id);
+        },
+      ),
+      GoRoute(
+        name: spendingTrendsRoute,
+        path: spendingTrendsPath,
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return SpendingTrendsScreen(budgetId: id);
         },
       ),
     ],

--- a/openbudget_app/lib/src/routing/app_router.g.dart
+++ b/openbudget_app/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'0f540d14d499ffcb44e520e518e154cf22d729c6';
+String _$appRouterHash() => r'85f237f2b1119a3257a6193d9c81ea5c47cc468f';

--- a/openbudget_app/lib/src/routing/route_names.dart
+++ b/openbudget_app/lib/src/routing/route_names.dart
@@ -34,3 +34,5 @@ const importTransactionsRoute = 'importTransactions';
 const importTransactionsPath = '/budgets/:id/import';
 const netWorthRoute = 'netWorth';
 const netWorthPath = '/budgets/:id/net-worth';
+const spendingTrendsRoute = 'spendingTrends';
+const spendingTrendsPath = '/budgets/:id/reports/trends';


### PR DESCRIPTION
## Summary
- Adds a **Spending Trends** screen showing income vs expenses over the last 6 months
- Features a bar chart comparing monthly income and expenses side-by-side
- Shows average income and average expenses across the period
- Includes a monthly breakdown list with net income for each month
- Accessible from the Reports screen via the trends icon in the app bar

## Changes
- `spending_trends_provider.dart` — Riverpod provider that aggregates 6 months of spending data
- `spending_trends_screen.dart` — Full UI with bar chart, averages card, and monthly summary tiles
- `route_names.dart` / `app_router.dart` — New route at `/budgets/:id/reports/trends`
- `reports_screen.dart` — Added navigation button to spending trends screen
- `app_en.arb` — Added 8 l10n strings for spending trends

## Test plan
- [ ] Navigate to Reports → tap trends icon → verify Spending Trends screen loads
- [ ] Verify 6 months of data are displayed in the chart
- [ ] Verify income bars (blue) and expense bars (red) render correctly
- [ ] Verify averages match the displayed month data
- [ ] Verify empty state when no transactions exist