### PR TITLE
feat: add settings screen with budget rename and logout

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -397,5 +397,17 @@
   },
   "budgetDeleteButton": "Delete",
   "budgetDeleteSuccess": "Budget deleted",
-  "budgetDeleteError": "Could not delete budget. Please try again."
+  "budgetDeleteError": "Could not delete budget. Please try again.",
+  "settingsTitle": "Settings",
+  "settingsLoadError": "Could not load settings",
+  "settingsBudgetSection": "Budget",
+  "settingsBudgetName": "Budget Name",
+  "settingsCurrency": "Currency",
+  "settingsNavigationSection": "Quick Access",
+  "settingsAccountSection": "Account",
+  "settingsRenameBudget": "Rename Budget",
+  "settingsRenameSuccess": "Budget renamed",
+  "settingsRenameError": "Could not rename budget. Please try again.",
+  "settingsLogoutConfirm": "Are you sure you want to sign out?",
+  "settingsVersion": "OpenBudget v1.0.0"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1851,6 +1851,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not delete budget. Please try again.'**
   String get budgetDeleteError;
+
+  /// No description provided for @settingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settingsTitle;
+
+  /// No description provided for @settingsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load settings'**
+  String get settingsLoadError;
+
+  /// No description provided for @settingsBudgetSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget'**
+  String get settingsBudgetSection;
+
+  /// No description provided for @settingsBudgetName.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget Name'**
+  String get settingsBudgetName;
+
+  /// No description provided for @settingsCurrency.
+  ///
+  /// In en, this message translates to:
+  /// **'Currency'**
+  String get settingsCurrency;
+
+  /// No description provided for @settingsNavigationSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Quick Access'**
+  String get settingsNavigationSection;
+
+  /// No description provided for @settingsAccountSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Account'**
+  String get settingsAccountSection;
+
+  /// No description provided for @settingsRenameBudget.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename Budget'**
+  String get settingsRenameBudget;
+
+  /// No description provided for @settingsRenameSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget renamed'**
+  String get settingsRenameSuccess;
+
+  /// No description provided for @settingsRenameError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not rename budget. Please try again.'**
+  String get settingsRenameError;
+
+  /// No description provided for @settingsLogoutConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to sign out?'**
+  String get settingsLogoutConfirm;
+
+  /// No description provided for @settingsVersion.
+  ///
+  /// In en, this message translates to:
+  /// **'OpenBudget v1.0.0'**
+  String get settingsVersion;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -1018,4 +1018,41 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get budgetDeleteError => 'Could not delete budget. Please try again.';
+
+  @override
+  String get settingsTitle => 'Settings';
+
+  @override
+  String get settingsLoadError => 'Could not load settings';
+
+  @override
+  String get settingsBudgetSection => 'Budget';
+
+  @override
+  String get settingsBudgetName => 'Budget Name';
+
+  @override
+  String get settingsCurrency => 'Currency';
+
+  @override
+  String get settingsNavigationSection => 'Quick Access';
+
+  @override
+  String get settingsAccountSection => 'Account';
+
+  @override
+  String get settingsRenameBudget => 'Rename Budget';
+
+  @override
+  String get settingsRenameSuccess => 'Budget renamed';
+
+  @override
+  String get settingsRenameError =>
+      'Could not rename budget. Please try again.';
+
+  @override
+  String get settingsLogoutConfirm => 'Are you sure you want to sign out?';
+
+  @override
+  String get settingsVersion => 'OpenBudget v1.0.0';
 }

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -134,6 +134,11 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   onPressed: () =>
                       context.go('/budgets/$budgetId/transactions'),
                 ),
+                IconButton(
+                  icon: const Icon(Icons.settings_rounded),
+                  tooltip: l10n.settingsTitle,
+                  onPressed: () => context.go('/budgets/$budgetId/settings'),
+                ),
               ],
             ],
           ),

