### PR TITLE
feat: add spending by payee report

### DIFF
--- a/.changeset/spending-by-payee-report.md
+++ b/.changeset/spending-by-payee-report.md
@@ -1,0 +1,5 @@
+---
+openbudget_app: minor
+---
+
+Add spending by payee report screen with monthly navigation and payee breakdown.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -443,6 +443,21 @@
   "themeLight": "Light",
   "themeDark": "Dark",
   "transactionDateToday": "Today",
-  "transactionDateYesterday": "Yesterday"
+  "transactionDateYesterday": "Yesterday",
+  "spendingByPayeeTitle": "Spending by Payee",
+  "spendingByPayeeEmptyTitle": "No Payee Data",
+  "spendingByPayeeEmptySubtitle": "Add expense transactions to see spending by payee",
+  "spendingByPayeeTotalSpent": "Total Spent",
+  "spendingByPayeePayeeCount": "Payees",
+  "spendingByPayeeBreakdown": "Spending Breakdown",
+  "spendingByPayeeTransactionCount": "{count, plural, =1{1 transaction} other{{count} transactions}}",
+  "@spendingByPayeeTransactionCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
+
 
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -2001,6 +2001,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Yesterday'**
   String get transactionDateYesterday;
+
+  /// No description provided for @spendingByPayeeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending by Payee'**
+  String get spendingByPayeeTitle;
+
+  /// No description provided for @spendingByPayeeEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Payee Data'**
+  String get spendingByPayeeEmptyTitle;
+
+  /// No description provided for @spendingByPayeeEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add expense transactions to see spending by payee'**
+  String get spendingByPayeeEmptySubtitle;
+
+  /// No description provided for @spendingByPayeeTotalSpent.
+  ///
+  /// In en, this message translates to:
+  /// **'Total Spent'**
+  String get spendingByPayeeTotalSpent;
+
+  /// No description provided for @spendingByPayeePayeeCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Payees'**
+  String get spendingByPayeePayeeCount;
+
+  /// No description provided for @spendingByPayeeBreakdown.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending Breakdown'**
+  String get spendingByPayeeBreakdown;
+
+  /// No description provided for @spendingByPayeeTransactionCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction} other{{count} transactions}}'**
+  String spendingByPayeeTransactionCount(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -1118,4 +1118,34 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get transactionDateYesterday => 'Yesterday';
+
+  @override
+  String get spendingByPayeeTitle => 'Spending by Payee';
+
+  @override
+  String get spendingByPayeeEmptyTitle => 'No Payee Data';
+
+  @override
+  String get spendingByPayeeEmptySubtitle =>
+      'Add expense transactions to see spending by payee';
+
+  @override
+  String get spendingByPayeeTotalSpent => 'Total Spent';
+
+  @override
+  String get spendingByPayeePayeeCount => 'Payees';
+
+  @override
+  String get spendingByPayeeBreakdown => 'Spending Breakdown';
+
+  @override
+  String spendingByPayeeTransactionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions',
+      one: '1 transaction',
+    );
+    return '$_temp0';
+  }
 }

