### PR TITLE
feat: add category trends report

### DIFF
--- a/.changeset/category-trends-report.md
+++ b/.changeset/category-trends-report.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add category trends report showing spending per category over the last 6 months with mini bar charts.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -458,5 +458,9 @@
       }
     }
   },
-  "budgetGoToToday": "Back to Today"
+  "budgetGoToToday": "Back to Today",
+  "categoryTrendsTitle": "Category Trends",
+  "categoryTrendsLoadError": "Could not load category trends",
+  "categoryTrendsEmptyTitle": "No Category Data",
+  "categoryTrendsEmptySubtitle": "Add categorized transactions to see spending trends by category"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -2049,6 +2049,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Back to Today'**
   String get budgetGoToToday;
+
+  /// No description provided for @categoryTrendsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Category Trends'**
+  String get categoryTrendsTitle;
+
+  /// No description provided for @categoryTrendsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load category trends'**
+  String get categoryTrendsLoadError;
+
+  /// No description provided for @categoryTrendsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Category Data'**
+  String get categoryTrendsEmptyTitle;
+
+  /// No description provided for @categoryTrendsEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add categorized transactions to see spending trends by category'**
+  String get categoryTrendsEmptySubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -1151,4 +1151,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get budgetGoToToday => 'Back to Today';
+
+  @override
+  String get categoryTrendsTitle => 'Category Trends';
+
+  @override
+  String get categoryTrendsLoadError => 'Could not load category trends';
+
+  @override
+  String get categoryTrendsEmptyTitle => 'No Category Data';
+
+  @override
+  String get categoryTrendsEmptySubtitle =>
+      'Add categorized transactions to see spending trends by category';
 }

--- a/openbudget_app/lib/src/features/reports/providers/category_trends_provider.dart
+++ b/openbudget_app/lib/src/features/reports/providers/category_trends_provider.dart
@@ -1,0 +1,112 @@
+import 'package:openbudget_app/src/features/reports/providers/spending_report_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'category_trends_provider.g.dart';
+
+/// Fetches spending‐by‐category for each of the last [months] months and
+/// pivots the data so each category has a time series of spending amounts.
+@riverpod
+Future<CategoryTrendsData> categoryTrends(
+  Ref ref,
+  String budgetId, {
+  int months = 6,
+}) async {
+  final now = DateTime.now();
+  final monthHeaders = <MonthLabel>[];
+  final categoryMap = <String, List<int>>{};
+
+  for (var i = months - 1; i >= 0; i--) {
+    var year = now.year;
+    var month = now.month - i;
+    while (month <= 0) {
+      month += 12;
+      year--;
+    }
+
+    monthHeaders.add(MonthLabel(year: year, month: month));
+
+    final report = await ref.watch(
+      spendingReportProvider(budgetId, year, month).future,
+    );
+
+    // Ensure every category has an entry for this month index.
+    final monthIndex = monthHeaders.length - 1;
+    for (final existing in categoryMap.keys) {
+      if (categoryMap[existing]!.length <= monthIndex) {
+        categoryMap[existing]!.add(0);
+      }
+    }
+
+    for (final entry in report.categorySpending.entries) {
+      categoryMap.putIfAbsent(entry.key, () => List.filled(monthIndex, 0));
+      categoryMap[entry.key]!.add(entry.value);
+    }
+
+    // Back-fill any newly added categories for this month.
+    for (final entry in categoryMap.entries) {
+      while (entry.value.length <= monthIndex) {
+        entry.value.add(0);
+      }
+    }
+  }
+
+  // Sort categories by total descending.
+  final sortedEntries = categoryMap.entries.toList()
+    ..sort((a, b) {
+      final totalA = a.value.fold<int>(0, (s, v) => s + v);
+      final totalB = b.value.fold<int>(0, (s, v) => s + v);
+      return totalB.compareTo(totalA);
+    });
+
+  final categories = sortedEntries
+      .map(
+        (e) => CategoryTrendLine(
+          categoryName: e.key,
+          monthlyCents: e.value,
+          totalCents: e.value.fold<int>(0, (s, v) => s + v),
+        ),
+      )
+      .toList();
+
+  // Resolve the currency from the first report that has data.
+  final firstReport = await ref.watch(
+    spendingReportProvider(budgetId, now.year, now.month).future,
+  );
+
+  return CategoryTrendsData(
+    months: monthHeaders,
+    categories: categories,
+    currencyCode: firstReport.currencyCode,
+  );
+}
+
+class CategoryTrendsData {
+  const CategoryTrendsData({
+    required this.months,
+    required this.categories,
+    required this.currencyCode,
+  });
+
+  final List<MonthLabel> months;
+  final List<CategoryTrendLine> categories;
+  final String currencyCode;
+}
+
+class MonthLabel {
+  const MonthLabel({required this.year, required this.month});
+
+  final int year;
+  final int month;
+}
+
+class CategoryTrendLine {
+  const CategoryTrendLine({
+    required this.categoryName,
+    required this.monthlyCents,
+    required this.totalCents,
+  });
+
+  final String categoryName;
+  final List<int> monthlyCents;
+  final int totalCents;
+}

