### PR TITLE
feat: add theme mode toggle with system/light/dark support

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -437,5 +437,9 @@
         "type": "int"
       }
     }
-  }
+  },
+  "themeTitle": "Appearance",
+  "themeSystem": "System",
+  "themeLight": "Light",
+  "themeDark": "Dark"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1965,6 +1965,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{1 transaction copied to clipboard} other{{count} transactions copied to clipboard}}'**
   String transactionExportSuccess(int count);
+
+  /// No description provided for @themeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Appearance'**
+  String get themeTitle;
+
+  /// No description provided for @themeSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'System'**
+  String get themeSystem;
+
+  /// No description provided for @themeLight.
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeLight;
+
+  /// No description provided for @themeDark.
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeDark;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -1100,4 +1100,16 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get themeTitle => 'Appearance';
+
+  @override
+  String get themeSystem => 'System';
+
+  @override
+  String get themeLight => 'Light';
+
+  @override
+  String get themeDark => 'Dark';
 }

--- a/openbudget_app/lib/main.dart
+++ b/openbudget_app/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/providers/theme_mode_provider.dart';
 import 'package:openbudget_app/src/routing/app_router.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -16,11 +17,13 @@ class OpenBudgetApp extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(appRouterProvider);
+    final themeMode = ref.watch(themeModeProvider);
 
     return MaterialApp.router(
       title: 'OpenBudget',
       theme: OpenBudgetTheme.light,
       darkTheme: OpenBudgetTheme.dark,
+      themeMode: themeMode,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       routerConfig: router,

--- a/openbudget_app/lib/src/providers/theme_mode_provider.dart
+++ b/openbudget_app/lib/src/providers/theme_mode_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'theme_mode_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class ThemeModeNotifier extends _$ThemeModeNotifier {
+  @override
+  ThemeMode build() {
+    return ThemeMode.system;
+  }
+
+  // Riverpod notifiers use methods, not setters, for state mutations.
+  // ignore: use_setters_to_change_properties
+  void setThemeMode(ThemeMode mode) {
+    state = mode;
+  }
+}

--- a/openbudget_app/lib/src/providers/theme_mode_provider.g.dart
+++ b/openbudget_app/lib/src/providers/theme_mode_provider.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'theme_mode_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ThemeModeNotifier)
+final themeModeProvider = ThemeModeNotifierProvider._();
+
+final class ThemeModeNotifierProvider
+    extends $NotifierProvider<ThemeModeNotifier, ThemeMode> {
+  ThemeModeNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'themeModeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$themeModeNotifierHash();
+
+  @$internal
+  @override
+  ThemeModeNotifier create() => ThemeModeNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ThemeMode value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ThemeMode>(value),
+    );
+  }
+}
+
+String _$themeModeNotifierHash() => r'fb6ca2f860f9355a9a7ff328e8b439712749b7c3';
+
+abstract class _$ThemeModeNotifier extends $Notifier<ThemeMode> {
+  ThemeMode build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<ThemeMode, ThemeMode>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<ThemeMode, ThemeMode>,
+              ThemeMode,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `ThemeModeNotifier` provider to control app appearance
- Integrates with `MaterialApp.router` themeMode parameter
- Defaults to system theme, supports light/dark override
- Adds 4 l10n strings for appearance selection

## Test plan
- [ ] App defaults to system theme mode
- [ ] Theme mode can be changed via the provider
- [ ] Light mode and dark mode render correctly
- [ ] System mode follows OS preference