### PR TITLE
feat: add clearing status toggle to transaction list

### DIFF
--- a/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
@@ -111,6 +111,29 @@ class TransactionActions extends _$TransactionActions {
     }
   }
 
+  Future<Transaction> toggleCleared({
+    required String transactionId,
+    required String budgetId,
+  }) async {
+    final client = ref.read(serverpodClientProvider);
+    try {
+      final transaction = await client.transaction.toggleCleared(
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(transactionId),
+      );
+      if (ref.mounted) {
+        ref.invalidate(transactionListProvider(budgetId));
+      }
+      return transaction;
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+
   Future<Transaction> addExpense({
     required String description,
     required int amountCents,

--- a/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.g.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.g.dart
@@ -42,7 +42,7 @@ final class TransactionActionsProvider
 }
 
 String _$transactionActionsHash() =>
-    r'c91633922a47ece5e9e702d52371dbae44ae0563';
+    r'bc813ad8cedcf9bbc9ef06088bf0cd27dedde721';
 
 abstract class _$TransactionActions extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
@@ -287,6 +287,22 @@ class _TransactionTile extends HookConsumerWidget {
         ? Icons.arrow_downward_rounded
         : Icons.arrow_upward_rounded;
 
+    final statusIcon = transaction.reconciled
+        ? Icons.lock_outline_rounded
+        : transaction.cleared
+        ? Icons.check_circle_outline
+        : Icons.circle_outlined;
+    final statusColor = transaction.reconciled
+        ? colorScheme.primary
+        : transaction.cleared
+        ? ColorTokens.secondary
+        : colorScheme.outline;
+    final statusTooltip = transaction.reconciled
+        ? l10n.transactionReconciled
+        : transaction.cleared
+        ? l10n.transactionCleared
+        : l10n.transactionUncleared;
+
     return Dismissible(
       key: ValueKey(transaction.id),
       direction: DismissDirection.endToStart,
@@ -306,9 +322,28 @@ class _TransactionTile extends HookConsumerWidget {
         margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
         child: ListTile(
           onTap: () => _showEditDialog(context),
-          leading: CircleAvatar(
-            backgroundColor: color.withAlpha(25),
-            child: Icon(icon, color: color, size: 20),
+          leading: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Tooltip(
+                message: statusTooltip,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(RadiusTokens.xl),
+                  onTap: transaction.reconciled
+                      ? null
+                      : () => _toggleCleared(context, ref, l10n),
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Icon(statusIcon, size: 20, color: statusColor),
+                  ),
+                ),
+              ),
+              const SizedBox(width: SpacingTokens.xs),
+              CircleAvatar(
+                backgroundColor: color.withAlpha(25),
+                child: Icon(icon, color: color, size: 20),
+              ),
+            ],
           ),
           title: Row(
             children: [
@@ -357,6 +392,27 @@ class _TransactionTile extends HookConsumerWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _toggleCleared(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l10n,
+  ) async {
+    try {
+      await ref
+          .read(transactionActionsProvider.notifier)
+          .toggleCleared(
+            transactionId: transaction.id?.toString() ?? '',
+            budgetId: budgetId,
+          );
+    } on Exception catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l10n.transactionEditError)));
+      }
+    }
   }
 
   Future<bool?> _confirmDelete(


### PR DESCRIPTION
## Summary
- Adds cleared/uncleared/reconciled status indicators (circle, checkmark, lock icons) to each transaction tile in the global transaction list
- Users can tap the status icon to toggle between uncleared and cleared states
- Reconciled transactions show a lock icon and cannot be toggled
- Adds `toggleCleared` method to `TransactionActions` provider, calling the existing backend endpoint
- Consistent with the existing clearing UI in the account detail screen

## Test plan
- [ ] Open transaction list — verify each transaction shows a clearing status icon (empty circle for uncleared)
- [ ] Tap the status icon — verify it toggles to cleared (checkmark)
- [ ] Tap again — verify it toggles back to uncleared
- [ ] Verify reconciled transactions show lock icon and cannot be toggled
- [ ] Verify tooltip shows correct status label on long press