### PR TITLE
feat: add back-to-today button in budget month navigator

### DIFF
--- a/.changeset/budget-today-button.md
+++ b/.changeset/budget-today-button.md
@@ -1,0 +1,5 @@
+---
+openbudget_app: patch
+---
+
+Add "Back to Today" tap target on budget month navigator and use localized month names.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -457,7 +457,6 @@
         "type": "int"
       }
     }
-  }
-
-
+  },
+  "budgetGoToToday": "Back to Today"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -2043,6 +2043,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{1 transaction} other{{count} transactions}}'**
   String spendingByPayeeTransactionCount(int count);
+
+  /// No description provided for @budgetGoToToday.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to Today'**
+  String get budgetGoToToday;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -1148,4 +1148,7 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get budgetGoToToday => 'Back to Today';
 }

--- a/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
@@ -26,26 +26,13 @@ class BudgetHeader extends HookConsumerWidget {
   final int month;
   final int totalOverspentCents;
 
-  static const _monthNames = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ];
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final ageOfMoneyAsync = ref.watch(ageOfMoneyProvider(budgetId));
+    final now = DateTime.now();
+    final isCurrentMonth = year == now.year && month == now.month;
     final color = readyToAssignCents > 0
         ? ColorTokens.secondary
         : readyToAssignCents < 0
@@ -82,14 +69,33 @@ class BudgetHeader extends HookConsumerWidget {
                 padding: EdgeInsets.zero,
                 constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: SpacingTokens.sm,
-                ),
-                child: Text(
-                  '${_monthNames[month - 1]} $year',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
+              GestureDetector(
+                onTap: isCurrentMonth
+                    ? null
+                    : () => ref
+                          .read(selectedMonthProvider(budgetId).notifier)
+                          .setMonth(now.year, now.month),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: SpacingTokens.sm,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '${_localizedMonth(l10n, month)} $year',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (!isCurrentMonth)
+                        Text(
+                          l10n.budgetGoToToday,
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: theme.colorScheme.primary,
+                          ),
+                        ),
+                    ],
                   ),
                 ),
               ),
@@ -196,6 +202,22 @@ class BudgetHeader extends HookConsumerWidget {
       ),
     );
   }
+
+  String _localizedMonth(AppLocalizations l10n, int month) => switch (month) {
+    1 => l10n.budgetMonthJanuary,
+    2 => l10n.budgetMonthFebruary,
+    3 => l10n.budgetMonthMarch,
+    4 => l10n.budgetMonthApril,
+    5 => l10n.budgetMonthMay,
+    6 => l10n.budgetMonthJune,
+    7 => l10n.budgetMonthJuly,
+    8 => l10n.budgetMonthAugust,
+    9 => l10n.budgetMonthSeptember,
+    10 => l10n.budgetMonthOctober,
+    11 => l10n.budgetMonthNovember,
+    12 => l10n.budgetMonthDecember,
+    _ => '',
+  };
 
   void _showAutoAssignDialog(BuildContext context) {
     showDialog<void>(


### PR DESCRIPTION
## Summary
- Tapping the month/year label when viewing a past or future month jumps back to the current month
- Shows a "Back to Today" hint text below the month name when not on the current month
- Replaces hardcoded English month names with localized `AppLocalizations` strings
- Adds 1 new l10n string: `budgetGoToToday`

## Test plan
- [ ] Navigate to budget detail screen
- [ ] Use chevron arrows to go to a different month
- [ ] Verify "Back to Today" text appears below month name
- [ ] Tap the month label to jump back to current month
- [ ] Verify the hint disappears when on current month