### PR TITLE
feat: add budget delete with confirmation dialog

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -385,5 +385,17 @@
   "accountCloseConfirm": "Close this account? It will be moved to Closed Accounts.",
   "accountCloseSuccess": "Account closed",
   "accountReopenButton": "Reopen Account",
-  "accountReopenSuccess": "Account reopened"
+  "accountReopenSuccess": "Account reopened",
+  "budgetDeleteTitle": "Delete Budget",
+  "budgetDeleteConfirm": "Delete \"{name}\"? This will permanently remove the budget and all its data.",
+  "@budgetDeleteConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "budgetDeleteButton": "Delete",
+  "budgetDeleteSuccess": "Budget deleted",
+  "budgetDeleteError": "Could not delete budget. Please try again."
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1821,6 +1821,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Account reopened'**
   String get accountReopenSuccess;
+
+  /// No description provided for @budgetDeleteTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Budget'**
+  String get budgetDeleteTitle;
+
+  /// No description provided for @budgetDeleteConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete \"{name}\"? This will permanently remove the budget and all its data.'**
+  String budgetDeleteConfirm(String name);
+
+  /// No description provided for @budgetDeleteButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get budgetDeleteButton;
+
+  /// No description provided for @budgetDeleteSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget deleted'**
+  String get budgetDeleteSuccess;
+
+  /// No description provided for @budgetDeleteError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not delete budget. Please try again.'**
+  String get budgetDeleteError;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -1001,4 +1001,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get accountReopenSuccess => 'Account reopened';
+
+  @override
+  String get budgetDeleteTitle => 'Delete Budget';
+
+  @override
+  String budgetDeleteConfirm(String name) {
+    return 'Delete \"$name\"? This will permanently remove the budget and all its data.';
+  }
+
+  @override
+  String get budgetDeleteButton => 'Delete';
+
+  @override
+  String get budgetDeleteSuccess => 'Budget deleted';
+
+  @override
+  String get budgetDeleteError => 'Could not delete budget. Please try again.';
 }

--- a/openbudget_app/lib/src/features/home/providers/budget_actions_provider.dart
+++ b/openbudget_app/lib/src/features/home/providers/budget_actions_provider.dart
@@ -1,0 +1,33 @@
+import 'package:openbudget_app/src/features/home/providers/budget_list_provider.dart';
+import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'budget_actions_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class BudgetActions extends _$BudgetActions {
+  @override
+  AsyncValue<void> build() {
+    return const AsyncValue.data(null);
+  }
+
+  Future<void> deleteBudget({required String budgetId}) async {
+    state = const AsyncValue.loading();
+    final client = ref.read(serverpodClientProvider);
+    try {
+      // Serverpod API requires UuidValue which is experimental in uuid package.
+      // ignore: experimental_member_use
+      await client.budget.delete(UuidValue.fromString(budgetId));
+      if (ref.mounted) {
+        ref.invalidate(budgetListProvider);
+        state = const AsyncValue.data(null);
+      }
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+}

--- a/openbudget_app/lib/src/features/home/providers/budget_actions_provider.g.dart
+++ b/openbudget_app/lib/src/features/home/providers/budget_actions_provider.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budget_actions_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(BudgetActions)
+final budgetActionsProvider = BudgetActionsProvider._();
+
+final class BudgetActionsProvider
+    extends $NotifierProvider<BudgetActions, AsyncValue<void>> {
+  BudgetActionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetActionsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetActionsHash();
+
+  @$internal
+  @override
+  BudgetActions create() => BudgetActions();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<void> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
+  }
+}
+
+String _$budgetActionsHash() => r'172ea3035afcd6b28711eaf2a060d3810614007a';
+
+abstract class _$BudgetActions extends $Notifier<AsyncValue<void>> {
+  AsyncValue<void> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<void>, AsyncValue<void>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, AsyncValue<void>>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/openbudget_app/lib/src/features/home/screens/home_screen.dart
+++ b/openbudget_app/lib/src/features/home/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/auth/providers/auth_provider.dart';
+import 'package:openbudget_app/src/features/home/providers/budget_actions_provider.dart';
 import 'package:openbudget_app/src/features/home/providers/budget_list_provider.dart';
 import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
@@ -97,6 +98,12 @@ class HomeScreen extends HookConsumerWidget {
                   margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
                   child: ListTile(
                     onTap: () => context.go('/budgets/${budget.id}'),
+                    onLongPress: () => _confirmDeleteBudget(
+                      context,
+                      ref,
+                      budget.id?.toString() ?? '',
+                      budget.name,
+                    ),
                     leading: CircleAvatar(
                       backgroundColor: colorScheme.primaryContainer,
                       child: Icon(
@@ -136,5 +143,58 @@ class HomeScreen extends HookConsumerWidget {
         orElse: () => null,
       ),
     );
+  }
+
+  Future<void> _confirmDeleteBudget(
+    BuildContext context,
+    WidgetRef ref,
+    String budgetId,
+    String budgetName,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.budgetDeleteTitle),
+        content: Text(l10n.budgetDeleteConfirm(budgetName)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
+            child: Text(l10n.budgetDeleteButton),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    try {
+      await ref
+          .read(budgetActionsProvider.notifier)
+          .deleteBudget(budgetId: budgetId);
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l10n.budgetDeleteSuccess)));
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.budgetDeleteError),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Long-press a budget on the home screen to trigger delete
- Shows confirmation dialog with budget name and warning
- Adds `BudgetActions` provider with `deleteBudget` method
- Adds 5 l10n strings for delete flow

## Test plan
- [ ] Long-press budget → confirmation dialog appears with budget name
- [ ] Confirm delete → budget is removed and snackbar shows success
- [ ] Cancel delete → dialog dismisses, budget remains
- [ ] Error handling → snackbar shows error message