### PR TITLE
feat: add copy-as-CSV export to transaction list

### DIFF
--- a/.changeset/transaction-clipboard-export.md
+++ b/.changeset/transaction-clipboard-export.md
@@ -1,0 +1,5 @@
+---
+openbudget_app: minor
+---
+
+Add copy-as-CSV button to transaction list for clipboard export.


### PR DESCRIPTION
## Summary
- Adds a clipboard copy icon in the transaction list app bar
- Copies all transactions as CSV (Date, Description, Amount, Memo, Status)
- Properly escapes CSV values containing commas, quotes, or newlines
- Shows snackbar confirmation with count of exported transactions

## Test plan
- [ ] Open transaction list with transactions
- [ ] Tap the copy icon in the app bar
- [ ] Verify snackbar shows export count
- [ ] Paste clipboard content and verify valid CSV format
- [ ] Verify button doesn't appear when transaction list is empty