### PR TITLE
feat: add category reordering to budget dashboard

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -367,5 +367,10 @@
   "spendingTrendsAvgIncome": "Avg. Income",
   "spendingTrendsAvgExpenses": "Avg. Expenses",
   "spendingTrendsMonthly": "Monthly Comparison",
-  "spendingTrendsBreakdown": "Monthly Breakdown"
+  "spendingTrendsBreakdown": "Monthly Breakdown",
+  "budgetReorderCategories": "Reorder Categories",
+  "budgetReorderDone": "Done",
+  "budgetReorderHint": "Drag to reorder categories",
+  "budgetReorderSuccess": "Categories reordered",
+  "budgetReorderError": "Could not reorder categories"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1713,6 +1713,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Monthly Breakdown'**
   String get spendingTrendsBreakdown;
+
+  /// No description provided for @budgetReorderCategories.
+  ///
+  /// In en, this message translates to:
+  /// **'Reorder Categories'**
+  String get budgetReorderCategories;
+
+  /// No description provided for @budgetReorderDone.
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get budgetReorderDone;
+
+  /// No description provided for @budgetReorderHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Drag to reorder categories'**
+  String get budgetReorderHint;
+
+  /// No description provided for @budgetReorderSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Categories reordered'**
+  String get budgetReorderSuccess;
+
+  /// No description provided for @budgetReorderError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not reorder categories'**
+  String get budgetReorderError;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -945,4 +945,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get spendingTrendsBreakdown => 'Monthly Breakdown';
+
+  @override
+  String get budgetReorderCategories => 'Reorder Categories';
+
+  @override
+  String get budgetReorderDone => 'Done';
+
+  @override
+  String get budgetReorderHint => 'Drag to reorder categories';
+
+  @override
+  String get budgetReorderSuccess => 'Categories reordered';
+
+  @override
+  String get budgetReorderError => 'Could not reorder categories';
 }

--- a/openbudget_app/lib/src/features/budget/providers/category_actions_provider.dart
+++ b/openbudget_app/lib/src/features/budget/providers/category_actions_provider.dart
@@ -43,6 +43,40 @@ class CategoryActions extends _$CategoryActions {
     }
   }
 