--- a/openbudget_app/lib/src/features/reports/providers/spending_by_payee_provider.dart
+++ b/openbudget_app/lib/src/features/reports/providers/spending_by_payee_provider.dart
@@ -1,0 +1,100 @@
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'spending_by_payee_provider.g.dart';
+
+class PayeeSpendingEntry {
+  const PayeeSpendingEntry({
+    required this.payeeName,
+    required this.totalCents,
+    required this.transactionCount,
+  });
+
+  final String payeeName;
+  final int totalCents;
+  final int transactionCount;
+}
+
+class PayeeSpendingReport {
+  const PayeeSpendingReport({
+    required this.entries,
+    required this.totalSpentCents,
+    required this.currencyCode,
+  });
+
+  final List<PayeeSpendingEntry> entries;
+  final int totalSpentCents;
+  final String currencyCode;
+}
+
+@riverpod
+Future<PayeeSpendingReport> spendingByPayee(
+  Ref ref,
+  String budgetId,
+  int year,
+  int month,
+) async {
+  final client = ref.read(serverpodClientProvider);
+  // Serverpod API requires UuidValue which is experimental in uuid package.
+  // ignore: experimental_member_use
+  final transactions = await client.transaction.listByMonth(
+    // Serverpod API requires UuidValue which is experimental in uuid package.
+    // ignore: experimental_member_use
+    UuidValue.fromString(budgetId),
+    year,
+    month,
+  );
+
+  final budget = await ref.watch(budgetDetailProvider(budgetId).future);
+
+  // Aggregate spending by payee description (expenses only).
+  final payeeMap = <String, _PayeeAccumulator>{};
+
+  for (final tx in transactions) {
+    if (tx.amountCents >= 0) continue; // Skip income.
+
+    final payeeName = tx.description;
+    if (payeeName.isEmpty) continue;
+
+    final existing = payeeMap[payeeName];
+    if (existing != null) {
+      existing
+        ..totalCents += tx.amountCents.abs()
+        ..count += 1;
+    } else {
+      payeeMap[payeeName] = _PayeeAccumulator(
+        totalCents: tx.amountCents.abs(),
+        count: 1,
+      );
+    }
+  }
+
+  final entries =
+      payeeMap.entries
+          .map(
+            (e) => PayeeSpendingEntry(
+              payeeName: e.key,
+              totalCents: e.value.totalCents,
+              transactionCount: e.value.count,
+            ),
+          )
+          .toList()
+        ..sort((a, b) => b.totalCents.compareTo(a.totalCents));
+
+  final totalSpent = entries.fold<int>(0, (sum, e) => sum + e.totalCents);
+
+  return PayeeSpendingReport(
+    entries: entries,
+    totalSpentCents: totalSpent,
+    currencyCode: budget.currencyCode,
+  );
+}
+
+class _PayeeAccumulator {
+  _PayeeAccumulator({required this.totalCents, required this.count});
+
+  int totalCents;
+  int count;
+}