--- a/openbudget_app/lib/src/features/settings/screens/settings_screen.dart
+++ b/openbudget_app/lib/src/features/settings/screens/settings_screen.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class SettingsScreen extends HookConsumerWidget {
+  const SettingsScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final budgetAsync = ref.watch(budgetDetailProvider(budgetId));
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.settingsTitle)),
+      body: budgetAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => Center(
+          child: Text(
+            l10n.settingsLoadError,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: colorScheme.error,
+            ),
+          ),
+        ),
+        data: (budget) => ListView(
+          padding: const EdgeInsets.all(SpacingTokens.md),
+          children: [
+            _SectionTitle(title: l10n.settingsBudgetSection),
+            Card(
+              child: Column(
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.edit_outlined),
+                    title: Text(l10n.settingsBudgetName),
+                    subtitle: Text(budget.name),
+                    onTap: () => _showRenameBudgetDialog(context, ref, budget),
+                  ),
+                  const Divider(height: 1),
+                  ListTile(
+                    leading: const Icon(Icons.attach_money_rounded),
+                    title: Text(l10n.settingsCurrency),
+                    subtitle: Text(budget.currencyCode),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: SpacingTokens.lg),
+            _SectionTitle(title: l10n.settingsNavigationSection),
+            Card(
+              child: Column(
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.repeat_rounded),
+                    title: Text(l10n.recurringListTitle),
+                    trailing: const Icon(Icons.chevron_right_rounded),
+                    onTap: () => Navigator.of(
+                      context,
+                    ).pushNamed('/budgets/$budgetId/recurring'),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: SpacingTokens.lg),
+            _SectionTitle(title: l10n.settingsAccountSection),
+            Card(
+              child: Column(
+                children: [
+                  ListTile(
+                    leading: Icon(
+                      Icons.logout_rounded,
+                      color: colorScheme.error,
+                    ),
+                    title: Text(
+                      l10n.homeLogout,
+                      style: TextStyle(color: colorScheme.error),
+                    ),
+                    onTap: () => _confirmLogout(context, ref),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: SpacingTokens.xl),
+            Center(
+              child: Text(
+                l10n.settingsVersion,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showRenameBudgetDialog(
+    BuildContext context,
+    WidgetRef ref,
+    Budget budget,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final controller = TextEditingController(text: budget.name);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.settingsRenameBudget),
+        content: TextField(
+          controller: controller,
+          decoration: InputDecoration(
+            labelText: l10n.createBudgetNameLabel,
+            prefixIcon: const Icon(Icons.label_outlined),
+          ),
+          autofocus: true,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_) => Navigator.of(ctx).pop(true),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(l10n.dialogSave),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final name = controller.text.trim();
+    controller.dispose();
+    if (name.isEmpty || name == budget.name) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    try {
+      final client = ref.read(serverpodClientProvider);
+      await client.budget.update(
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(budgetId),
+        name: name,
+      );
+      ref.invalidate(budgetDetailProvider(budgetId));
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.settingsRenameSuccess)),
+      );
+    } on Exception catch (_) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.settingsRenameError),
+          backgroundColor: colorScheme.error,
+        ),
+      );
+    }
+  }
+
+  Future<void> _confirmLogout(BuildContext context, WidgetRef ref) async {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.homeLogout),
+        content: Text(l10n.settingsLogoutConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
+            child: Text(l10n.homeLogout),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+    await ref.read(authProvider.notifier).logout();
+  }
+}
+
+class _SectionTitle extends HookWidget {
+  const _SectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: SpacingTokens.sm,
+        bottom: SpacingTokens.xs,
+      ),
+      child: Text(
+        title.toUpperCase(),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -15,6 +15,7 @@ import 'package:openbudget_app/src/features/recurring/screens/recurring_list_scr
 import 'package:openbudget_app/src/features/reports/screens/net_worth_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/reports_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/spending_trends_screen.dart';
+import 'package:openbudget_app/src/features/settings/screens/settings_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_expense_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_income_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/import_transactions_screen.dart';
@@ -185,6 +186,14 @@ GoRouter appRouter(Ref ref) {
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return SpendingTrendsScreen(budgetId: id);
+        },
+      ),
+      GoRoute(
+        name: settingsRoute,
+        path: settingsPath,
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return SettingsScreen(budgetId: id);
         },
       ),
     ],

--- a/openbudget_app/lib/src/routing/app_router.g.dart
+++ b/openbudget_app/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'85f237f2b1119a3257a6193d9c81ea5c47cc468f';
+String _$appRouterHash() => r'90be286bae553b9832a4b376c691cd5c77d10a36';

--- a/openbudget_app/lib/src/routing/route_names.dart
+++ b/openbudget_app/lib/src/routing/route_names.dart
@@ -36,3 +36,5 @@ const netWorthRoute = 'netWorth';
 const netWorthPath = '/budgets/:id/net-worth';
 const spendingTrendsRoute = 'spendingTrends';
 const spendingTrendsPath = '/budgets/:id/reports/trends';
+const settingsRoute = 'settings';
+const settingsPath = '/budgets/:id/settings';


### PR DESCRIPTION
## Summary
- Adds settings screen accessible via gear icon on budget dashboard
- Budget rename dialog with inline editing
- Currency display (read-only)
- Quick access to recurring transactions
- Sign out with confirmation dialog
- Adds route `/budgets/:id/settings` and 12 l10n strings

## Test plan
- [ ] Tap settings gear icon on budget dashboard → settings screen opens
- [ ] Tap Budget Name → rename dialog opens, submit renames budget
- [ ] Currency row shows current budget currency
- [ ] Recurring row navigates to recurring transactions
- [ ] Sign Out shows confirmation, confirm logs out