--- a/openbudget_app/lib/src/features/reports/providers/category_trends_provider.g.dart
+++ b/openbudget_app/lib/src/features/reports/providers/category_trends_provider.g.dart
@@ -1,0 +1,107 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'category_trends_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches spending‐by‐category for each of the last [months] months and
+/// pivots the data so each category has a time series of spending amounts.
+
+@ProviderFor(categoryTrends)
+final categoryTrendsProvider = CategoryTrendsFamily._();
+
+/// Fetches spending‐by‐category for each of the last [months] months and
+/// pivots the data so each category has a time series of spending amounts.
+
+final class CategoryTrendsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<CategoryTrendsData>,
+          CategoryTrendsData,
+          FutureOr<CategoryTrendsData>
+        >
+    with
+        $FutureModifier<CategoryTrendsData>,
+        $FutureProvider<CategoryTrendsData> {
+  /// Fetches spending‐by‐category for each of the last [months] months and
+  /// pivots the data so each category has a time series of spending amounts.
+  CategoryTrendsProvider._({
+    required CategoryTrendsFamily super.from,
+    required (String, {int months}) super.argument,
+  }) : super(
+         retry: null,
+         name: r'categoryTrendsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$categoryTrendsHash();
+
+  @override
+  String toString() {
+    return r'categoryTrendsProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<CategoryTrendsData> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<CategoryTrendsData> create(Ref ref) {
+    final argument = this.argument as (String, {int months});
+    return categoryTrends(ref, argument.$1, months: argument.months);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is CategoryTrendsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$categoryTrendsHash() => r'043d4aa143716c1e02277cc9b0481205b84bbb26';
+
+/// Fetches spending‐by‐category for each of the last [months] months and
+/// pivots the data so each category has a time series of spending amounts.
+
+final class CategoryTrendsFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<CategoryTrendsData>,
+          (String, {int months})
+        > {
+  CategoryTrendsFamily._()
+    : super(
+        retry: null,
+        name: r'categoryTrendsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches spending‐by‐category for each of the last [months] months and
+  /// pivots the data so each category has a time series of spending amounts.
+
+  CategoryTrendsProvider call(String budgetId, {int months = 6}) =>
+      CategoryTrendsProvider._(
+        argument: (budgetId, months: months),
+        from: this,
+      );
+
+  @override
+  String toString() => r'categoryTrendsProvider';
+}

--- a/openbudget_app/lib/src/features/reports/screens/category_trends_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/category_trends_screen.dart
@@ -1,0 +1,275 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/reports/providers/category_trends_provider.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class CategoryTrendsScreen extends HookConsumerWidget {
+  const CategoryTrendsScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final trendsAsync = ref.watch(categoryTrendsProvider(budgetId));
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.categoryTrendsTitle)),
+      body: trendsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline_rounded,
+                size: 48,
+                color: colorScheme.error,
+              ),
+              const SizedBox(height: SpacingTokens.md),
+              Text(
+                l10n.categoryTrendsLoadError,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.error,
+                ),
+              ),
+            ],
+          ),
+        ),
+        data: (data) {
+          if (data.categories.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(SpacingTokens.xl),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.category_rounded,
+                      size: 48,
+                      color: colorScheme.outlineVariant,
+                    ),
+                    const SizedBox(height: SpacingTokens.md),
+                    Text(
+                      l10n.categoryTrendsEmptyTitle,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: SpacingTokens.sm),
+                    Text(
+                      l10n.categoryTrendsEmptySubtitle,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          final currency = CurrencyCode.values.firstWhere(
+            (c) => c.code == data.currencyCode,
+            orElse: () => CurrencyCode.usd,
+          );
+
+          return ListView(
+            padding: const EdgeInsets.all(SpacingTokens.md),
+            children: [
+              _MonthHeaders(months: data.months, l10n: l10n),
+              const SizedBox(height: SpacingTokens.sm),
+              ...data.categories.map(
+                (cat) => _CategoryTrendRow(
+                  category: cat,
+                  months: data.months,
+                  currency: currency,
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _MonthHeaders extends HookWidget {
+  const _MonthHeaders({required this.months, required this.l10n});
+
+  final List<MonthLabel> months;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        const SizedBox(width: 120),
+        ...months.map(
+          (m) => Expanded(
+            child: Text(
+              _shortMonth(m.month),
+              textAlign: TextAlign.center,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 72),
+      ],
+    );
+  }
+
+  String _shortMonth(int month) {
+    const names = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return names[month - 1];
+  }
+}
+
+class _CategoryTrendRow extends HookWidget {
+  const _CategoryTrendRow({
+    required this.category,
+    required this.months,
+    required this.currency,
+  });
+
+  final CategoryTrendLine category;
+  final List<MonthLabel> months;
+  final CurrencyCode currency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final maxCents = category.monthlyCents.fold<int>(0, math.max);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: SpacingTokens.md,
+          vertical: SpacingTokens.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    category.categoryName,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                Text(
+                  formatCents(category.totalCents, currency),
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.primary,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: SpacingTokens.sm),
+            Row(
+              children: [
+                for (var i = 0; i < category.monthlyCents.length; i++) ...[
+                  if (i > 0) const SizedBox(width: 4),
+                  Expanded(
+                    child: _MiniBar(
+                      value: category.monthlyCents[i],
+                      maxValue: maxCents,
+                      currency: currency,
+                      colorScheme: colorScheme,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniBar extends HookWidget {
+  const _MiniBar({
+    required this.value,
+    required this.maxValue,
+    required this.currency,
+    required this.colorScheme,
+  });
+
+  final int value;
+  final int maxValue;
+  final CurrencyCode currency;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final fraction = maxValue > 0 ? value / maxValue : 0.0;
+
+    return Tooltip(
+      message: formatCents(value, currency),
+      child: Column(
+        children: [
+          SizedBox(
+            height: 48,
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: FractionallySizedBox(
+                heightFactor: fraction.clamp(0.05, 1.0),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: value > 0
+                        ? colorScheme.primary
+                        : colorScheme.surfaceContainerHighest,
+                    borderRadius: const BorderRadius.vertical(
+                      top: Radius.circular(3),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value > 0 ? formatCents(value, currency) : '-',
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontSize: 9,
+              color: colorScheme.onSurfaceVariant,
+            ),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
@@ -31,6 +31,14 @@ class ReportsScreen extends HookConsumerWidget {
         title: Text(l10n.reportsTitle),
         actions: [
           IconButton(
+            icon: const Icon(Icons.category_rounded),
+            tooltip: l10n.categoryTrendsTitle,
+            onPressed: () => context.pushNamed(
+              categoryTrendsRoute,
+              pathParameters: {'id': budgetId},
+            ),
+          ),
+          IconButton(
             icon: const Icon(Icons.store_rounded),
             tooltip: l10n.spendingByPayeeTitle,
             onPressed: () => context.pushNamed(

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -12,6 +12,7 @@ import 'package:openbudget_app/src/features/budget/screens/create_budget_screen.
 import 'package:openbudget_app/src/features/home/screens/home_screen.dart';
 import 'package:openbudget_app/src/features/payees/screens/payee_list_screen.dart';
 import 'package:openbudget_app/src/features/recurring/screens/recurring_list_screen.dart';
+import 'package:openbudget_app/src/features/reports/screens/category_trends_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/net_worth_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/reports_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/spending_by_payee_screen.dart';
@@ -195,6 +196,14 @@ GoRouter appRouter(Ref ref) {
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return SpendingByPayeeScreen(budgetId: id);
+        },
+      ),
+      GoRoute(
+        name: categoryTrendsRoute,
+        path: categoryTrendsPath,
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return CategoryTrendsScreen(budgetId: id);
         },
       ),
       GoRoute(

--- a/openbudget_app/lib/src/routing/app_router.g.dart
+++ b/openbudget_app/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'051633b1a7ac63f74050e90484ba46b83436b367';
+String _$appRouterHash() => r'70ac1ab69b64803be3419f9d333db471d7f1854c';

--- a/openbudget_app/lib/src/routing/route_names.dart
+++ b/openbudget_app/lib/src/routing/route_names.dart
@@ -38,5 +38,7 @@ const spendingTrendsRoute = 'spendingTrends';
 const spendingTrendsPath = '/budgets/:id/reports/trends';
 const spendingByPayeeRoute = 'spendingByPayee';
 const spendingByPayeePath = '/budgets/:id/reports/payees';
+const categoryTrendsRoute = 'categoryTrends';
+const categoryTrendsPath = '/budgets/:id/reports/category-trends';
 const settingsRoute = 'settings';
 const settingsPath = '/budgets/:id/settings';


### PR DESCRIPTION
## Summary
- Add Category Trends report showing spending per budget category over the last 6 months
- Each category displays a row with mini bar charts showing monthly spending amounts
- Categories sorted by total spend (highest first)
- Accessible from the reports screen via a new category icon button in the app bar

## Test plan
- [ ] Navigate to Reports > Category Trends icon
- [ ] Verify empty state when no categorized transactions exist
- [ ] Add categorized expenses across multiple months
- [ ] Verify bar heights scale correctly relative to each category's max
- [ ] Verify category totals show correct aggregate amounts