--- a/openbudget_app/lib/src/features/reports/providers/spending_by_payee_provider.g.dart
+++ b/openbudget_app/lib/src/features/reports/providers/spending_by_payee_provider.g.dart
@@ -1,0 +1,91 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'spending_by_payee_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(spendingByPayee)
+final spendingByPayeeProvider = SpendingByPayeeFamily._();
+
+final class SpendingByPayeeProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<PayeeSpendingReport>,
+          PayeeSpendingReport,
+          FutureOr<PayeeSpendingReport>
+        >
+    with
+        $FutureModifier<PayeeSpendingReport>,
+        $FutureProvider<PayeeSpendingReport> {
+  SpendingByPayeeProvider._({
+    required SpendingByPayeeFamily super.from,
+    required (String, int, int) super.argument,
+  }) : super(
+         retry: null,
+         name: r'spendingByPayeeProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$spendingByPayeeHash();
+
+  @override
+  String toString() {
+    return r'spendingByPayeeProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<PayeeSpendingReport> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<PayeeSpendingReport> create(Ref ref) {
+    final argument = this.argument as (String, int, int);
+    return spendingByPayee(ref, argument.$1, argument.$2, argument.$3);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is SpendingByPayeeProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$spendingByPayeeHash() => r'69e031091260249c680a0482ad09581e3aaf69bd';
+
+final class SpendingByPayeeFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<PayeeSpendingReport>,
+          (String, int, int)
+        > {
+  SpendingByPayeeFamily._()
+    : super(
+        retry: null,
+        name: r'spendingByPayeeProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  SpendingByPayeeProvider call(String budgetId, int year, int month) =>
+      SpendingByPayeeProvider._(argument: (budgetId, year, month), from: this);
+
+  @override
+  String toString() => r'spendingByPayeeProvider';
+}

--- a/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
@@ -31,6 +31,14 @@ class ReportsScreen extends HookConsumerWidget {
         title: Text(l10n.reportsTitle),
         actions: [
           IconButton(
+            icon: const Icon(Icons.store_rounded),
+            tooltip: l10n.spendingByPayeeTitle,
+            onPressed: () => context.pushNamed(
+              spendingByPayeeRoute,
+              pathParameters: {'id': budgetId},
+            ),
+          ),
+          IconButton(
             icon: const Icon(Icons.account_balance_wallet_rounded),
             tooltip: l10n.netWorthTitle,
             onPressed: () => context.pushNamed(

--- a/openbudget_app/lib/src/features/reports/screens/spending_by_payee_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/spending_by_payee_screen.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/reports/providers/spending_by_payee_provider.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class SpendingByPayeeScreen extends HookConsumerWidget {
+  const SpendingByPayeeScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final now = DateTime.now();
+    final selectedYear = useState(now.year);
+    final selectedMonth = useState(now.month);
+
+    final reportAsync = ref.watch(
+      spendingByPayeeProvider(
+        budgetId,
+        selectedYear.value,
+        selectedMonth.value,
+      ),
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.spendingByPayeeTitle)),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: SpacingTokens.md,
+              vertical: SpacingTokens.sm,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                IconButton(
+                  onPressed: () {
+                    if (selectedMonth.value == 1) {
+                      selectedMonth.value = 12;
+                      selectedYear.value--;
+                    } else {
+                      selectedMonth.value--;
+                    }
+                  },
+                  icon: const Icon(Icons.chevron_left),
+                ),
+                Text(
+                  _monthName(l10n, selectedMonth.value, selectedYear.value),
+                  style: theme.textTheme.titleMedium,
+                ),
+                IconButton(
+                  onPressed: () {
+                    if (selectedMonth.value == 12) {
+                      selectedMonth.value = 1;
+                      selectedYear.value++;
+                    } else {
+                      selectedMonth.value++;
+                    }
+                  },
+                  icon: const Icon(Icons.chevron_right),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: reportAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) => Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.error_outline_rounded,
+                      size: 48,
+                      color: colorScheme.error,
+                    ),
+                    const SizedBox(height: SpacingTokens.md),
+                    Text(
+                      l10n.reportsLoadError,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: colorScheme.error,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              data: (report) {
+                if (report.entries.isEmpty) {
+                  return Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.store_rounded,
+                          size: 48,
+                          color: colorScheme.outlineVariant,
+                        ),
+                        const SizedBox(height: SpacingTokens.md),
+                        Text(
+                          l10n.spendingByPayeeEmptyTitle,
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: SpacingTokens.sm),
+                        Text(
+                          l10n.spendingByPayeeEmptySubtitle,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  );
+                }
+
+                final currency = CurrencyCode.values.firstWhere(
+                  (c) => c.code == report.currencyCode,
+                  orElse: () => CurrencyCode.usd,
+                );
+
+                return ListView(
+                  padding: const EdgeInsets.all(SpacingTokens.md),
+                  children: [
+                    _TotalCard(
+                      totalCents: report.totalSpentCents,
+                      payeeCount: report.entries.length,
+                      currency: currency,
+                      l10n: l10n,
+                    ),
+                    const SizedBox(height: SpacingTokens.md),
+                    Text(
+                      l10n.spendingByPayeeBreakdown,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: SpacingTokens.sm),
+                    ...report.entries.map(
+                      (entry) => _PayeeSpendingRow(
+                        entry: entry,
+                        maxCents: report.totalSpentCents,
+                        currency: currency,
+                        colorScheme: colorScheme,
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _monthName(AppLocalizations l10n, int month, int year) {
+    final name = switch (month) {
+      1 => l10n.budgetMonthJanuary,
+      2 => l10n.budgetMonthFebruary,
+      3 => l10n.budgetMonthMarch,
+      4 => l10n.budgetMonthApril,
+      5 => l10n.budgetMonthMay,
+      6 => l10n.budgetMonthJune,
+      7 => l10n.budgetMonthJuly,
+      8 => l10n.budgetMonthAugust,
+      9 => l10n.budgetMonthSeptember,
+      10 => l10n.budgetMonthOctober,
+      11 => l10n.budgetMonthNovember,
+      12 => l10n.budgetMonthDecember,
+      _ => '',
+    };
+    return '$name $year';
+  }
+}
+
+class _TotalCard extends HookWidget {
+  const _TotalCard({
+    required this.totalCents,
+    required this.payeeCount,
+    required this.currency,
+    required this.l10n,
+  });
+
+  final int totalCents;
+  final int payeeCount;
+  final CurrencyCode currency;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(SpacingTokens.md),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                children: [
+                  Text(
+                    l10n.spendingByPayeeTotalSpent,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: SpacingTokens.xs),
+                  Text(
+                    formatCents(totalCents, currency),
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      color: colorScheme.error,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Column(
+                children: [
+                  Text(
+                    l10n.spendingByPayeePayeeCount,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: SpacingTokens.xs),
+                  Text(
+                    payeeCount.toString(),
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PayeeSpendingRow extends HookWidget {
+  const _PayeeSpendingRow({
+    required this.entry,
+    required this.maxCents,
+    required this.currency,
+    required this.colorScheme,
+  });
+
+  final PayeeSpendingEntry entry;
+  final int maxCents;
+  final CurrencyCode currency;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final fraction = maxCents > 0 ? entry.totalCents / maxCents : 0.0;
+    final l10n = AppLocalizations.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SpacingTokens.sm),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      entry.payeeName,
+                      style: theme.textTheme.bodyMedium,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    Text(
+                      l10n.spendingByPayeeTransactionCount(
+                        entry.transactionCount,
+                      ),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Text(
+                formatCents(entry.totalCents, currency),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: SpacingTokens.xs),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: fraction,
+              minHeight: 8,
+              backgroundColor: colorScheme.surfaceContainerHighest,
+              valueColor: AlwaysStoppedAnimation(colorScheme.primary),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -14,6 +14,7 @@ import 'package:openbudget_app/src/features/payees/screens/payee_list_screen.dar
 import 'package:openbudget_app/src/features/recurring/screens/recurring_list_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/net_worth_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/reports_screen.dart';
+import 'package:openbudget_app/src/features/reports/screens/spending_by_payee_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/spending_trends_screen.dart';
 import 'package:openbudget_app/src/features/settings/screens/settings_screen.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_expense_screen.dart';
@@ -186,6 +187,14 @@ GoRouter appRouter(Ref ref) {
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return SpendingTrendsScreen(budgetId: id);
+        },
+      ),
+      GoRoute(
+        name: spendingByPayeeRoute,
+        path: spendingByPayeePath,
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return SpendingByPayeeScreen(budgetId: id);
         },
       ),
       GoRoute(

--- a/openbudget_app/lib/src/routing/app_router.g.dart
+++ b/openbudget_app/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'90be286bae553b9832a4b376c691cd5c77d10a36';
+String _$appRouterHash() => r'051633b1a7ac63f74050e90484ba46b83436b367';

--- a/openbudget_app/lib/src/routing/route_names.dart
+++ b/openbudget_app/lib/src/routing/route_names.dart
@@ -36,5 +36,7 @@ const netWorthRoute = 'netWorth';
 const netWorthPath = '/budgets/:id/net-worth';
 const spendingTrendsRoute = 'spendingTrends';
 const spendingTrendsPath = '/budgets/:id/reports/trends';
+const spendingByPayeeRoute = 'spendingByPayee';
+const spendingByPayeePath = '/budgets/:id/reports/payees';
 const settingsRoute = 'settings';
 const settingsPath = '/budgets/:id/settings';


### PR DESCRIPTION
## Summary
- Adds a new **Spending by Payee** report screen showing monthly expense breakdown by payee
- Shows total spent and payee count in summary card, with progress bars per payee
- Accessible via store icon in the reports screen toolbar
- Includes month navigation with chevron arrows
- Adds 7 new l10n strings for the report

## Test plan
- [ ] Navigate to Reports > Spending by Payee icon
- [ ] Verify month navigation works (chevrons)
- [ ] Verify payee breakdown shows correct amounts
- [ ] Verify empty state when no expenses exist
- [ ] Verify spending bars are proportional to amounts