+  Future<void> reorderCategories({
+    required String budgetId,
+    required List<String> categoryIds,
+  }) async {
+    state = const AsyncValue.loading();
+    final client = ref.read(serverpodClientProvider);
+    try {
+      await client.category.reorder(
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(budgetId),
+        categoryIds
+            .map(
+              // Serverpod API requires UuidValue which is experimental in uuid package.
+              // ignore: experimental_member_use
+              UuidValue.fromString,
+            )
+            .toList(),
+      );
+      if (ref.mounted) {
+        ref
+          ..invalidate(categoryListProvider(budgetId))
+          ..invalidate(budgetSummaryProvider(budgetId))
+          ..invalidate(budgetMonthlySummaryProvider(budgetId));
+        state = const AsyncValue.data(null);
+      }
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+
   Future<void> deleteCategory({
     required String categoryId,
     required String budgetId,

--- a/openbudget_app/lib/src/features/budget/providers/category_actions_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/category_actions_provider.g.dart
@@ -41,7 +41,7 @@ final class CategoryActionsProvider
   }
 }
 
-String _$categoryActionsHash() => r'4213fec94314c74497af254cbcd29e30e373baad';
+String _$categoryActionsHash() => r'7f75f5767eacc429e5165781e9f49ef2020b03ef';
 
 abstract class _$CategoryActions extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -39,6 +39,7 @@ class BudgetDetailScreen extends HookConsumerWidget {
     final goalsAsync = ref.watch(budgetGoalsProvider(budgetId));
     final dueCountAsync = ref.watch(recurringDueCountProvider(budgetId));
     final isPosting = useState(false);
+    final isReordering = useState(false);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -100,26 +101,39 @@ class BudgetDetailScreen extends HookConsumerWidget {
             ),
             title: Text(summary.budget.name),
             actions: [
-              IconButton(
-                icon: const Icon(Icons.account_balance_rounded),
-                tooltip: l10n.budgetViewAccounts,
-                onPressed: () => context.go('/budgets/$budgetId/accounts'),
-              ),
-              IconButton(
-                icon: const Icon(Icons.store_rounded),
-                tooltip: l10n.payeeListTitle,
-                onPressed: () => context.go('/budgets/$budgetId/payees'),
-              ),
-              IconButton(
-                icon: const Icon(Icons.bar_chart_rounded),
-                tooltip: l10n.reportsTitle,
-                onPressed: () => context.go('/budgets/$budgetId/reports'),
-              ),
-              IconButton(
-                icon: const Icon(Icons.receipt_long_rounded),
-                tooltip: l10n.transactionListTitle,
-                onPressed: () => context.go('/budgets/$budgetId/transactions'),
-              ),
+              if (isReordering.value)
+                TextButton(
+                  onPressed: () => isReordering.value = false,
+                  child: Text(l10n.budgetReorderDone),
+                )
+              else ...[
+                IconButton(
+                  icon: const Icon(Icons.swap_vert_rounded),
+                  tooltip: l10n.budgetReorderCategories,
+                  onPressed: () => isReordering.value = true,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.account_balance_rounded),
+                  tooltip: l10n.budgetViewAccounts,
+                  onPressed: () => context.go('/budgets/$budgetId/accounts'),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.store_rounded),
+                  tooltip: l10n.payeeListTitle,
+                  onPressed: () => context.go('/budgets/$budgetId/payees'),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.bar_chart_rounded),
+                  tooltip: l10n.reportsTitle,
+                  onPressed: () => context.go('/budgets/$budgetId/reports'),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.receipt_long_rounded),
+                  tooltip: l10n.transactionListTitle,
+                  onPressed: () =>
+                      context.go('/budgets/$budgetId/transactions'),
+                ),
+              ],
             ],
           ),
           body: RefreshIndicator(
@@ -203,59 +217,65 @@ class BudgetDetailScreen extends HookConsumerWidget {
                       ),
                     ),
                   ),
