### PR TITLE
feat: add account editing, closing, and reopening

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -374,5 +374,13 @@
   "budgetReorderSuccess": "Categories reordered",
   "budgetReorderError": "Could not reorder categories",
   "transactionMemoLabel": "Memo",
-  "transactionMemoHint": "Add a note (optional)"
+  "transactionMemoHint": "Add a note (optional)",
+  "accountEditTitle": "Edit Account",
+  "accountEditSuccess": "Account updated",
+  "accountEditError": "Could not update account. Please try again.",
+  "accountCloseButton": "Close Account",
+  "accountCloseConfirm": "Close this account? It will be moved to Closed Accounts.",
+  "accountCloseSuccess": "Account closed",
+  "accountReopenButton": "Reopen Account",
+  "accountReopenSuccess": "Account reopened"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1755,6 +1755,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Add a note (optional)'**
   String get transactionMemoHint;
+
+  /// No description provided for @accountEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Account'**
+  String get accountEditTitle;
+
+  /// No description provided for @accountEditSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Account updated'**
+  String get accountEditSuccess;
+
+  /// No description provided for @accountEditError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update account. Please try again.'**
+  String get accountEditError;
+
+  /// No description provided for @accountCloseButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Close Account'**
+  String get accountCloseButton;
+
+  /// No description provided for @accountCloseConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Close this account? It will be moved to Closed Accounts.'**
+  String get accountCloseConfirm;
+
+  /// No description provided for @accountCloseSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Account closed'**
+  String get accountCloseSuccess;
+
+  /// No description provided for @accountReopenButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Reopen Account'**
+  String get accountReopenButton;
+
+  /// No description provided for @accountReopenSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Account reopened'**
+  String get accountReopenSuccess;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -966,4 +966,29 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get transactionMemoHint => 'Add a note (optional)';
+
+  @override
+  String get accountEditTitle => 'Edit Account';
+
+  @override
+  String get accountEditSuccess => 'Account updated';
+
+  @override
+  String get accountEditError => 'Could not update account. Please try again.';
+
+  @override
+  String get accountCloseButton => 'Close Account';
+
+  @override
+  String get accountCloseConfirm =>
+      'Close this account? It will be moved to Closed Accounts.';
+
+  @override
+  String get accountCloseSuccess => 'Account closed';
+
+  @override
+  String get accountReopenButton => 'Reopen Account';
+
+  @override
+  String get accountReopenSuccess => 'Account reopened';
 }

--- a/openbudget_app/lib/src/features/accounts/screens/account_list_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/account_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
+import 'package:openbudget_app/src/features/accounts/screens/edit_account_dialog.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
@@ -241,25 +242,51 @@ class _AccountTile extends HookWidget {
       margin: const EdgeInsets.only(bottom: SpacingTokens.xs),
       child: ListTile(
         onTap: () => context.go('/budgets/$budgetId/accounts/${account.id}'),
+        onLongPress: () => showDialog<void>(
+          context: context,
+          builder: (_) =>
+              EditAccountDialog(account: account, budgetId: budgetId),
+        ),
         leading: CircleAvatar(
           backgroundColor: colorScheme.secondaryContainer,
           child: Icon(icon, color: colorScheme.onSecondaryContainer, size: 20),
         ),
-        title: Text(account.name, style: theme.textTheme.titleMedium),
+        title: Row(
+          children: [
+            Flexible(
+              child: Text(account.name, style: theme.textTheme.titleMedium),
+            ),
+            if (account.isClosed) ...[
+              const SizedBox(width: SpacingTokens.xs),
+              Icon(
+                Icons.lock_outline_rounded,
+                size: 16,
+                color: colorScheme.outline,
+              ),
+            ],
+          ],
+        ),
         subtitle: Text(
           _labelForType(account.accountType),
           style: theme.textTheme.bodySmall?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),
         ),
-        trailing: Text(
-          formatCents(account.balanceCents, currency),
-          style: theme.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.w600,
-            color: account.balanceCents >= 0
-                ? colorScheme.primary
-                : colorScheme.error,
-          ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              formatCents(account.balanceCents, currency),
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: account.balanceCents >= 0
+                    ? colorScheme.primary
+                    : colorScheme.error,
+              ),
+            ),
+            const SizedBox(width: SpacingTokens.xs),
+            Icon(Icons.edit_outlined, size: 16, color: colorScheme.outline),
+          ],
         ),
       ),
     );

--- a/openbudget_app/lib/src/features/accounts/screens/edit_account_dialog.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/edit_account_dialog.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/accounts/providers/account_actions_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class EditAccountDialog extends HookConsumerWidget {
+  const EditAccountDialog({
+    required this.account,
+    required this.budgetId,
+    super.key,
+  });
+
+  final Account account;
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final nameController = useTextEditingController(text: account.name);
+    final onBudget = useState(account.onBudget);
+    final isSubmitting = useState(false);
+
+    final accountTypes = [
+      'checking',
+      'savings',
+      'creditCard',
+      'cash',
+      'investment',
+      'other',
+    ];
+    final selectedType = useState(account.accountType);
+
+    String typeLabel(String type) => switch (type) {
+      'checking' => l10n.accountTypeChecking,
+      'savings' => l10n.accountTypeSavings,
+      'creditCard' => l10n.accountTypeCreditCard,
+      'cash' => l10n.accountTypeCash,
+      'investment' => l10n.accountTypeInvestment,
+      _ => l10n.accountTypeOther,
+    };
+
+    return AlertDialog(
+      title: Text(l10n.accountEditTitle),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: InputDecoration(
+                labelText: l10n.accountNameLabel,
+                prefixIcon: const Icon(Icons.label_outlined),
+              ),
+              textInputAction: TextInputAction.done,
+            ),
+            const SizedBox(height: SpacingTokens.md),
+            DropdownButtonFormField<String>(
+              initialValue: selectedType.value,
+              items: accountTypes
+                  .map(
+                    (type) => DropdownMenuItem(
+                      value: type,
+                      child: Text(typeLabel(type)),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) {
+                if (value != null) selectedType.value = value;
+              },
+              decoration: InputDecoration(
+                labelText: l10n.accountTypeLabel,
+                prefixIcon: const Icon(Icons.account_balance_rounded),
+              ),
+            ),
+            const SizedBox(height: SpacingTokens.md),
+            SwitchListTile(
+              value: onBudget.value,
+              onChanged: (value) => onBudget.value = value,
+              title: Text(l10n.accountOnBudgetLabel),
+              subtitle: Text(l10n.accountOnBudgetHint),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.dialogCancel),
+        ),
+        if (!account.isClosed)
+          TextButton(
+            onPressed: isSubmitting.value
+                ? null
+                : () => _closeAccount(context, ref),
+            style: TextButton.styleFrom(foregroundColor: colorScheme.error),
+            child: Text(l10n.accountCloseButton),
+          ),
+        if (account.isClosed)
+          TextButton(
+            onPressed: isSubmitting.value
+                ? null
+                : () => _reopenAccount(context, ref),
+            child: Text(l10n.accountReopenButton),
+          ),
+        FilledButton(
+          onPressed: isSubmitting.value
+              ? null
+              : () async {
+                  final name = nameController.text.trim();
+                  if (name.isEmpty) return;
+
+                  isSubmitting.value = true;
+                  final navigator = Navigator.of(context);
+                  final messenger = ScaffoldMessenger.of(context);
+                  try {
+                    await ref
+                        .read(accountActionsProvider.notifier)
+                        .updateAccount(
+                          accountId: account.id?.toString() ?? '',
+                          budgetId: budgetId,
+                          name: name,
+                          accountType: selectedType.value,
+                          onBudget: onBudget.value,
+                        );
+                    messenger.showSnackBar(
+                      SnackBar(content: Text(l10n.accountEditSuccess)),
+                    );
+                    navigator.pop();
+                  } on Exception catch (_) {
+                    isSubmitting.value = false;
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: Text(l10n.accountEditError),
+                        backgroundColor: colorScheme.error,
+                      ),
+                    );
+                  }
+                },
+          child: isSubmitting.value
+              ? const SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(l10n.dialogSave),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _closeAccount(BuildContext context, WidgetRef ref) async {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.accountCloseButton),
+        content: Text(l10n.accountCloseConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
+            child: Text(l10n.accountCloseButton),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(accountActionsProvider.notifier)
+          .updateAccount(
+            accountId: account.id?.toString() ?? '',
+            budgetId: budgetId,
+            isClosed: true,
+          );
+      messenger.showSnackBar(SnackBar(content: Text(l10n.accountCloseSuccess)));
+      navigator.pop();
+    } on Exception catch (_) {
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.accountEditError),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _reopenAccount(BuildContext context, WidgetRef ref) async {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(accountActionsProvider.notifier)
+          .updateAccount(
+            accountId: account.id?.toString() ?? '',
+            budgetId: budgetId,
+            isClosed: false,
+          );
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.accountReopenSuccess)),
+      );
+      navigator.pop();
+    } on Exception catch (_) {
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.accountEditError),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an `EditAccountDialog` accessible via long-press on any account tile in the account list
- Users can rename accounts, change account type, and toggle on-budget status
- Close account action with confirmation dialog moves accounts to "Closed Accounts" section
- Reopen action for closed accounts restores them to their original group
- Closed accounts show a lock icon next to their name
- Edit pencil icon added to account tile trailing for discoverability
- 8 new l10n strings for account edit/close/reopen actions

## Test plan
- [ ] Long-press an account tile — verify edit dialog appears
- [ ] Change account name and save — verify name updates in list
- [ ] Change account type — verify type label updates
- [ ] Toggle on-budget switch — verify account moves between sections
- [ ] Close an account — verify it moves to Closed Accounts section with lock icon
- [ ] Long-press a closed account — verify reopen button appears
- [ ] Reopen a closed account — verify it returns to its original section