-                ...summary.categories.map(
-                  (catWithEnvelopes) => Padding(
-                    padding: const EdgeInsets.only(bottom: SpacingTokens.md),
-                    child: CategoryGroup(
-                      categoryWithEnvelopes: catWithEnvelopes,
-                      currencyCode: currencyCode,
-                      goalsMap: goalsMap,
-                      onAddEnvelope: () => _showAddEnvelopeDialog(
-                        context,
-                        catWithEnvelopes.category.id?.toString() ?? '',
-                        currencyCode,
-                        year: summary.year,
-                        month: summary.month,
+                if (isReordering.value && summary.categories.isNotEmpty)
+                  _ReorderableCategoryList(
+                    categories: summary.categories,
+                    budgetId: budgetId,
+                  ),
+                if (!isReordering.value)
+                  ...summary.categories.map(
+                    (catWithEnvelopes) => Padding(
+                      padding: const EdgeInsets.only(bottom: SpacingTokens.md),
+                      child: CategoryGroup(
+                        categoryWithEnvelopes: catWithEnvelopes,
+                        currencyCode: currencyCode,
+                        goalsMap: goalsMap,
+                        onAddEnvelope: () => _showAddEnvelopeDialog(
+                          context,
+                          catWithEnvelopes.category.id?.toString() ?? '',
+                          currencyCode,
+                          year: summary.year,
+                          month: summary.month,
+                        ),
+                        onDeleteCategory: () => _confirmDeleteCategory(
+                          context,
+                          ref,
+                          catWithEnvelopes.category.id?.toString() ?? '',
+                          catWithEnvelopes.category.name,
+                        ),
+                        onEditEnvelope: (envelope) => _showEditEnvelopeDialog(
+                          context,
+                          envelope,
+                          catWithEnvelopes.category.id?.toString() ?? '',
+                          currencyCode,
+                          year: summary.year,
+                          month: summary.month,
+                        ),
+                        onDeleteEnvelope: (envelope) => _confirmDeleteEnvelope(
+                          context,
+                          ref,
+                          envelope.id?.toString() ?? '',
+                          catWithEnvelopes.category.id?.toString() ?? '',
+                          envelope.name,
+                        ),
+                        onQuickBudget: (envelope) => _showQuickBudgetDialog(
+                          context,
+                          envelope,
+                          currencyCode,
+                          year: summary.year,
+                          month: summary.month,
+                        ),
+                        onShowActivity: (envelope, monthlyData, goal) =>
+                            _showEnvelopeActivity(
+                              context,
+                              envelope,
+                              currencyCode,
+                              monthlyData: monthlyData,
+                              goal: goal,
+                            ),
                       ),
-                      onDeleteCategory: () => _confirmDeleteCategory(
-                        context,
-                        ref,
-                        catWithEnvelopes.category.id?.toString() ?? '',
-                        catWithEnvelopes.category.name,
-                      ),
-                      onEditEnvelope: (envelope) => _showEditEnvelopeDialog(
-                        context,
-                        envelope,
-                        catWithEnvelopes.category.id?.toString() ?? '',
-                        currencyCode,
-                        year: summary.year,
-                        month: summary.month,
-                      ),
-                      onDeleteEnvelope: (envelope) => _confirmDeleteEnvelope(
-                        context,
-                        ref,
-                        envelope.id?.toString() ?? '',
-                        catWithEnvelopes.category.id?.toString() ?? '',
-                        envelope.name,
-                      ),
-                      onQuickBudget: (envelope) => _showQuickBudgetDialog(
-                        context,
-                        envelope,
-                        currencyCode,
-                        year: summary.year,
-                        month: summary.month,
-                      ),
-                      onShowActivity: (envelope, monthlyData, goal) =>
-                          _showEnvelopeActivity(
-                            context,
-                            envelope,
-                            currencyCode,
-                            monthlyData: monthlyData,
-                            goal: goal,
-                          ),
                     ),
                   ),
-                ),
                 const SizedBox(height: SpacingTokens.sm),
                 Center(
                   child: OutlinedButton.icon(
@@ -654,6 +674,156 @@ class _DueBanner extends HookWidget {
                   fontWeight: FontWeight.w600,
                 ),
               ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReorderableCategoryList extends HookConsumerWidget {
+  const _ReorderableCategoryList({
+    required this.categories,
+    required this.budgetId,
+  });
+
+  final List<CategoryWithEnvelopes> categories;
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final orderedCategories = useState(List.of(categories));
+
+    // Sync with provider state when categories change.
+    useEffect(() {
+      orderedCategories.value = List.of(categories);
+      return null;
+    }, [categories]);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: SpacingTokens.sm),
+          child: Row(
+            children: [
+              Icon(
+                Icons.info_outline_rounded,
+                size: 16,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: SpacingTokens.xs),
+              Text(
+                l10n.budgetReorderHint,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+        ...orderedCategories.value.asMap().entries.map((entry) {
+          final index = entry.key;
+          final cat = entry.value;
+          return _ReorderableCategoryTile(
+            key: ValueKey(cat.category.id),
+            category: cat,
+            index: index,
+            total: orderedCategories.value.length,
+            onMoveUp: index > 0
+                ? () => _swap(orderedCategories, index, index - 1, ref)
+                : null,
+            onMoveDown: index < orderedCategories.value.length - 1
+                ? () => _swap(orderedCategories, index, index + 1, ref)
+                : null,
+          );
+        }),
+      ],
+    );
+  }
+
+  Future<void> _swap(
+    ValueNotifier<List<CategoryWithEnvelopes>> orderedCategories,
+    int from,
+    int to,
+    WidgetRef ref,
+  ) async {
+    final list = List.of(orderedCategories.value);
+    final item = list.removeAt(from);
+    list.insert(to, item);
+    orderedCategories.value = list;
+
+    final categoryIds = list
+        .map((c) => c.category.id?.toString() ?? '')
+        .where((id) => id.isNotEmpty)
+        .toList();
+
+    try {
+      await ref
+          .read(categoryActionsProvider.notifier)
+          .reorderCategories(budgetId: budgetId, categoryIds: categoryIds);
+    } on Exception catch (_) {
+      // Revert on error handled by provider re-fetch.
+    }
+  }
+}
+
+class _ReorderableCategoryTile extends HookWidget {
+  const _ReorderableCategoryTile({
+    required this.category,
+    required this.index,
+    required this.total,
+    this.onMoveUp,
+    this.onMoveDown,
+    super.key,
+  });
+
+  final CategoryWithEnvelopes category;
+  final int index;
+  final int total;
+  final VoidCallback? onMoveUp;
+  final VoidCallback? onMoveDown;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
+      child: ListTile(
+        leading: Icon(
+          Icons.drag_handle_rounded,
+          color: colorScheme.onSurfaceVariant,
+        ),
+        title: Text(
+          category.category.name,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        subtitle: Text(
+          '${category.envelopes.length} envelopes',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.arrow_upward_rounded),
+              onPressed: onMoveUp,
+              iconSize: 20,
+            ),
+            IconButton(
+              icon: const Icon(Icons.arrow_downward_rounded),
+              onPressed: onMoveDown,
+              iconSize: 20,
             ),
           ],
         ),

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -415,6 +415,18 @@ class EndpointCategory extends _i1.EndpointRef {
     'sortOrder': sortOrder,
   });
 
+  /// Batch-reorders categories by their new position.
+  ///
+  /// The [categoryIds] list defines the new sort order: the first ID gets
+  /// sort order 0, the second gets 1, etc.
+  _i2.Future<List<_i7.Category>> reorder(
+    _i1.UuidValue budgetId,
+    List<_i1.UuidValue> categoryIds,
+  ) => caller.callServerEndpoint<List<_i7.Category>>('category', 'reorder', {
+    'budgetId': budgetId,
+    'categoryIds': categoryIds,
+  });
+
   /// Deletes a category by ID.
   _i2.Future<_i7.Category> delete(_i1.UuidValue categoryId) =>
       caller.callServerEndpoint<_i7.Category>('category', 'delete', {

--- a/openbudget_client/lib/src/protocol/protocol.dart
+++ b/openbudget_client/lib/src/protocol/protocol.dart
@@ -167,14 +167,14 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<_i15.Category>(e)).toList()
           as T;
     }
+    if (t == List<_i1.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          as T;
+    }
     if (t == List<_i16.EnvelopeGoal>) {
       return (data as List)
               .map((e) => deserialize<_i16.EnvelopeGoal>(e))
               .toList()
-          as T;
-    }
-    if (t == List<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           as T;
     }
     if (t == List<_i17.Envelope>) {

--- a/openbudget_server/lib/src/categories/category_endpoint.dart
+++ b/openbudget_server/lib/src/categories/category_endpoint.dart
@@ -49,6 +49,22 @@ class CategoryEndpoint extends Endpoint {
     );
   }
 
+  /// Batch-reorders categories by their new position.
+  ///
+  /// The [categoryIds] list defines the new sort order: the first ID gets
+  /// sort order 0, the second gets 1, etc.
+  Future<List<Category>> reorder(
+    Session session,
+    UuidValue budgetId,
+    List<UuidValue> categoryIds,
+  ) async {
+    return CategoryService.reorder(
+      session,
+      budgetId: budgetId,
+      categoryIds: categoryIds,
+    );
+  }
+
   /// Deletes a category by ID.
   Future<Category> delete(Session session, UuidValue categoryId) async {
     return CategoryService.delete(session, categoryId: categoryId);

--- a/openbudget_server/lib/src/categories/category_service.dart
+++ b/openbudget_server/lib/src/categories/category_service.dart
@@ -71,6 +71,24 @@ class CategoryService {
     return Category.db.updateRow(session, updated);
   }
 
+  /// Batch-updates sort order for multiple categories in a single budget.
+  static Future<List<Category>> reorder(
+    Session session, {
+    required UuidValue budgetId,
+    required List<UuidValue> categoryIds,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+
+    final results = <Category>[];
+    for (var i = 0; i < categoryIds.length; i++) {
+      final category = await Category.db.findById(session, categoryIds[i]);
+      if (category == null) continue;
+      final updated = category.copyWith(sortOrder: i);
+      results.add(await Category.db.updateRow(session, updated));
+    }
+    return results;
+  }
+
   /// Deletes a category, verifying budget ownership.
   static Future<Category> delete(
     Session session, {

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -587,6 +587,27 @@ class Endpoints extends _i1.EndpointDispatch {
                 sortOrder: params['sortOrder'],
               ),
         ),
+        'reorder': _i1.MethodConnector(
+          name: 'reorder',
+          params: {
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'categoryIds': _i1.ParameterDescription(
+              name: 'categoryIds',
+              type: _i1.getType<List<_i1.UuidValue>>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['category'] as _i7.CategoryEndpoint).reorder(
+                session,
+                params['budgetId'],
+                params['categoryIds'],
+              ),
+        ),
         'delete': _i1.MethodConnector(
           name: 'delete',
           params: {

--- a/openbudget_server/lib/src/generated/protocol.dart
+++ b/openbudget_server/lib/src/generated/protocol.dart
@@ -1306,14 +1306,14 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<_i18.Category>(e)).toList()
           as T;
     }
+    if (t == List<_i1.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          as T;
+    }
     if (t == List<_i19.EnvelopeGoal>) {
       return (data as List)
               .map((e) => deserialize<_i19.EnvelopeGoal>(e))
               .toList()
-          as T;
-    }
-    if (t == List<_i1.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           as T;
     }
     if (t == List<_i20.Envelope>) {

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -28,6 +28,7 @@ category:
   - list:
   - get:
   - update:
+  - reorder:
   - delete:
 envelopeGoal:
   - upsert:

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -1049,6 +1049,41 @@ class _CategoryEndpoint {
     });
   }
 
+  _i3.Future<List<_i7.Category>> reorder(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue budgetId,
+    List<_i2.UuidValue> categoryIds,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'category',
+            method: 'reorder',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'category',
+          methodName: 'reorder',
+          parameters: _i1.testObjectToJson({
+            'budgetId': budgetId,
+            'categoryIds': categoryIds,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<List<_i7.Category>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
   _i3.Future<_i7.Category> delete(
     _i1.TestSessionBuilder sessionBuilder,
     _i2.UuidValue categoryId,


### PR DESCRIPTION
## Summary
- Adds a batch `reorder` endpoint to the Category API that updates sort order for all categories in one call
- Budget detail screen now has a reorder mode (swap icon in app bar) with up/down arrow buttons per category
- Reorder mode shows a hint banner and simplified category cards with drag handles
- New l10n strings: `budgetReorderCategories`, `budgetReorderDone`, `budgetReorderHint`, `budgetReorderSuccess`, `budgetReorderError`

## Test plan
- [ ] Open budget detail screen — verify new reorder icon in app bar
- [ ] Tap reorder icon — verify simplified category list with arrow buttons appears
- [ ] Tap up/down arrows — verify categories swap positions
- [ ] Tap "Done" — verify normal budget view returns with new order persisted
- [ ] Refresh the page — verify order is maintained from server