### PR TITLE
feat: add copy previous month allocations

### DIFF
--- a/.changeset/copy-previous-month.md
+++ b/.changeset/copy-previous-month.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add copy previous month feature. Copy all budget allocations from the previous month to the current month with a single tap from the budget header.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -1,497 +1,501 @@
 {
-    "@@locale": "en",
-    "appTitle": "OpenBudget",
-    "loginTitle": "Welcome to OpenBudget",
-    "loginEmailLabel": "Email",
-    "loginPasswordLabel": "Password",
-    "loginButton": "Sign In",
-    "loginLoading": "Signing In...",
-    "loginCreateAccount": "Create Account",
-    "registerTitle": "Create Account",
-    "registerStepEmail": "Enter your email to get started",
-    "registerStepCode": "Enter the verification code sent to your email",
-    "registerStepPassword": "Choose a password for your account",
-    "registerSendCode": "Send Verification Code",
-    "registerCodeLabel": "Verification Code",
-    "registerVerifyCode": "Verify Code",
-    "registerConfirmPassword": "Confirm Password",
-    "registerCreateAccount": "Create Account",
-    "registerSubmitting": "Please wait...",
-    "registerAlreadyHaveAccount": "Already have an account? Sign In",
-    "registerEmailRequired": "Please enter your email address",
-    "registerEmailError": "Could not start registration. Please try again.",
-    "registerCodeRequired": "Please enter the verification code",
-    "registerCodeError": "Invalid verification code. Please try again.",
-    "registerPasswordRequired": "Please enter a password",
-    "registerPasswordMismatch": "Passwords do not match",
-    "homeLogout": "Sign Out",
-    "homeNoBudgets": "No Budgets Yet",
-    "homeCreateBudget": "Create Your First Budget",
-    "homeLoadError": "Could not load budgets",
-    "homeRetry": "Retry",
-    "homeBudgetCount": "{count, plural, =1{1 budget} other{{count} budgets}}",
-    "@homeBudgetCount": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "createBudgetTitle": "Create Budget",
-    "createBudgetNameLabel": "Budget Name",
-    "createBudgetCurrencyLabel": "Primary Currency",
-    "createBudgetButton": "Create",
-    "budgetEmptyTitle": "No Categories Yet",
-    "budgetEmptySubtitle": "Add your first envelope category to start budgeting",
-    "budgetReadyToAssign": "Ready to Assign",
-    "budgetColumnBudgeted": "Budgeted",
-    "budgetColumnSpent": "Spent",
-    "budgetColumnAvailable": "Available",
-    "budgetAddCategory": "Add Category",
-    "budgetAddEnvelope": "Add Envelope",
-    "budgetAddIncome": "Add Income",
-    "budgetAddExpense": "Add Expense",
-    "budgetCategoryTotal": "Total",
-    "budgetCategoryNameLabel": "Category Name",
-    "budgetEnvelopeNameLabel": "Envelope Name",
-    "budgetEnvelopeAmountLabel": "Budgeted Amount",
-    "budgetLoadError": "Could not load budget details",
-    "dialogSave": "Save",
-    "dialogSaving": "Saving...",
-    "dialogCancel": "Cancel",
-    "transactionAddIncome": "Add Income",
-    "transactionAddExpense": "Add Expense",
-    "transactionDescriptionLabel": "Description",
-    "transactionAmountLabel": "Amount",
-    "transactionSave": "Save Transaction",
-    "transactionSubmitting": "Saving...",
-    "transactionUnassigned": "Unassigned",
-    "transactionListTitle": "Transactions",
-    "transactionLoadError": "Could not load transactions",
-    "transactionEmpty": "No transactions yet",
-    "createBudgetCreating": "Creating...",
-    "createBudgetSuccess": "Budget created successfully",
-    "createBudgetError": "Could not create budget. Please try again.",
-    "budgetCategoryCreated": "Category created",
-    "budgetEnvelopeCreated": "Envelope created",
-    "budgetCategoryCreateError": "Could not create category",
-    "budgetEnvelopeCreateError": "Could not create envelope",
-    "transactionSuccess": "Transaction saved",
-    "transactionError": "Could not save transaction. Please try again.",
-    "deleteConfirmTitle": "Delete",
-    "deleteConfirmMessage": "Are you sure you want to delete this?",
-    "deleteConfirmButton": "Delete",
-    "deleteSuccess": "Deleted successfully",
-    "deleteError": "Could not delete. Please try again.",
-    "editEnvelopeTitle": "Edit Envelope",
-    "editEnvelopeSaved": "Envelope updated",
-    "editEnvelopeError": "Could not update envelope",
-    "accountListTitle": "Accounts",
-    "accountLoadError": "Could not load accounts",
-    "accountEmptyTitle": "No Accounts Yet",
-    "accountEmptySubtitle": "Add your first account to track balances",
-    "accountAddTitle": "Add Account",
-    "accountAddButton": "Add Account",
-    "accountNameLabel": "Account Name",
-    "accountTypeLabel": "Account Type",
-    "accountBalanceLabel": "Starting Balance",
-    "accountOnBudgetLabel": "On Budget",
-    "accountOnBudgetHint": "Include in budget calculations",
-    "accountTypeChecking": "Checking",
-    "accountTypeSavings": "Savings",
-    "accountTypeCreditCard": "Credit Card",
-    "accountTypeCash": "Cash",
-    "accountTypeInvestment": "Investment",
-    "accountTypeOther": "Other",
-    "accountOnBudget": "Budget Accounts",
-    "accountOffBudget": "Tracking Accounts",
-    "accountClosed": "Closed Accounts",
-    "accountCreateSuccess": "Account created",
-    "accountCreateError": "Could not create account. Please try again.",
-    "budgetViewAccounts": "Accounts",
-    "transactionEditTitle": "Edit Transaction",
-    "transactionEditSuccess": "Transaction updated",
-    "transactionEditError": "Could not update transaction. Please try again.",
-    "budgetMonthJanuary": "January",
-    "budgetMonthFebruary": "February",
-    "budgetMonthMarch": "March",
-    "budgetMonthApril": "April",
-    "budgetMonthMay": "May",
-    "budgetMonthJune": "June",
-    "budgetMonthJuly": "July",
-    "budgetMonthAugust": "August",
-    "budgetMonthSeptember": "September",
-    "budgetMonthOctober": "October",
-    "budgetMonthNovember": "November",
-    "budgetMonthDecember": "December",
-    "budgetAllocationUpdated": "Allocation updated",
-    "budgetAllocationError": "Could not update allocation",
-    "transactionSearchHint": "Search transactions...",
-    "transactionFilterAll": "All",
-    "transactionFilterIncome": "Income",
-    "transactionFilterExpense": "Expense",
-    "transactionNoResults": "No matching transactions",
-    "transactionResultCount": "{count, plural, =1{1 result} other{{count} results}}",
-    "@transactionResultCount": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "payeeListTitle": "Payees",
-    "payeeLoadError": "Could not load payees",
-    "payeeEmptyTitle": "No Payees Yet",
-    "payeeEmptySubtitle": "Add payees to track who you transact with",
-    "payeeAddButton": "Add Payee",
-    "payeeNameLabel": "Payee Name",
-    "payeeCreateSuccess": "Payee created",
-    "payeeCreateError": "Could not create payee. Please try again.",
-    "payeeEditTitle": "Edit Payee",
-    "payeeEditSuccess": "Payee updated",
-    "payeeEditError": "Could not update payee. Please try again.",
-    "goalSetTitle": "Set Goal",
-    "goalTypeLabel": "Goal Type",
-    "goalTypeBalance": "Balance",
-    "goalTypeByDate": "By Date",
-    "goalTypeMonthly": "Monthly",
-    "goalAmountLabel": "Target Amount",
-    "goalDateLabel": "Target Date",
-    "goalDateSelect": "Select a date",
-    "goalSaved": "Goal saved",
-    "goalRemoved": "Goal removed",
-    "goalRemove": "Remove Goal",
-    "goalError": "Could not save goal. Please try again.",
-    "goalSetGoal": "Set Goal",
-    "transferTitle": "Transfer",
-    "transferFromAccount": "From Account",
-    "transferToAccount": "To Account",
-    "transferDate": "Transfer Date",
-    "transferButton": "Transfer",
-    "transferDefaultDescription": "Account Transfer",
-    "transferSuccess": "Transfer completed",
-    "transferError": "Could not complete transfer. Please try again.",
-    "transferSameAccountError": "Cannot transfer to the same account",
-    "transferNeedTwoAccounts": "You need at least two accounts to make a transfer",
-    "reportsTitle": "Reports",
-    "reportsLoadError": "Could not load report data",
-    "reportsIncome": "Income",
-    "reportsExpenses": "Expenses",
-    "reportsNetIncome": "Net Income",
-    "reportsTransactions": "Transactions",
-    "reportsSpendingByCategory": "Spending by Category",
-    "reportsEmptyTitle": "No Data Yet",
-    "reportsEmptySubtitle": "Add transactions to see spending reports for this month",
-    "moveMoneyTitle": "Move Money",
-    "moveMoneyFrom": "From Envelope",
-    "moveMoneyTo": "To Envelope",
-    "moveMoneyButton": "Move",
-    "moveMoneySuccess": "Money moved between envelopes",
-    "moveMoneyError": "Could not move money. Please try again.",
-    "moveMoneySameError": "Cannot move money to the same envelope",
-    "creditCardPaymentsTitle": "Credit Card Payments",
-    "creditCardSpentThisMonth": "Spent this month",
-    "accountDetailBalance": "Balance",
-    "transactionUncleared": "Uncleared",
-    "transactionCleared": "Cleared",
-    "transactionReconciled": "Reconciled",
-    "reconcileTitle": "Reconcile Account",
-    "reconcileMessage": "Mark all cleared transactions as reconciled? This locks them from further editing.",
-    "reconcileButton": "Reconcile",
-    "reconcileSuccess": "{count, plural, =0{No transactions to reconcile} =1{1 transaction reconciled} other{{count} transactions reconciled}}",
-    "@reconcileSuccess": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "reconcileError": "Could not reconcile account. Please try again.",
-    "recurringListTitle": "Recurring Transactions",
-    "recurringLoadError": "Could not load recurring transactions",
-    "recurringEmptyTitle": "No Recurring Transactions",
-    "recurringEmptySubtitle": "Set up recurring transactions for bills, subscriptions, and regular income",
-    "recurringAddButton": "Add Recurring",
-    "recurringAddTitle": "Add Recurring Transaction",
-    "recurringEditTitle": "Edit Recurring Transaction",
-    "recurringFrequencyLabel": "Frequency",
-    "recurringFreqDaily": "Daily",
-    "recurringFreqWeekly": "Weekly",
-    "recurringFreqBiweekly": "Biweekly",
-    "recurringFreqMonthly": "Monthly",
-    "recurringFreqYearly": "Yearly",
-    "recurringStartDate": "Start Date",
-    "recurringNextDate": "Next",
-    "recurringCreateSuccess": "Recurring transaction created",
-    "recurringCreateError": "Could not create recurring transaction. Please try again.",
-    "recurringEditSuccess": "Recurring transaction updated",
-    "recurringEditError": "Could not update recurring transaction. Please try again.",
-    "ageOfMoneyLabel": "{days, plural, =1{Age of Money: 1 day} other{Age of Money: {days} days}}",
-    "@ageOfMoneyLabel": {
-        "placeholders": {
-            "days": {
-                "type": "int"
-            }
-        }
-    },
-    "quickBudgetTitle": "Quick Budget",
-    "quickBudgetLastMonth": "Budgeted Last Month",
-    "quickBudgetSpentLastMonth": "Spent Last Month",
-    "quickBudgetAverageBudgeted": "Average Budgeted",
-    "quickBudgetAverageSpent": "Average Spent",
-    "quickBudgetError": "Could not load budget suggestions",
-    "splitTransactionTitle": "Split Transaction",
-    "splitAddSplit": "Add Split",
-    "splitRemoveSplit": "Remove",
-    "splitEnvelopeLabel": "Envelope",
-    "splitAmountLabel": "Amount",
-    "splitMemoLabel": "Memo (optional)",
-    "splitRemainingLabel": "Remaining to assign",
-    "splitMismatchError": "Split amounts must equal the total",
-    "splitMinimumError": "At least two splits are required",
-    "splitSaveSuccess": "Split transaction saved",
-    "splitSaveError": "Could not save split transaction. Please try again.",
-    "splitLabel": "Split",
-    "splitCount": "{count, plural, =1{1 split} other{{count} splits}}",
-    "@splitCount": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "payeeNone": "No Payee",
-    "payeeLabel": "Payee",
-    "payeeAutoEnvelopeHint": "Envelope auto-suggested from last transaction with this payee",
-    "accountRunningBalance": "Running Balance",
-    "budgetOverspentWarning": "Overspent: {amount}",
-    "@budgetOverspentWarning": {
-        "placeholders": {
-            "amount": {
-                "type": "String"
-            }
-        }
-    },
-    "importTitle": "Import Transactions",
-    "importInstructions": "Paste CSV data with columns for date, description, and amount. Headers are auto-detected.",
-    "importCsvLabel": "CSV Data",
-    "importCsvHint": "Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00",
-    "importPreview": "Preview",
-    "importPreviewCount": "{count, plural, =1{1 transaction to import} other{{count} transactions to import}}",
-    "@importPreviewCount": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "importButton": "{count, plural, =1{Import 1 Transaction} other{Import {count} Transactions}}",
-    "@importButton": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "importImporting": "Importing...",
-    "importSuccess": "{count, plural, =1{1 transaction imported} other{{count} transactions imported}}",
-    "@importSuccess": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "importError": "Could not import transactions. Please try again.",
-    "importMoreRows": "{count, plural, =1{...and 1 more row} other{...and {count} more rows}}",
-    "@importMoreRows": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "recurringDueBanner": "{count, plural, =1{1 scheduled transaction is due} other{{count} scheduled transactions are due}}",
-    "@recurringDueBanner": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "recurringPostDue": "Post Now",
-    "recurringPosting": "Posting...",
-    "recurringPostSuccess": "{count, plural, =1{1 transaction posted} other{{count} transactions posted}}",
-    "@recurringPostSuccess": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "recurringPostError": "Could not post scheduled transactions. Please try again.",
-    "autoAssignTitle": "Auto-Assign",
-    "autoAssignButton": "Auto-Assign",
-    "autoAssignAssigning": "Assigning...",
-    "autoAssignDistributing": "Distributing to underfunded envelopes",
-    "autoAssignNothingToAssign": "All envelopes with goals are fully funded!",
-    "autoAssignEnvelopeCount": "{count, plural, =1{1 envelope} other{{count} envelopes}}",
-    "@autoAssignEnvelopeCount": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "autoAssignSuccess": "{count, plural, =1{Auto-assigned to 1 envelope} other{Auto-assigned to {count} envelopes}}",
-    "@autoAssignSuccess": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "autoAssignError": "Could not auto-assign. Please try again.",
-    "envelopeActivityTitle": "Activity",
-    "envelopeNoActivity": "No transactions this month",
-    "netWorthTitle": "Net Worth",
-    "netWorthAssets": "Assets",
-    "netWorthLiabilities": "Liabilities",
-    "netWorthLoadError": "Could not load net worth data",
-    "netWorthEmptyTitle": "No Accounts Yet",
-    "netWorthEmptySubtitle": "Add accounts to see your net worth breakdown",
-    "spendingTrendsTitle": "Spending Trends",
-    "spendingTrendsLoadError": "Could not load spending trends",
-    "spendingTrendsEmptyTitle": "No Spending Data",
-    "spendingTrendsEmptySubtitle": "Add transactions to see spending trends over time",
-    "spendingTrendsAvgIncome": "Avg. Income",
-    "spendingTrendsAvgExpenses": "Avg. Expenses",
-    "spendingTrendsMonthly": "Monthly Comparison",
-    "spendingTrendsBreakdown": "Monthly Breakdown",
-    "budgetEditCategoryTitle": "Rename Category",
-    "budgetEditCategorySuccess": "Category renamed",
-    "budgetEditCategoryError": "Could not rename category. Please try again.",
-    "budgetReorderCategories": "Reorder Categories",
-    "budgetReorderDone": "Done",
-    "budgetReorderHint": "Drag to reorder categories",
-    "budgetReorderSuccess": "Categories reordered",
-    "budgetReorderError": "Could not reorder categories",
-    "transactionMemoLabel": "Memo",
-    "transactionMemoHint": "Add a note (optional)",
-    "accountEditTitle": "Edit Account",
-    "accountEditSuccess": "Account updated",
-    "accountEditError": "Could not update account. Please try again.",
-    "accountCloseButton": "Close Account",
-    "accountCloseConfirm": "Close this account? It will be moved to Closed Accounts.",
-    "accountCloseSuccess": "Account closed",
-    "accountReopenButton": "Reopen Account",
-    "accountReopenSuccess": "Account reopened",
-    "budgetDeleteTitle": "Delete Budget",
-    "budgetDeleteConfirm": "Delete \"{name}\"? This will permanently remove the budget and all its data.",
-    "@budgetDeleteConfirm": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
-    "budgetDeleteButton": "Delete",
-    "budgetDeleteSuccess": "Budget deleted",
-    "budgetDeleteError": "Could not delete budget. Please try again.",
-    "settingsTitle": "Settings",
-    "settingsLoadError": "Could not load settings",
-    "settingsBudgetSection": "Budget",
-    "settingsBudgetName": "Budget Name",
-    "settingsCurrency": "Currency",
-    "settingsNavigationSection": "Quick Access",
-    "settingsAccountSection": "Account",
-    "settingsRenameBudget": "Rename Budget",
-    "settingsRenameSuccess": "Budget renamed",
-    "settingsRenameError": "Could not rename budget. Please try again.",
-    "settingsLogoutConfirm": "Are you sure you want to sign out?",
-    "settingsVersion": "OpenBudget v1.0.0",
-    "homeBudgetAccounts": "{count, plural, =1{1 account} other{{count} accounts}}",
-    "@homeBudgetAccounts": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "homeBudgetTotalBalance": "Total Balance",
-    "payeeSearchHint": "Search payees...",
-    "payeeSearchNoResults": "No matching payees",
-    "payeeSearchResultCount": "{count, plural, =1{1 payee} other{{count} payees}}",
-    "@payeeSearchResultCount": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "transactionExportCsv": "Copy as CSV",
-    "transactionExportSuccess": "{count, plural, =1{1 transaction copied to clipboard} other{{count} transactions copied to clipboard}}",
-    "@transactionExportSuccess": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "themeTitle": "Appearance",
-    "themeSystem": "System",
-    "themeLight": "Light",
-    "themeDark": "Dark",
-    "transactionDateToday": "Today",
-    "transactionDateYesterday": "Yesterday",
-    "spendingByPayeeTitle": "Spending by Payee",
-    "spendingByPayeeEmptyTitle": "No Payee Data",
-    "spendingByPayeeEmptySubtitle": "Add expense transactions to see spending by payee",
-    "spendingByPayeeTotalSpent": "Total Spent",
-    "spendingByPayeePayeeCount": "Payees",
-    "spendingByPayeeBreakdown": "Spending Breakdown",
-    "spendingByPayeeTransactionCount": "{count, plural, =1{1 transaction} other{{count} transactions}}",
-    "@spendingByPayeeTransactionCount": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "budgetGoToToday": "Back to Today",
-    "categoryTrendsTitle": "Category Trends",
-    "categoryTrendsLoadError": "Could not load category trends",
-    "categoryTrendsEmptyTitle": "No Category Data",
-    "categoryTrendsEmptySubtitle": "Add categorized transactions to see spending trends by category",
-    "recurringDueLabel": "Due now",
-    "recurringSkipButton": "Skip",
-    "recurringSkipSuccess": "Occurrence skipped",
-    "recurringSkipError": "Could not skip occurrence. Please try again.",
-    "settingsDataSection": "Data",
-    "settingsExportData": "Export Budget",
-    "settingsExportDataHint": "Copy all budget data as JSON to clipboard",
-    "settingsExportSuccess": "Budget data copied to clipboard",
-    "settingsExportError": "Could not export budget data. Please try again.",
-    "envelopeReorderHint": "Long press an envelope to reorder within category",
-    "templateTitle": "Budget Templates",
-    "templateSaveButton": "Save Current Month as Template",
-    "templateNameLabel": "Template Name",
-    "templateNameHint": "e.g. Standard Month",
-    "templateSaveSuccess": "Template saved",
-    "templateSaveError": "Could not save template. Please try again.",
-    "templateApplyButton": "Apply",
-    "templateApplySuccess": "Template applied to current month",
-    "templateApplyError": "Could not apply template. Please try again.",
-    "templateDeleteSuccess": "Template deleted",
-    "templateDeleteError": "Could not delete template. Please try again.",
-    "templateEmptyTitle": "No Templates",
-    "templateEmptySubtitle": "Save your current month allocations as a template to quickly set up future months.",
-    "duplicateWarning": "{count, plural, =1{Possible duplicate: 1 similar transaction found} other{Possible duplicates: {count} similar transactions found}}",
-    "@duplicateWarning": {
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
+  "@@locale": "en",
+  "@ageOfMoneyLabel": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
     }
+  },
+  "@autoAssignEnvelopeCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@autoAssignSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@budgetDeleteConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@budgetOverspentWarning": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
+  "@duplicateWarning": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@homeBudgetAccounts": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@homeBudgetCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@importButton": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@importMoreRows": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@importPreviewCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@importSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@payeeSearchResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@reconcileSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@recurringDueBanner": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@recurringPostSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@spendingByPayeeTransactionCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@splitCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@transactionExportSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@transactionResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "accountAddButton": "Add Account",
+  "accountAddTitle": "Add Account",
+  "accountBalanceLabel": "Starting Balance",
+  "accountCloseButton": "Close Account",
+  "accountCloseConfirm": "Close this account? It will be moved to Closed Accounts.",
+  "accountCloseSuccess": "Account closed",
+  "accountClosed": "Closed Accounts",
+  "accountCreateError": "Could not create account. Please try again.",
+  "accountCreateSuccess": "Account created",
+  "accountDetailBalance": "Balance",
+  "accountEditError": "Could not update account. Please try again.",
+  "accountEditSuccess": "Account updated",
+  "accountEditTitle": "Edit Account",
+  "accountEmptySubtitle": "Add your first account to track balances",
+  "accountEmptyTitle": "No Accounts Yet",
+  "accountListTitle": "Accounts",
+  "accountLoadError": "Could not load accounts",
+  "accountNameLabel": "Account Name",
+  "accountOffBudget": "Tracking Accounts",
+  "accountOnBudget": "Budget Accounts",
+  "accountOnBudgetHint": "Include in budget calculations",
+  "accountOnBudgetLabel": "On Budget",
+  "accountReopenButton": "Reopen Account",
+  "accountReopenSuccess": "Account reopened",
+  "accountRunningBalance": "Running Balance",
+  "accountTypeCash": "Cash",
+  "accountTypeChecking": "Checking",
+  "accountTypeCreditCard": "Credit Card",
+  "accountTypeInvestment": "Investment",
+  "accountTypeLabel": "Account Type",
+  "accountTypeOther": "Other",
+  "accountTypeSavings": "Savings",
+  "ageOfMoneyLabel": "{days, plural, =1{Age of Money: 1 day} other{Age of Money: {days} days}}",
+  "appTitle": "OpenBudget",
+  "autoAssignAssigning": "Assigning...",
+  "autoAssignButton": "Auto-Assign",
+  "autoAssignDistributing": "Distributing to underfunded envelopes",
+  "autoAssignEnvelopeCount": "{count, plural, =1{1 envelope} other{{count} envelopes}}",
+  "autoAssignError": "Could not auto-assign. Please try again.",
+  "autoAssignNothingToAssign": "All envelopes with goals are fully funded!",
+  "autoAssignSuccess": "{count, plural, =1{Auto-assigned to 1 envelope} other{Auto-assigned to {count} envelopes}}",
+  "autoAssignTitle": "Auto-Assign",
+  "budgetAddCategory": "Add Category",
+  "budgetAddEnvelope": "Add Envelope",
+  "budgetAddExpense": "Add Expense",
+  "budgetAddIncome": "Add Income",
+  "budgetAllocationError": "Could not update allocation",
+  "budgetAllocationUpdated": "Allocation updated",
+  "budgetCategoryCreateError": "Could not create category",
+  "budgetCategoryCreated": "Category created",
+  "budgetCategoryNameLabel": "Category Name",
+  "budgetCategoryTotal": "Total",
+  "budgetColumnAvailable": "Available",
+  "budgetColumnBudgeted": "Budgeted",
+  "budgetColumnSpent": "Spent",
+  "budgetCopyLastMonth": "Copy Last Month",
+  "budgetCopyLastMonthConfirm": "Copy all budget allocations from last month to the current month? This will overwrite any existing allocations.",
+  "budgetCopyLastMonthError": "Could not copy previous month. Please try again.",
+  "budgetCopyLastMonthSuccess": "Allocations copied from previous month",
+  "budgetDeleteButton": "Delete",
+  "budgetDeleteConfirm": "Delete \"{name}\"? This will permanently remove the budget and all its data.",
+  "budgetDeleteError": "Could not delete budget. Please try again.",
+  "budgetDeleteSuccess": "Budget deleted",
+  "budgetDeleteTitle": "Delete Budget",
+  "budgetEditCategoryError": "Could not rename category. Please try again.",
+  "budgetEditCategorySuccess": "Category renamed",
+  "budgetEditCategoryTitle": "Rename Category",
+  "budgetEmptySubtitle": "Add your first envelope category to start budgeting",
+  "budgetEmptyTitle": "No Categories Yet",
+  "budgetEnvelopeAmountLabel": "Budgeted Amount",
+  "budgetEnvelopeCreateError": "Could not create envelope",
+  "budgetEnvelopeCreated": "Envelope created",
+  "budgetEnvelopeNameLabel": "Envelope Name",
+  "budgetGoToToday": "Back to Today",
+  "budgetLoadError": "Could not load budget details",
+  "budgetMonthApril": "April",
+  "budgetMonthAugust": "August",
+  "budgetMonthDecember": "December",
+  "budgetMonthFebruary": "February",
+  "budgetMonthJanuary": "January",
+  "budgetMonthJuly": "July",
+  "budgetMonthJune": "June",
+  "budgetMonthMarch": "March",
+  "budgetMonthMay": "May",
+  "budgetMonthNovember": "November",
+  "budgetMonthOctober": "October",
+  "budgetMonthSeptember": "September",
+  "budgetOverspentWarning": "Overspent: {amount}",
+  "budgetReadyToAssign": "Ready to Assign",
+  "budgetReorderCategories": "Reorder Categories",
+  "budgetReorderDone": "Done",
+  "budgetReorderError": "Could not reorder categories",
+  "budgetReorderHint": "Drag to reorder categories",
+  "budgetReorderSuccess": "Categories reordered",
+  "budgetViewAccounts": "Accounts",
+  "categoryTrendsEmptySubtitle": "Add categorized transactions to see spending trends by category",
+  "categoryTrendsEmptyTitle": "No Category Data",
+  "categoryTrendsLoadError": "Could not load category trends",
+  "categoryTrendsTitle": "Category Trends",
+  "createBudgetButton": "Create",
+  "createBudgetCreating": "Creating...",
+  "createBudgetCurrencyLabel": "Primary Currency",
+  "createBudgetError": "Could not create budget. Please try again.",
+  "createBudgetNameLabel": "Budget Name",
+  "createBudgetSuccess": "Budget created successfully",
+  "createBudgetTitle": "Create Budget",
+  "creditCardPaymentsTitle": "Credit Card Payments",
+  "creditCardSpentThisMonth": "Spent this month",
+  "deleteConfirmButton": "Delete",
+  "deleteConfirmMessage": "Are you sure you want to delete this?",
+  "deleteConfirmTitle": "Delete",
+  "deleteError": "Could not delete. Please try again.",
+  "deleteSuccess": "Deleted successfully",
+  "dialogCancel": "Cancel",
+  "dialogSave": "Save",
+  "dialogSaving": "Saving...",
+  "duplicateWarning": "{count, plural, =1{Possible duplicate: 1 similar transaction found} other{Possible duplicates: {count} similar transactions found}}",
+  "editEnvelopeError": "Could not update envelope",
+  "editEnvelopeSaved": "Envelope updated",
+  "editEnvelopeTitle": "Edit Envelope",
+  "envelopeActivityTitle": "Activity",
+  "envelopeNoActivity": "No transactions this month",
+  "envelopeReorderHint": "Long press an envelope to reorder within category",
+  "goalAmountLabel": "Target Amount",
+  "goalDateLabel": "Target Date",
+  "goalDateSelect": "Select a date",
+  "goalError": "Could not save goal. Please try again.",
+  "goalRemove": "Remove Goal",
+  "goalRemoved": "Goal removed",
+  "goalSaved": "Goal saved",
+  "goalSetGoal": "Set Goal",
+  "goalSetTitle": "Set Goal",
+  "goalTypeBalance": "Balance",
+  "goalTypeByDate": "By Date",
+  "goalTypeLabel": "Goal Type",
+  "goalTypeMonthly": "Monthly",
+  "homeBudgetAccounts": "{count, plural, =1{1 account} other{{count} accounts}}",
+  "homeBudgetCount": "{count, plural, =1{1 budget} other{{count} budgets}}",
+  "homeBudgetTotalBalance": "Total Balance",
+  "homeCreateBudget": "Create Your First Budget",
+  "homeLoadError": "Could not load budgets",
+  "homeLogout": "Sign Out",
+  "homeNoBudgets": "No Budgets Yet",
+  "homeRetry": "Retry",
+  "importButton": "{count, plural, =1{Import 1 Transaction} other{Import {count} Transactions}}",
+  "importCsvHint": "Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00",
+  "importCsvLabel": "CSV Data",
+  "importError": "Could not import transactions. Please try again.",
+  "importImporting": "Importing...",
+  "importInstructions": "Paste CSV data with columns for date, description, and amount. Headers are auto-detected.",
+  "importMoreRows": "{count, plural, =1{...and 1 more row} other{...and {count} more rows}}",
+  "importPreview": "Preview",
+  "importPreviewCount": "{count, plural, =1{1 transaction to import} other{{count} transactions to import}}",
+  "importSuccess": "{count, plural, =1{1 transaction imported} other{{count} transactions imported}}",
+  "importTitle": "Import Transactions",
+  "loginButton": "Sign In",
+  "loginCreateAccount": "Create Account",
+  "loginEmailLabel": "Email",
+  "loginLoading": "Signing In...",
+  "loginPasswordLabel": "Password",
+  "loginTitle": "Welcome to OpenBudget",
+  "moveMoneyButton": "Move",
+  "moveMoneyError": "Could not move money. Please try again.",
+  "moveMoneyFrom": "From Envelope",
+  "moveMoneySameError": "Cannot move money to the same envelope",
+  "moveMoneySuccess": "Money moved between envelopes",
+  "moveMoneyTitle": "Move Money",
+  "moveMoneyTo": "To Envelope",
+  "netWorthAssets": "Assets",
+  "netWorthEmptySubtitle": "Add accounts to see your net worth breakdown",
+  "netWorthEmptyTitle": "No Accounts Yet",
+  "netWorthLiabilities": "Liabilities",
+  "netWorthLoadError": "Could not load net worth data",
+  "netWorthTitle": "Net Worth",
+  "payeeAddButton": "Add Payee",
+  "payeeAutoEnvelopeHint": "Envelope auto-suggested from last transaction with this payee",
+  "payeeCreateError": "Could not create payee. Please try again.",
+  "payeeCreateSuccess": "Payee created",
+  "payeeEditError": "Could not update payee. Please try again.",
+  "payeeEditSuccess": "Payee updated",
+  "payeeEditTitle": "Edit Payee",
+  "payeeEmptySubtitle": "Add payees to track who you transact with",
+  "payeeEmptyTitle": "No Payees Yet",
+  "payeeLabel": "Payee",
+  "payeeListTitle": "Payees",
+  "payeeLoadError": "Could not load payees",
+  "payeeNameLabel": "Payee Name",
+  "payeeNone": "No Payee",
+  "payeeSearchHint": "Search payees...",
+  "payeeSearchNoResults": "No matching payees",
+  "payeeSearchResultCount": "{count, plural, =1{1 payee} other{{count} payees}}",
+  "quickBudgetAverageBudgeted": "Average Budgeted",
+  "quickBudgetAverageSpent": "Average Spent",
+  "quickBudgetError": "Could not load budget suggestions",
+  "quickBudgetLastMonth": "Budgeted Last Month",
+  "quickBudgetSpentLastMonth": "Spent Last Month",
+  "quickBudgetTitle": "Quick Budget",
+  "reconcileButton": "Reconcile",
+  "reconcileError": "Could not reconcile account. Please try again.",
+  "reconcileMessage": "Mark all cleared transactions as reconciled? This locks them from further editing.",
+  "reconcileSuccess": "{count, plural, =0{No transactions to reconcile} =1{1 transaction reconciled} other{{count} transactions reconciled}}",
+  "reconcileTitle": "Reconcile Account",
+  "recurringAddButton": "Add Recurring",
+  "recurringAddTitle": "Add Recurring Transaction",
+  "recurringCreateError": "Could not create recurring transaction. Please try again.",
+  "recurringCreateSuccess": "Recurring transaction created",
+  "recurringDueBanner": "{count, plural, =1{1 scheduled transaction is due} other{{count} scheduled transactions are due}}",
+  "recurringDueLabel": "Due now",
+  "recurringEditError": "Could not update recurring transaction. Please try again.",
+  "recurringEditSuccess": "Recurring transaction updated",
+  "recurringEditTitle": "Edit Recurring Transaction",
+  "recurringEmptySubtitle": "Set up recurring transactions for bills, subscriptions, and regular income",
+  "recurringEmptyTitle": "No Recurring Transactions",
+  "recurringFreqBiweekly": "Biweekly",
+  "recurringFreqDaily": "Daily",
+  "recurringFreqMonthly": "Monthly",
+  "recurringFreqWeekly": "Weekly",
+  "recurringFreqYearly": "Yearly",
+  "recurringFrequencyLabel": "Frequency",
+  "recurringListTitle": "Recurring Transactions",
+  "recurringLoadError": "Could not load recurring transactions",
+  "recurringNextDate": "Next",
+  "recurringPostDue": "Post Now",
+  "recurringPostError": "Could not post scheduled transactions. Please try again.",
+  "recurringPostSuccess": "{count, plural, =1{1 transaction posted} other{{count} transactions posted}}",
+  "recurringPosting": "Posting...",
+  "recurringSkipButton": "Skip",
+  "recurringSkipError": "Could not skip occurrence. Please try again.",
+  "recurringSkipSuccess": "Occurrence skipped",
+  "recurringStartDate": "Start Date",
+  "registerAlreadyHaveAccount": "Already have an account? Sign In",
+  "registerCodeError": "Invalid verification code. Please try again.",
+  "registerCodeLabel": "Verification Code",
+  "registerCodeRequired": "Please enter the verification code",
+  "registerConfirmPassword": "Confirm Password",
+  "registerCreateAccount": "Create Account",
+  "registerEmailError": "Could not start registration. Please try again.",
+  "registerEmailRequired": "Please enter your email address",
+  "registerPasswordMismatch": "Passwords do not match",
+  "registerPasswordRequired": "Please enter a password",
+  "registerSendCode": "Send Verification Code",
+  "registerStepCode": "Enter the verification code sent to your email",
+  "registerStepEmail": "Enter your email to get started",
+  "registerStepPassword": "Choose a password for your account",
+  "registerSubmitting": "Please wait...",
+  "registerTitle": "Create Account",
+  "registerVerifyCode": "Verify Code",
+  "reportsEmptySubtitle": "Add transactions to see spending reports for this month",
+  "reportsEmptyTitle": "No Data Yet",
+  "reportsExpenses": "Expenses",
+  "reportsIncome": "Income",
+  "reportsLoadError": "Could not load report data",
+  "reportsNetIncome": "Net Income",
+  "reportsSpendingByCategory": "Spending by Category",
+  "reportsTitle": "Reports",
+  "reportsTransactions": "Transactions",
+  "settingsAccountSection": "Account",
+  "settingsBudgetName": "Budget Name",
+  "settingsBudgetSection": "Budget",
+  "settingsCurrency": "Currency",
+  "settingsDataSection": "Data",
+  "settingsExportData": "Export Budget",
+  "settingsExportDataHint": "Copy all budget data as JSON to clipboard",
+  "settingsExportError": "Could not export budget data. Please try again.",
+  "settingsExportSuccess": "Budget data copied to clipboard",
+  "settingsLoadError": "Could not load settings",
+  "settingsLogoutConfirm": "Are you sure you want to sign out?",
+  "settingsNavigationSection": "Quick Access",
+  "settingsRenameBudget": "Rename Budget",
+  "settingsRenameError": "Could not rename budget. Please try again.",
+  "settingsRenameSuccess": "Budget renamed",
+  "settingsTitle": "Settings",
+  "settingsVersion": "OpenBudget v1.0.0",
+  "spendingByPayeeBreakdown": "Spending Breakdown",
+  "spendingByPayeeEmptySubtitle": "Add expense transactions to see spending by payee",
+  "spendingByPayeeEmptyTitle": "No Payee Data",
+  "spendingByPayeePayeeCount": "Payees",
+  "spendingByPayeeTitle": "Spending by Payee",
+  "spendingByPayeeTotalSpent": "Total Spent",
+  "spendingByPayeeTransactionCount": "{count, plural, =1{1 transaction} other{{count} transactions}}",
+  "spendingTrendsAvgExpenses": "Avg. Expenses",
+  "spendingTrendsAvgIncome": "Avg. Income",
+  "spendingTrendsBreakdown": "Monthly Breakdown",
+  "spendingTrendsEmptySubtitle": "Add transactions to see spending trends over time",
+  "spendingTrendsEmptyTitle": "No Spending Data",
+  "spendingTrendsLoadError": "Could not load spending trends",
+  "spendingTrendsMonthly": "Monthly Comparison",
+  "spendingTrendsTitle": "Spending Trends",
+  "splitAddSplit": "Add Split",
+  "splitAmountLabel": "Amount",
+  "splitCount": "{count, plural, =1{1 split} other{{count} splits}}",
+  "splitEnvelopeLabel": "Envelope",
+  "splitLabel": "Split",
+  "splitMemoLabel": "Memo (optional)",
+  "splitMinimumError": "At least two splits are required",
+  "splitMismatchError": "Split amounts must equal the total",
+  "splitRemainingLabel": "Remaining to assign",
+  "splitRemoveSplit": "Remove",
+  "splitSaveError": "Could not save split transaction. Please try again.",
+  "splitSaveSuccess": "Split transaction saved",
+  "splitTransactionTitle": "Split Transaction",
+  "templateApplyButton": "Apply",
+  "templateApplyError": "Could not apply template. Please try again.",
+  "templateApplySuccess": "Template applied to current month",
+  "templateDeleteError": "Could not delete template. Please try again.",
+  "templateDeleteSuccess": "Template deleted",
+  "templateEmptySubtitle": "Save your current month allocations as a template to quickly set up future months.",
+  "templateEmptyTitle": "No Templates",
+  "templateNameHint": "e.g. Standard Month",
+  "templateNameLabel": "Template Name",
+  "templateSaveButton": "Save Current Month as Template",
+  "templateSaveError": "Could not save template. Please try again.",
+  "templateSaveSuccess": "Template saved",
+  "templateTitle": "Budget Templates",
+  "themeDark": "Dark",
+  "themeLight": "Light",
+  "themeSystem": "System",
+  "themeTitle": "Appearance",
+  "transactionAddExpense": "Add Expense",
+  "transactionAddIncome": "Add Income",
+  "transactionAmountLabel": "Amount",
+  "transactionCleared": "Cleared",
+  "transactionDateToday": "Today",
+  "transactionDateYesterday": "Yesterday",
+  "transactionDescriptionLabel": "Description",
+  "transactionEditError": "Could not update transaction. Please try again.",
+  "transactionEditSuccess": "Transaction updated",
+  "transactionEditTitle": "Edit Transaction",
+  "transactionEmpty": "No transactions yet",
+  "transactionError": "Could not save transaction. Please try again.",
+  "transactionExportCsv": "Copy as CSV",
+  "transactionExportSuccess": "{count, plural, =1{1 transaction copied to clipboard} other{{count} transactions copied to clipboard}}",
+  "transactionFilterAll": "All",
+  "transactionFilterExpense": "Expense",
+  "transactionFilterIncome": "Income",
+  "transactionListTitle": "Transactions",
+  "transactionLoadError": "Could not load transactions",
+  "transactionMemoHint": "Add a note (optional)",
+  "transactionMemoLabel": "Memo",
+  "transactionNoResults": "No matching transactions",
+  "transactionReconciled": "Reconciled",
+  "transactionResultCount": "{count, plural, =1{1 result} other{{count} results}}",
+  "transactionSave": "Save Transaction",
+  "transactionSearchHint": "Search transactions...",
+  "transactionSubmitting": "Saving...",
+  "transactionSuccess": "Transaction saved",
+  "transactionUnassigned": "Unassigned",
+  "transactionUncleared": "Uncleared",
+  "transferButton": "Transfer",
+  "transferDate": "Transfer Date",
+  "transferDefaultDescription": "Account Transfer",
+  "transferError": "Could not complete transfer. Please try again.",
+  "transferFromAccount": "From Account",
+  "transferNeedTwoAccounts": "You need at least two accounts to make a transfer",
+  "transferSameAccountError": "Cannot transfer to the same account",
+  "transferSuccess": "Transfer completed",
+  "transferTitle": "Transfer",
+  "transferToAccount": "To Account"
 }

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -94,503 +94,11 @@ abstract class AppLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[Locale('en')];
 
-  /// No description provided for @appTitle.
+  /// No description provided for @accountAddButton.
   ///
   /// In en, this message translates to:
-  /// **'OpenBudget'**
-  String get appTitle;
-
-  /// No description provided for @loginTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Welcome to OpenBudget'**
-  String get loginTitle;
-
-  /// No description provided for @loginEmailLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Email'**
-  String get loginEmailLabel;
-
-  /// No description provided for @loginPasswordLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Password'**
-  String get loginPasswordLabel;
-
-  /// No description provided for @loginButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Sign In'**
-  String get loginButton;
-
-  /// No description provided for @loginLoading.
-  ///
-  /// In en, this message translates to:
-  /// **'Signing In...'**
-  String get loginLoading;
-
-  /// No description provided for @loginCreateAccount.
-  ///
-  /// In en, this message translates to:
-  /// **'Create Account'**
-  String get loginCreateAccount;
-
-  /// No description provided for @registerTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Create Account'**
-  String get registerTitle;
-
-  /// No description provided for @registerStepEmail.
-  ///
-  /// In en, this message translates to:
-  /// **'Enter your email to get started'**
-  String get registerStepEmail;
-
-  /// No description provided for @registerStepCode.
-  ///
-  /// In en, this message translates to:
-  /// **'Enter the verification code sent to your email'**
-  String get registerStepCode;
-
-  /// No description provided for @registerStepPassword.
-  ///
-  /// In en, this message translates to:
-  /// **'Choose a password for your account'**
-  String get registerStepPassword;
-
-  /// No description provided for @registerSendCode.
-  ///
-  /// In en, this message translates to:
-  /// **'Send Verification Code'**
-  String get registerSendCode;
-
-  /// No description provided for @registerCodeLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Verification Code'**
-  String get registerCodeLabel;
-
-  /// No description provided for @registerVerifyCode.
-  ///
-  /// In en, this message translates to:
-  /// **'Verify Code'**
-  String get registerVerifyCode;
-
-  /// No description provided for @registerConfirmPassword.
-  ///
-  /// In en, this message translates to:
-  /// **'Confirm Password'**
-  String get registerConfirmPassword;
-
-  /// No description provided for @registerCreateAccount.
-  ///
-  /// In en, this message translates to:
-  /// **'Create Account'**
-  String get registerCreateAccount;
-
-  /// No description provided for @registerSubmitting.
-  ///
-  /// In en, this message translates to:
-  /// **'Please wait...'**
-  String get registerSubmitting;
-
-  /// No description provided for @registerAlreadyHaveAccount.
-  ///
-  /// In en, this message translates to:
-  /// **'Already have an account? Sign In'**
-  String get registerAlreadyHaveAccount;
-
-  /// No description provided for @registerEmailRequired.
-  ///
-  /// In en, this message translates to:
-  /// **'Please enter your email address'**
-  String get registerEmailRequired;
-
-  /// No description provided for @registerEmailError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not start registration. Please try again.'**
-  String get registerEmailError;
-
-  /// No description provided for @registerCodeRequired.
-  ///
-  /// In en, this message translates to:
-  /// **'Please enter the verification code'**
-  String get registerCodeRequired;
-
-  /// No description provided for @registerCodeError.
-  ///
-  /// In en, this message translates to:
-  /// **'Invalid verification code. Please try again.'**
-  String get registerCodeError;
-
-  /// No description provided for @registerPasswordRequired.
-  ///
-  /// In en, this message translates to:
-  /// **'Please enter a password'**
-  String get registerPasswordRequired;
-
-  /// No description provided for @registerPasswordMismatch.
-  ///
-  /// In en, this message translates to:
-  /// **'Passwords do not match'**
-  String get registerPasswordMismatch;
-
-  /// No description provided for @homeLogout.
-  ///
-  /// In en, this message translates to:
-  /// **'Sign Out'**
-  String get homeLogout;
-
-  /// No description provided for @homeNoBudgets.
-  ///
-  /// In en, this message translates to:
-  /// **'No Budgets Yet'**
-  String get homeNoBudgets;
-
-  /// No description provided for @homeCreateBudget.
-  ///
-  /// In en, this message translates to:
-  /// **'Create Your First Budget'**
-  String get homeCreateBudget;
-
-  /// No description provided for @homeLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load budgets'**
-  String get homeLoadError;
-
-  /// No description provided for @homeRetry.
-  ///
-  /// In en, this message translates to:
-  /// **'Retry'**
-  String get homeRetry;
-
-  /// No description provided for @homeBudgetCount.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 budget} other{{count} budgets}}'**
-  String homeBudgetCount(int count);
-
-  /// No description provided for @createBudgetTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Create Budget'**
-  String get createBudgetTitle;
-
-  /// No description provided for @createBudgetNameLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Budget Name'**
-  String get createBudgetNameLabel;
-
-  /// No description provided for @createBudgetCurrencyLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Primary Currency'**
-  String get createBudgetCurrencyLabel;
-
-  /// No description provided for @createBudgetButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Create'**
-  String get createBudgetButton;
-
-  /// No description provided for @budgetEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Categories Yet'**
-  String get budgetEmptyTitle;
-
-  /// No description provided for @budgetEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add your first envelope category to start budgeting'**
-  String get budgetEmptySubtitle;
-
-  /// No description provided for @budgetReadyToAssign.
-  ///
-  /// In en, this message translates to:
-  /// **'Ready to Assign'**
-  String get budgetReadyToAssign;
-
-  /// No description provided for @budgetColumnBudgeted.
-  ///
-  /// In en, this message translates to:
-  /// **'Budgeted'**
-  String get budgetColumnBudgeted;
-
-  /// No description provided for @budgetColumnSpent.
-  ///
-  /// In en, this message translates to:
-  /// **'Spent'**
-  String get budgetColumnSpent;
-
-  /// No description provided for @budgetColumnAvailable.
-  ///
-  /// In en, this message translates to:
-  /// **'Available'**
-  String get budgetColumnAvailable;
-
-  /// No description provided for @budgetAddCategory.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Category'**
-  String get budgetAddCategory;
-
-  /// No description provided for @budgetAddEnvelope.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Envelope'**
-  String get budgetAddEnvelope;
-
-  /// No description provided for @budgetAddIncome.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Income'**
-  String get budgetAddIncome;
-
-  /// No description provided for @budgetAddExpense.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Expense'**
-  String get budgetAddExpense;
-
-  /// No description provided for @budgetCategoryTotal.
-  ///
-  /// In en, this message translates to:
-  /// **'Total'**
-  String get budgetCategoryTotal;
-
-  /// No description provided for @budgetCategoryNameLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Category Name'**
-  String get budgetCategoryNameLabel;
-
-  /// No description provided for @budgetEnvelopeNameLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Envelope Name'**
-  String get budgetEnvelopeNameLabel;
-
-  /// No description provided for @budgetEnvelopeAmountLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Budgeted Amount'**
-  String get budgetEnvelopeAmountLabel;
-
-  /// No description provided for @budgetLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load budget details'**
-  String get budgetLoadError;
-
-  /// No description provided for @dialogSave.
-  ///
-  /// In en, this message translates to:
-  /// **'Save'**
-  String get dialogSave;
-
-  /// No description provided for @dialogSaving.
-  ///
-  /// In en, this message translates to:
-  /// **'Saving...'**
-  String get dialogSaving;
-
-  /// No description provided for @dialogCancel.
-  ///
-  /// In en, this message translates to:
-  /// **'Cancel'**
-  String get dialogCancel;
-
-  /// No description provided for @transactionAddIncome.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Income'**
-  String get transactionAddIncome;
-
-  /// No description provided for @transactionAddExpense.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Expense'**
-  String get transactionAddExpense;
-
-  /// No description provided for @transactionDescriptionLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Description'**
-  String get transactionDescriptionLabel;
-
-  /// No description provided for @transactionAmountLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Amount'**
-  String get transactionAmountLabel;
-
-  /// No description provided for @transactionSave.
-  ///
-  /// In en, this message translates to:
-  /// **'Save Transaction'**
-  String get transactionSave;
-
-  /// No description provided for @transactionSubmitting.
-  ///
-  /// In en, this message translates to:
-  /// **'Saving...'**
-  String get transactionSubmitting;
-
-  /// No description provided for @transactionUnassigned.
-  ///
-  /// In en, this message translates to:
-  /// **'Unassigned'**
-  String get transactionUnassigned;
-
-  /// No description provided for @transactionListTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Transactions'**
-  String get transactionListTitle;
-
-  /// No description provided for @transactionLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load transactions'**
-  String get transactionLoadError;
-
-  /// No description provided for @transactionEmpty.
-  ///
-  /// In en, this message translates to:
-  /// **'No transactions yet'**
-  String get transactionEmpty;
-
-  /// No description provided for @createBudgetCreating.
-  ///
-  /// In en, this message translates to:
-  /// **'Creating...'**
-  String get createBudgetCreating;
-
-  /// No description provided for @createBudgetSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Budget created successfully'**
-  String get createBudgetSuccess;
-
-  /// No description provided for @createBudgetError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not create budget. Please try again.'**
-  String get createBudgetError;
-
-  /// No description provided for @budgetCategoryCreated.
-  ///
-  /// In en, this message translates to:
-  /// **'Category created'**
-  String get budgetCategoryCreated;
-
-  /// No description provided for @budgetEnvelopeCreated.
-  ///
-  /// In en, this message translates to:
-  /// **'Envelope created'**
-  String get budgetEnvelopeCreated;
-
-  /// No description provided for @budgetCategoryCreateError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not create category'**
-  String get budgetCategoryCreateError;
-
-  /// No description provided for @budgetEnvelopeCreateError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not create envelope'**
-  String get budgetEnvelopeCreateError;
-
-  /// No description provided for @transactionSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Transaction saved'**
-  String get transactionSuccess;
-
-  /// No description provided for @transactionError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not save transaction. Please try again.'**
-  String get transactionError;
-
-  /// No description provided for @deleteConfirmTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Delete'**
-  String get deleteConfirmTitle;
-
-  /// No description provided for @deleteConfirmMessage.
-  ///
-  /// In en, this message translates to:
-  /// **'Are you sure you want to delete this?'**
-  String get deleteConfirmMessage;
-
-  /// No description provided for @deleteConfirmButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Delete'**
-  String get deleteConfirmButton;
-
-  /// No description provided for @deleteSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Deleted successfully'**
-  String get deleteSuccess;
-
-  /// No description provided for @deleteError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not delete. Please try again.'**
-  String get deleteError;
-
-  /// No description provided for @editEnvelopeTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Edit Envelope'**
-  String get editEnvelopeTitle;
-
-  /// No description provided for @editEnvelopeSaved.
-  ///
-  /// In en, this message translates to:
-  /// **'Envelope updated'**
-  String get editEnvelopeSaved;
-
-  /// No description provided for @editEnvelopeError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not update envelope'**
-  String get editEnvelopeError;
-
-  /// No description provided for @accountListTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Accounts'**
-  String get accountListTitle;
-
-  /// No description provided for @accountLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load accounts'**
-  String get accountLoadError;
-
-  /// No description provided for @accountEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Accounts Yet'**
-  String get accountEmptyTitle;
-
-  /// No description provided for @accountEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add your first account to track balances'**
-  String get accountEmptySubtitle;
+  /// **'Add Account'**
+  String get accountAddButton;
 
   /// No description provided for @accountAddTitle.
   ///
@@ -598,1199 +106,11 @@ abstract class AppLocalizations {
   /// **'Add Account'**
   String get accountAddTitle;
 
-  /// No description provided for @accountAddButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Account'**
-  String get accountAddButton;
-
-  /// No description provided for @accountNameLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Account Name'**
-  String get accountNameLabel;
-
-  /// No description provided for @accountTypeLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Account Type'**
-  String get accountTypeLabel;
-
   /// No description provided for @accountBalanceLabel.
   ///
   /// In en, this message translates to:
   /// **'Starting Balance'**
   String get accountBalanceLabel;
-
-  /// No description provided for @accountOnBudgetLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'On Budget'**
-  String get accountOnBudgetLabel;
-
-  /// No description provided for @accountOnBudgetHint.
-  ///
-  /// In en, this message translates to:
-  /// **'Include in budget calculations'**
-  String get accountOnBudgetHint;
-
-  /// No description provided for @accountTypeChecking.
-  ///
-  /// In en, this message translates to:
-  /// **'Checking'**
-  String get accountTypeChecking;
-
-  /// No description provided for @accountTypeSavings.
-  ///
-  /// In en, this message translates to:
-  /// **'Savings'**
-  String get accountTypeSavings;
-
-  /// No description provided for @accountTypeCreditCard.
-  ///
-  /// In en, this message translates to:
-  /// **'Credit Card'**
-  String get accountTypeCreditCard;
-
-  /// No description provided for @accountTypeCash.
-  ///
-  /// In en, this message translates to:
-  /// **'Cash'**
-  String get accountTypeCash;
-
-  /// No description provided for @accountTypeInvestment.
-  ///
-  /// In en, this message translates to:
-  /// **'Investment'**
-  String get accountTypeInvestment;
-
-  /// No description provided for @accountTypeOther.
-  ///
-  /// In en, this message translates to:
-  /// **'Other'**
-  String get accountTypeOther;
-
-  /// No description provided for @accountOnBudget.
-  ///
-  /// In en, this message translates to:
-  /// **'Budget Accounts'**
-  String get accountOnBudget;
-
-  /// No description provided for @accountOffBudget.
-  ///
-  /// In en, this message translates to:
-  /// **'Tracking Accounts'**
-  String get accountOffBudget;
-
-  /// No description provided for @accountClosed.
-  ///
-  /// In en, this message translates to:
-  /// **'Closed Accounts'**
-  String get accountClosed;
-
-  /// No description provided for @accountCreateSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Account created'**
-  String get accountCreateSuccess;
-
-  /// No description provided for @accountCreateError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not create account. Please try again.'**
-  String get accountCreateError;
-
-  /// No description provided for @budgetViewAccounts.
-  ///
-  /// In en, this message translates to:
-  /// **'Accounts'**
-  String get budgetViewAccounts;
-
-  /// No description provided for @transactionEditTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Edit Transaction'**
-  String get transactionEditTitle;
-
-  /// No description provided for @transactionEditSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Transaction updated'**
-  String get transactionEditSuccess;
-
-  /// No description provided for @transactionEditError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not update transaction. Please try again.'**
-  String get transactionEditError;
-
-  /// No description provided for @budgetMonthJanuary.
-  ///
-  /// In en, this message translates to:
-  /// **'January'**
-  String get budgetMonthJanuary;
-
-  /// No description provided for @budgetMonthFebruary.
-  ///
-  /// In en, this message translates to:
-  /// **'February'**
-  String get budgetMonthFebruary;
-
-  /// No description provided for @budgetMonthMarch.
-  ///
-  /// In en, this message translates to:
-  /// **'March'**
-  String get budgetMonthMarch;
-
-  /// No description provided for @budgetMonthApril.
-  ///
-  /// In en, this message translates to:
-  /// **'April'**
-  String get budgetMonthApril;
-
-  /// No description provided for @budgetMonthMay.
-  ///
-  /// In en, this message translates to:
-  /// **'May'**
-  String get budgetMonthMay;
-
-  /// No description provided for @budgetMonthJune.
-  ///
-  /// In en, this message translates to:
-  /// **'June'**
-  String get budgetMonthJune;
-
-  /// No description provided for @budgetMonthJuly.
-  ///
-  /// In en, this message translates to:
-  /// **'July'**
-  String get budgetMonthJuly;
-
-  /// No description provided for @budgetMonthAugust.
-  ///
-  /// In en, this message translates to:
-  /// **'August'**
-  String get budgetMonthAugust;
-
-  /// No description provided for @budgetMonthSeptember.
-  ///
-  /// In en, this message translates to:
-  /// **'September'**
-  String get budgetMonthSeptember;
-
-  /// No description provided for @budgetMonthOctober.
-  ///
-  /// In en, this message translates to:
-  /// **'October'**
-  String get budgetMonthOctober;
-
-  /// No description provided for @budgetMonthNovember.
-  ///
-  /// In en, this message translates to:
-  /// **'November'**
-  String get budgetMonthNovember;
-
-  /// No description provided for @budgetMonthDecember.
-  ///
-  /// In en, this message translates to:
-  /// **'December'**
-  String get budgetMonthDecember;
-
-  /// No description provided for @budgetAllocationUpdated.
-  ///
-  /// In en, this message translates to:
-  /// **'Allocation updated'**
-  String get budgetAllocationUpdated;
-
-  /// No description provided for @budgetAllocationError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not update allocation'**
-  String get budgetAllocationError;
-
-  /// No description provided for @transactionSearchHint.
-  ///
-  /// In en, this message translates to:
-  /// **'Search transactions...'**
-  String get transactionSearchHint;
-
-  /// No description provided for @transactionFilterAll.
-  ///
-  /// In en, this message translates to:
-  /// **'All'**
-  String get transactionFilterAll;
-
-  /// No description provided for @transactionFilterIncome.
-  ///
-  /// In en, this message translates to:
-  /// **'Income'**
-  String get transactionFilterIncome;
-
-  /// No description provided for @transactionFilterExpense.
-  ///
-  /// In en, this message translates to:
-  /// **'Expense'**
-  String get transactionFilterExpense;
-
-  /// No description provided for @transactionNoResults.
-  ///
-  /// In en, this message translates to:
-  /// **'No matching transactions'**
-  String get transactionNoResults;
-
-  /// No description provided for @transactionResultCount.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 result} other{{count} results}}'**
-  String transactionResultCount(int count);
-
-  /// No description provided for @payeeListTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Payees'**
-  String get payeeListTitle;
-
-  /// No description provided for @payeeLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load payees'**
-  String get payeeLoadError;
-
-  /// No description provided for @payeeEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Payees Yet'**
-  String get payeeEmptyTitle;
-
-  /// No description provided for @payeeEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add payees to track who you transact with'**
-  String get payeeEmptySubtitle;
-
-  /// No description provided for @payeeAddButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Payee'**
-  String get payeeAddButton;
-
-  /// No description provided for @payeeNameLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Payee Name'**
-  String get payeeNameLabel;
-
-  /// No description provided for @payeeCreateSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Payee created'**
-  String get payeeCreateSuccess;
-
-  /// No description provided for @payeeCreateError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not create payee. Please try again.'**
-  String get payeeCreateError;
-
-  /// No description provided for @payeeEditTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Edit Payee'**
-  String get payeeEditTitle;
-
-  /// No description provided for @payeeEditSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Payee updated'**
-  String get payeeEditSuccess;
-
-  /// No description provided for @payeeEditError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not update payee. Please try again.'**
-  String get payeeEditError;
-
-  /// No description provided for @goalSetTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Set Goal'**
-  String get goalSetTitle;
-
-  /// No description provided for @goalTypeLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Goal Type'**
-  String get goalTypeLabel;
-
-  /// No description provided for @goalTypeBalance.
-  ///
-  /// In en, this message translates to:
-  /// **'Balance'**
-  String get goalTypeBalance;
-
-  /// No description provided for @goalTypeByDate.
-  ///
-  /// In en, this message translates to:
-  /// **'By Date'**
-  String get goalTypeByDate;
-
-  /// No description provided for @goalTypeMonthly.
-  ///
-  /// In en, this message translates to:
-  /// **'Monthly'**
-  String get goalTypeMonthly;
-
-  /// No description provided for @goalAmountLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Target Amount'**
-  String get goalAmountLabel;
-
-  /// No description provided for @goalDateLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Target Date'**
-  String get goalDateLabel;
-
-  /// No description provided for @goalDateSelect.
-  ///
-  /// In en, this message translates to:
-  /// **'Select a date'**
-  String get goalDateSelect;
-
-  /// No description provided for @goalSaved.
-  ///
-  /// In en, this message translates to:
-  /// **'Goal saved'**
-  String get goalSaved;
-
-  /// No description provided for @goalRemoved.
-  ///
-  /// In en, this message translates to:
-  /// **'Goal removed'**
-  String get goalRemoved;
-
-  /// No description provided for @goalRemove.
-  ///
-  /// In en, this message translates to:
-  /// **'Remove Goal'**
-  String get goalRemove;
-
-  /// No description provided for @goalError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not save goal. Please try again.'**
-  String get goalError;
-
-  /// No description provided for @goalSetGoal.
-  ///
-  /// In en, this message translates to:
-  /// **'Set Goal'**
-  String get goalSetGoal;
-
-  /// No description provided for @transferTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Transfer'**
-  String get transferTitle;
-
-  /// No description provided for @transferFromAccount.
-  ///
-  /// In en, this message translates to:
-  /// **'From Account'**
-  String get transferFromAccount;
-
-  /// No description provided for @transferToAccount.
-  ///
-  /// In en, this message translates to:
-  /// **'To Account'**
-  String get transferToAccount;
-
-  /// No description provided for @transferDate.
-  ///
-  /// In en, this message translates to:
-  /// **'Transfer Date'**
-  String get transferDate;
-
-  /// No description provided for @transferButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Transfer'**
-  String get transferButton;
-
-  /// No description provided for @transferDefaultDescription.
-  ///
-  /// In en, this message translates to:
-  /// **'Account Transfer'**
-  String get transferDefaultDescription;
-
-  /// No description provided for @transferSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Transfer completed'**
-  String get transferSuccess;
-
-  /// No description provided for @transferError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not complete transfer. Please try again.'**
-  String get transferError;
-
-  /// No description provided for @transferSameAccountError.
-  ///
-  /// In en, this message translates to:
-  /// **'Cannot transfer to the same account'**
-  String get transferSameAccountError;
-
-  /// No description provided for @transferNeedTwoAccounts.
-  ///
-  /// In en, this message translates to:
-  /// **'You need at least two accounts to make a transfer'**
-  String get transferNeedTwoAccounts;
-
-  /// No description provided for @reportsTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Reports'**
-  String get reportsTitle;
-
-  /// No description provided for @reportsLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load report data'**
-  String get reportsLoadError;
-
-  /// No description provided for @reportsIncome.
-  ///
-  /// In en, this message translates to:
-  /// **'Income'**
-  String get reportsIncome;
-
-  /// No description provided for @reportsExpenses.
-  ///
-  /// In en, this message translates to:
-  /// **'Expenses'**
-  String get reportsExpenses;
-
-  /// No description provided for @reportsNetIncome.
-  ///
-  /// In en, this message translates to:
-  /// **'Net Income'**
-  String get reportsNetIncome;
-
-  /// No description provided for @reportsTransactions.
-  ///
-  /// In en, this message translates to:
-  /// **'Transactions'**
-  String get reportsTransactions;
-
-  /// No description provided for @reportsSpendingByCategory.
-  ///
-  /// In en, this message translates to:
-  /// **'Spending by Category'**
-  String get reportsSpendingByCategory;
-
-  /// No description provided for @reportsEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Data Yet'**
-  String get reportsEmptyTitle;
-
-  /// No description provided for @reportsEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add transactions to see spending reports for this month'**
-  String get reportsEmptySubtitle;
-
-  /// No description provided for @moveMoneyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Move Money'**
-  String get moveMoneyTitle;
-
-  /// No description provided for @moveMoneyFrom.
-  ///
-  /// In en, this message translates to:
-  /// **'From Envelope'**
-  String get moveMoneyFrom;
-
-  /// No description provided for @moveMoneyTo.
-  ///
-  /// In en, this message translates to:
-  /// **'To Envelope'**
-  String get moveMoneyTo;
-
-  /// No description provided for @moveMoneyButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Move'**
-  String get moveMoneyButton;
-
-  /// No description provided for @moveMoneySuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Money moved between envelopes'**
-  String get moveMoneySuccess;
-
-  /// No description provided for @moveMoneyError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not move money. Please try again.'**
-  String get moveMoneyError;
-
-  /// No description provided for @moveMoneySameError.
-  ///
-  /// In en, this message translates to:
-  /// **'Cannot move money to the same envelope'**
-  String get moveMoneySameError;
-
-  /// No description provided for @creditCardPaymentsTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Credit Card Payments'**
-  String get creditCardPaymentsTitle;
-
-  /// No description provided for @creditCardSpentThisMonth.
-  ///
-  /// In en, this message translates to:
-  /// **'Spent this month'**
-  String get creditCardSpentThisMonth;
-
-  /// No description provided for @accountDetailBalance.
-  ///
-  /// In en, this message translates to:
-  /// **'Balance'**
-  String get accountDetailBalance;
-
-  /// No description provided for @transactionUncleared.
-  ///
-  /// In en, this message translates to:
-  /// **'Uncleared'**
-  String get transactionUncleared;
-
-  /// No description provided for @transactionCleared.
-  ///
-  /// In en, this message translates to:
-  /// **'Cleared'**
-  String get transactionCleared;
-
-  /// No description provided for @transactionReconciled.
-  ///
-  /// In en, this message translates to:
-  /// **'Reconciled'**
-  String get transactionReconciled;
-
-  /// No description provided for @reconcileTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Reconcile Account'**
-  String get reconcileTitle;
-
-  /// No description provided for @reconcileMessage.
-  ///
-  /// In en, this message translates to:
-  /// **'Mark all cleared transactions as reconciled? This locks them from further editing.'**
-  String get reconcileMessage;
-
-  /// No description provided for @reconcileButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Reconcile'**
-  String get reconcileButton;
-
-  /// No description provided for @reconcileSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =0{No transactions to reconcile} =1{1 transaction reconciled} other{{count} transactions reconciled}}'**
-  String reconcileSuccess(int count);
-
-  /// No description provided for @reconcileError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not reconcile account. Please try again.'**
-  String get reconcileError;
-
-  /// No description provided for @recurringListTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Recurring Transactions'**
-  String get recurringListTitle;
-
-  /// No description provided for @recurringLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load recurring transactions'**
-  String get recurringLoadError;
-
-  /// No description provided for @recurringEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Recurring Transactions'**
-  String get recurringEmptyTitle;
-
-  /// No description provided for @recurringEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Set up recurring transactions for bills, subscriptions, and regular income'**
-  String get recurringEmptySubtitle;
-
-  /// No description provided for @recurringAddButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Recurring'**
-  String get recurringAddButton;
-
-  /// No description provided for @recurringAddTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Recurring Transaction'**
-  String get recurringAddTitle;
-
-  /// No description provided for @recurringEditTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Edit Recurring Transaction'**
-  String get recurringEditTitle;
-
-  /// No description provided for @recurringFrequencyLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Frequency'**
-  String get recurringFrequencyLabel;
-
-  /// No description provided for @recurringFreqDaily.
-  ///
-  /// In en, this message translates to:
-  /// **'Daily'**
-  String get recurringFreqDaily;
-
-  /// No description provided for @recurringFreqWeekly.
-  ///
-  /// In en, this message translates to:
-  /// **'Weekly'**
-  String get recurringFreqWeekly;
-
-  /// No description provided for @recurringFreqBiweekly.
-  ///
-  /// In en, this message translates to:
-  /// **'Biweekly'**
-  String get recurringFreqBiweekly;
-
-  /// No description provided for @recurringFreqMonthly.
-  ///
-  /// In en, this message translates to:
-  /// **'Monthly'**
-  String get recurringFreqMonthly;
-
-  /// No description provided for @recurringFreqYearly.
-  ///
-  /// In en, this message translates to:
-  /// **'Yearly'**
-  String get recurringFreqYearly;
-
-  /// No description provided for @recurringStartDate.
-  ///
-  /// In en, this message translates to:
-  /// **'Start Date'**
-  String get recurringStartDate;
-
-  /// No description provided for @recurringNextDate.
-  ///
-  /// In en, this message translates to:
-  /// **'Next'**
-  String get recurringNextDate;
-
-  /// No description provided for @recurringCreateSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Recurring transaction created'**
-  String get recurringCreateSuccess;
-
-  /// No description provided for @recurringCreateError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not create recurring transaction. Please try again.'**
-  String get recurringCreateError;
-
-  /// No description provided for @recurringEditSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Recurring transaction updated'**
-  String get recurringEditSuccess;
-
-  /// No description provided for @recurringEditError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not update recurring transaction. Please try again.'**
-  String get recurringEditError;
-
-  /// No description provided for @ageOfMoneyLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'{days, plural, =1{Age of Money: 1 day} other{Age of Money: {days} days}}'**
-  String ageOfMoneyLabel(int days);
-
-  /// No description provided for @quickBudgetTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Quick Budget'**
-  String get quickBudgetTitle;
-
-  /// No description provided for @quickBudgetLastMonth.
-  ///
-  /// In en, this message translates to:
-  /// **'Budgeted Last Month'**
-  String get quickBudgetLastMonth;
-
-  /// No description provided for @quickBudgetSpentLastMonth.
-  ///
-  /// In en, this message translates to:
-  /// **'Spent Last Month'**
-  String get quickBudgetSpentLastMonth;
-
-  /// No description provided for @quickBudgetAverageBudgeted.
-  ///
-  /// In en, this message translates to:
-  /// **'Average Budgeted'**
-  String get quickBudgetAverageBudgeted;
-
-  /// No description provided for @quickBudgetAverageSpent.
-  ///
-  /// In en, this message translates to:
-  /// **'Average Spent'**
-  String get quickBudgetAverageSpent;
-
-  /// No description provided for @quickBudgetError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load budget suggestions'**
-  String get quickBudgetError;
-
-  /// No description provided for @splitTransactionTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Split Transaction'**
-  String get splitTransactionTitle;
-
-  /// No description provided for @splitAddSplit.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Split'**
-  String get splitAddSplit;
-
-  /// No description provided for @splitRemoveSplit.
-  ///
-  /// In en, this message translates to:
-  /// **'Remove'**
-  String get splitRemoveSplit;
-
-  /// No description provided for @splitEnvelopeLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Envelope'**
-  String get splitEnvelopeLabel;
-
-  /// No description provided for @splitAmountLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Amount'**
-  String get splitAmountLabel;
-
-  /// No description provided for @splitMemoLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Memo (optional)'**
-  String get splitMemoLabel;
-
-  /// No description provided for @splitRemainingLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Remaining to assign'**
-  String get splitRemainingLabel;
-
-  /// No description provided for @splitMismatchError.
-  ///
-  /// In en, this message translates to:
-  /// **'Split amounts must equal the total'**
-  String get splitMismatchError;
-
-  /// No description provided for @splitMinimumError.
-  ///
-  /// In en, this message translates to:
-  /// **'At least two splits are required'**
-  String get splitMinimumError;
-
-  /// No description provided for @splitSaveSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Split transaction saved'**
-  String get splitSaveSuccess;
-
-  /// No description provided for @splitSaveError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not save split transaction. Please try again.'**
-  String get splitSaveError;
-
-  /// No description provided for @splitLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Split'**
-  String get splitLabel;
-
-  /// No description provided for @splitCount.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 split} other{{count} splits}}'**
-  String splitCount(int count);
-
-  /// No description provided for @payeeNone.
-  ///
-  /// In en, this message translates to:
-  /// **'No Payee'**
-  String get payeeNone;
-
-  /// No description provided for @payeeLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Payee'**
-  String get payeeLabel;
-
-  /// No description provided for @payeeAutoEnvelopeHint.
-  ///
-  /// In en, this message translates to:
-  /// **'Envelope auto-suggested from last transaction with this payee'**
-  String get payeeAutoEnvelopeHint;
-
-  /// No description provided for @accountRunningBalance.
-  ///
-  /// In en, this message translates to:
-  /// **'Running Balance'**
-  String get accountRunningBalance;
-
-  /// No description provided for @budgetOverspentWarning.
-  ///
-  /// In en, this message translates to:
-  /// **'Overspent: {amount}'**
-  String budgetOverspentWarning(String amount);
-
-  /// No description provided for @importTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Import Transactions'**
-  String get importTitle;
-
-  /// No description provided for @importInstructions.
-  ///
-  /// In en, this message translates to:
-  /// **'Paste CSV data with columns for date, description, and amount. Headers are auto-detected.'**
-  String get importInstructions;
-
-  /// No description provided for @importCsvLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'CSV Data'**
-  String get importCsvLabel;
-
-  /// No description provided for @importCsvHint.
-  ///
-  /// In en, this message translates to:
-  /// **'Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00'**
-  String get importCsvHint;
-
-  /// No description provided for @importPreview.
-  ///
-  /// In en, this message translates to:
-  /// **'Preview'**
-  String get importPreview;
-
-  /// No description provided for @importPreviewCount.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 transaction to import} other{{count} transactions to import}}'**
-  String importPreviewCount(int count);
-
-  /// No description provided for @importButton.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{Import 1 Transaction} other{Import {count} Transactions}}'**
-  String importButton(int count);
-
-  /// No description provided for @importImporting.
-  ///
-  /// In en, this message translates to:
-  /// **'Importing...'**
-  String get importImporting;
-
-  /// No description provided for @importSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 transaction imported} other{{count} transactions imported}}'**
-  String importSuccess(int count);
-
-  /// No description provided for @importError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not import transactions. Please try again.'**
-  String get importError;
-
-  /// No description provided for @importMoreRows.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{...and 1 more row} other{...and {count} more rows}}'**
-  String importMoreRows(int count);
-
-  /// No description provided for @recurringDueBanner.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 scheduled transaction is due} other{{count} scheduled transactions are due}}'**
-  String recurringDueBanner(int count);
-
-  /// No description provided for @recurringPostDue.
-  ///
-  /// In en, this message translates to:
-  /// **'Post Now'**
-  String get recurringPostDue;
-
-  /// No description provided for @recurringPosting.
-  ///
-  /// In en, this message translates to:
-  /// **'Posting...'**
-  String get recurringPosting;
-
-  /// No description provided for @recurringPostSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 transaction posted} other{{count} transactions posted}}'**
-  String recurringPostSuccess(int count);
-
-  /// No description provided for @recurringPostError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not post scheduled transactions. Please try again.'**
-  String get recurringPostError;
-
-  /// No description provided for @autoAssignTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Auto-Assign'**
-  String get autoAssignTitle;
-
-  /// No description provided for @autoAssignButton.
-  ///
-  /// In en, this message translates to:
-  /// **'Auto-Assign'**
-  String get autoAssignButton;
-
-  /// No description provided for @autoAssignAssigning.
-  ///
-  /// In en, this message translates to:
-  /// **'Assigning...'**
-  String get autoAssignAssigning;
-
-  /// No description provided for @autoAssignDistributing.
-  ///
-  /// In en, this message translates to:
-  /// **'Distributing to underfunded envelopes'**
-  String get autoAssignDistributing;
-
-  /// No description provided for @autoAssignNothingToAssign.
-  ///
-  /// In en, this message translates to:
-  /// **'All envelopes with goals are fully funded!'**
-  String get autoAssignNothingToAssign;
-
-  /// No description provided for @autoAssignEnvelopeCount.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{1 envelope} other{{count} envelopes}}'**
-  String autoAssignEnvelopeCount(int count);
-
-  /// No description provided for @autoAssignSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'{count, plural, =1{Auto-assigned to 1 envelope} other{Auto-assigned to {count} envelopes}}'**
-  String autoAssignSuccess(int count);
-
-  /// No description provided for @autoAssignError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not auto-assign. Please try again.'**
-  String get autoAssignError;
-
-  /// No description provided for @envelopeActivityTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Activity'**
-  String get envelopeActivityTitle;
-
-  /// No description provided for @envelopeNoActivity.
-  ///
-  /// In en, this message translates to:
-  /// **'No transactions this month'**
-  String get envelopeNoActivity;
-
-  /// No description provided for @netWorthTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Net Worth'**
-  String get netWorthTitle;
-
-  /// No description provided for @netWorthAssets.
-  ///
-  /// In en, this message translates to:
-  /// **'Assets'**
-  String get netWorthAssets;
-
-  /// No description provided for @netWorthLiabilities.
-  ///
-  /// In en, this message translates to:
-  /// **'Liabilities'**
-  String get netWorthLiabilities;
-
-  /// No description provided for @netWorthLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load net worth data'**
-  String get netWorthLoadError;
-
-  /// No description provided for @netWorthEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Accounts Yet'**
-  String get netWorthEmptyTitle;
-
-  /// No description provided for @netWorthEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add accounts to see your net worth breakdown'**
-  String get netWorthEmptySubtitle;
-
-  /// No description provided for @spendingTrendsTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Spending Trends'**
-  String get spendingTrendsTitle;
-
-  /// No description provided for @spendingTrendsLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load spending trends'**
-  String get spendingTrendsLoadError;
-
-  /// No description provided for @spendingTrendsEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Spending Data'**
-  String get spendingTrendsEmptyTitle;
-
-  /// No description provided for @spendingTrendsEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add transactions to see spending trends over time'**
-  String get spendingTrendsEmptySubtitle;
-
-  /// No description provided for @spendingTrendsAvgIncome.
-  ///
-  /// In en, this message translates to:
-  /// **'Avg. Income'**
-  String get spendingTrendsAvgIncome;
-
-  /// No description provided for @spendingTrendsAvgExpenses.
-  ///
-  /// In en, this message translates to:
-  /// **'Avg. Expenses'**
-  String get spendingTrendsAvgExpenses;
-
-  /// No description provided for @spendingTrendsMonthly.
-  ///
-  /// In en, this message translates to:
-  /// **'Monthly Comparison'**
-  String get spendingTrendsMonthly;
-
-  /// No description provided for @spendingTrendsBreakdown.
-  ///
-  /// In en, this message translates to:
-  /// **'Monthly Breakdown'**
-  String get spendingTrendsBreakdown;
-
-  /// No description provided for @budgetEditCategoryTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Rename Category'**
-  String get budgetEditCategoryTitle;
-
-  /// No description provided for @budgetEditCategorySuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Category renamed'**
-  String get budgetEditCategorySuccess;
-
-  /// No description provided for @budgetEditCategoryError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not rename category. Please try again.'**
-  String get budgetEditCategoryError;
-
-  /// No description provided for @budgetReorderCategories.
-  ///
-  /// In en, this message translates to:
-  /// **'Reorder Categories'**
-  String get budgetReorderCategories;
-
-  /// No description provided for @budgetReorderDone.
-  ///
-  /// In en, this message translates to:
-  /// **'Done'**
-  String get budgetReorderDone;
-
-  /// No description provided for @budgetReorderHint.
-  ///
-  /// In en, this message translates to:
-  /// **'Drag to reorder categories'**
-  String get budgetReorderHint;
-
-  /// No description provided for @budgetReorderSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Categories reordered'**
-  String get budgetReorderSuccess;
-
-  /// No description provided for @budgetReorderError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not reorder categories'**
-  String get budgetReorderError;
-
-  /// No description provided for @transactionMemoLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Memo'**
-  String get transactionMemoLabel;
-
-  /// No description provided for @transactionMemoHint.
-  ///
-  /// In en, this message translates to:
-  /// **'Add a note (optional)'**
-  String get transactionMemoHint;
-
-  /// No description provided for @accountEditTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Edit Account'**
-  String get accountEditTitle;
-
-  /// No description provided for @accountEditSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Account updated'**
-  String get accountEditSuccess;
-
-  /// No description provided for @accountEditError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not update account. Please try again.'**
-  String get accountEditError;
 
   /// No description provided for @accountCloseButton.
   ///
@@ -1810,6 +130,102 @@ abstract class AppLocalizations {
   /// **'Account closed'**
   String get accountCloseSuccess;
 
+  /// No description provided for @accountClosed.
+  ///
+  /// In en, this message translates to:
+  /// **'Closed Accounts'**
+  String get accountClosed;
+
+  /// No description provided for @accountCreateError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not create account. Please try again.'**
+  String get accountCreateError;
+
+  /// No description provided for @accountCreateSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Account created'**
+  String get accountCreateSuccess;
+
+  /// No description provided for @accountDetailBalance.
+  ///
+  /// In en, this message translates to:
+  /// **'Balance'**
+  String get accountDetailBalance;
+
+  /// No description provided for @accountEditError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update account. Please try again.'**
+  String get accountEditError;
+
+  /// No description provided for @accountEditSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Account updated'**
+  String get accountEditSuccess;
+
+  /// No description provided for @accountEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Account'**
+  String get accountEditTitle;
+
+  /// No description provided for @accountEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add your first account to track balances'**
+  String get accountEmptySubtitle;
+
+  /// No description provided for @accountEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Accounts Yet'**
+  String get accountEmptyTitle;
+
+  /// No description provided for @accountListTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Accounts'**
+  String get accountListTitle;
+
+  /// No description provided for @accountLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load accounts'**
+  String get accountLoadError;
+
+  /// No description provided for @accountNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Account Name'**
+  String get accountNameLabel;
+
+  /// No description provided for @accountOffBudget.
+  ///
+  /// In en, this message translates to:
+  /// **'Tracking Accounts'**
+  String get accountOffBudget;
+
+  /// No description provided for @accountOnBudget.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget Accounts'**
+  String get accountOnBudget;
+
+  /// No description provided for @accountOnBudgetHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Include in budget calculations'**
+  String get accountOnBudgetHint;
+
+  /// No description provided for @accountOnBudgetLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'On Budget'**
+  String get accountOnBudgetLabel;
+
   /// No description provided for @accountReopenButton.
   ///
   /// In en, this message translates to:
@@ -1822,17 +238,215 @@ abstract class AppLocalizations {
   /// **'Account reopened'**
   String get accountReopenSuccess;
 
-  /// No description provided for @budgetDeleteTitle.
+  /// No description provided for @accountRunningBalance.
   ///
   /// In en, this message translates to:
-  /// **'Delete Budget'**
-  String get budgetDeleteTitle;
+  /// **'Running Balance'**
+  String get accountRunningBalance;
 
-  /// No description provided for @budgetDeleteConfirm.
+  /// No description provided for @accountTypeCash.
   ///
   /// In en, this message translates to:
-  /// **'Delete \"{name}\"? This will permanently remove the budget and all its data.'**
-  String budgetDeleteConfirm(String name);
+  /// **'Cash'**
+  String get accountTypeCash;
+
+  /// No description provided for @accountTypeChecking.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking'**
+  String get accountTypeChecking;
+
+  /// No description provided for @accountTypeCreditCard.
+  ///
+  /// In en, this message translates to:
+  /// **'Credit Card'**
+  String get accountTypeCreditCard;
+
+  /// No description provided for @accountTypeInvestment.
+  ///
+  /// In en, this message translates to:
+  /// **'Investment'**
+  String get accountTypeInvestment;
+
+  /// No description provided for @accountTypeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Account Type'**
+  String get accountTypeLabel;
+
+  /// No description provided for @accountTypeOther.
+  ///
+  /// In en, this message translates to:
+  /// **'Other'**
+  String get accountTypeOther;
+
+  /// No description provided for @accountTypeSavings.
+  ///
+  /// In en, this message translates to:
+  /// **'Savings'**
+  String get accountTypeSavings;
+
+  /// No description provided for @ageOfMoneyLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{days, plural, =1{Age of Money: 1 day} other{Age of Money: {days} days}}'**
+  String ageOfMoneyLabel(int days);
+
+  /// No description provided for @appTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'OpenBudget'**
+  String get appTitle;
+
+  /// No description provided for @autoAssignAssigning.
+  ///
+  /// In en, this message translates to:
+  /// **'Assigning...'**
+  String get autoAssignAssigning;
+
+  /// No description provided for @autoAssignButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-Assign'**
+  String get autoAssignButton;
+
+  /// No description provided for @autoAssignDistributing.
+  ///
+  /// In en, this message translates to:
+  /// **'Distributing to underfunded envelopes'**
+  String get autoAssignDistributing;
+
+  /// No description provided for @autoAssignEnvelopeCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 envelope} other{{count} envelopes}}'**
+  String autoAssignEnvelopeCount(int count);
+
+  /// No description provided for @autoAssignError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not auto-assign. Please try again.'**
+  String get autoAssignError;
+
+  /// No description provided for @autoAssignNothingToAssign.
+  ///
+  /// In en, this message translates to:
+  /// **'All envelopes with goals are fully funded!'**
+  String get autoAssignNothingToAssign;
+
+  /// No description provided for @autoAssignSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Auto-assigned to 1 envelope} other{Auto-assigned to {count} envelopes}}'**
+  String autoAssignSuccess(int count);
+
+  /// No description provided for @autoAssignTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-Assign'**
+  String get autoAssignTitle;
+
+  /// No description provided for @budgetAddCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Category'**
+  String get budgetAddCategory;
+
+  /// No description provided for @budgetAddEnvelope.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Envelope'**
+  String get budgetAddEnvelope;
+
+  /// No description provided for @budgetAddExpense.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Expense'**
+  String get budgetAddExpense;
+
+  /// No description provided for @budgetAddIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Income'**
+  String get budgetAddIncome;
+
+  /// No description provided for @budgetAllocationError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update allocation'**
+  String get budgetAllocationError;
+
+  /// No description provided for @budgetAllocationUpdated.
+  ///
+  /// In en, this message translates to:
+  /// **'Allocation updated'**
+  String get budgetAllocationUpdated;
+
+  /// No description provided for @budgetCategoryCreateError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not create category'**
+  String get budgetCategoryCreateError;
+
+  /// No description provided for @budgetCategoryCreated.
+  ///
+  /// In en, this message translates to:
+  /// **'Category created'**
+  String get budgetCategoryCreated;
+
+  /// No description provided for @budgetCategoryNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Category Name'**
+  String get budgetCategoryNameLabel;
+
+  /// No description provided for @budgetCategoryTotal.
+  ///
+  /// In en, this message translates to:
+  /// **'Total'**
+  String get budgetCategoryTotal;
+
+  /// No description provided for @budgetColumnAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Available'**
+  String get budgetColumnAvailable;
+
+  /// No description provided for @budgetColumnBudgeted.
+  ///
+  /// In en, this message translates to:
+  /// **'Budgeted'**
+  String get budgetColumnBudgeted;
+
+  /// No description provided for @budgetColumnSpent.
+  ///
+  /// In en, this message translates to:
+  /// **'Spent'**
+  String get budgetColumnSpent;
+
+  /// No description provided for @budgetCopyLastMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy Last Month'**
+  String get budgetCopyLastMonth;
+
+  /// No description provided for @budgetCopyLastMonthConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy all budget allocations from last month to the current month? This will overwrite any existing allocations.'**
+  String get budgetCopyLastMonthConfirm;
+
+  /// No description provided for @budgetCopyLastMonthError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not copy previous month. Please try again.'**
+  String get budgetCopyLastMonthError;
+
+  /// No description provided for @budgetCopyLastMonthSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Allocations copied from previous month'**
+  String get budgetCopyLastMonthSuccess;
 
   /// No description provided for @budgetDeleteButton.
   ///
@@ -1840,11 +454,11 @@ abstract class AppLocalizations {
   /// **'Delete'**
   String get budgetDeleteButton;
 
-  /// No description provided for @budgetDeleteSuccess.
+  /// No description provided for @budgetDeleteConfirm.
   ///
   /// In en, this message translates to:
-  /// **'Budget deleted'**
-  String get budgetDeleteSuccess;
+  /// **'Delete \"{name}\"? This will permanently remove the budget and all its data.'**
+  String budgetDeleteConfirm(String name);
 
   /// No description provided for @budgetDeleteError.
   ///
@@ -1852,77 +466,449 @@ abstract class AppLocalizations {
   /// **'Could not delete budget. Please try again.'**
   String get budgetDeleteError;
 
-  /// No description provided for @settingsTitle.
+  /// No description provided for @budgetDeleteSuccess.
   ///
   /// In en, this message translates to:
-  /// **'Settings'**
-  String get settingsTitle;
+  /// **'Budget deleted'**
+  String get budgetDeleteSuccess;
 
-  /// No description provided for @settingsLoadError.
+  /// No description provided for @budgetDeleteTitle.
   ///
   /// In en, this message translates to:
-  /// **'Could not load settings'**
-  String get settingsLoadError;
+  /// **'Delete Budget'**
+  String get budgetDeleteTitle;
 
-  /// No description provided for @settingsBudgetSection.
+  /// No description provided for @budgetEditCategoryError.
   ///
   /// In en, this message translates to:
-  /// **'Budget'**
-  String get settingsBudgetSection;
+  /// **'Could not rename category. Please try again.'**
+  String get budgetEditCategoryError;
 
-  /// No description provided for @settingsBudgetName.
+  /// No description provided for @budgetEditCategorySuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Category renamed'**
+  String get budgetEditCategorySuccess;
+
+  /// No description provided for @budgetEditCategoryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename Category'**
+  String get budgetEditCategoryTitle;
+
+  /// No description provided for @budgetEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add your first envelope category to start budgeting'**
+  String get budgetEmptySubtitle;
+
+  /// No description provided for @budgetEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Categories Yet'**
+  String get budgetEmptyTitle;
+
+  /// No description provided for @budgetEnvelopeAmountLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Budgeted Amount'**
+  String get budgetEnvelopeAmountLabel;
+
+  /// No description provided for @budgetEnvelopeCreateError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not create envelope'**
+  String get budgetEnvelopeCreateError;
+
+  /// No description provided for @budgetEnvelopeCreated.
+  ///
+  /// In en, this message translates to:
+  /// **'Envelope created'**
+  String get budgetEnvelopeCreated;
+
+  /// No description provided for @budgetEnvelopeNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Envelope Name'**
+  String get budgetEnvelopeNameLabel;
+
+  /// No description provided for @budgetGoToToday.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to Today'**
+  String get budgetGoToToday;
+
+  /// No description provided for @budgetLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load budget details'**
+  String get budgetLoadError;
+
+  /// No description provided for @budgetMonthApril.
+  ///
+  /// In en, this message translates to:
+  /// **'April'**
+  String get budgetMonthApril;
+
+  /// No description provided for @budgetMonthAugust.
+  ///
+  /// In en, this message translates to:
+  /// **'August'**
+  String get budgetMonthAugust;
+
+  /// No description provided for @budgetMonthDecember.
+  ///
+  /// In en, this message translates to:
+  /// **'December'**
+  String get budgetMonthDecember;
+
+  /// No description provided for @budgetMonthFebruary.
+  ///
+  /// In en, this message translates to:
+  /// **'February'**
+  String get budgetMonthFebruary;
+
+  /// No description provided for @budgetMonthJanuary.
+  ///
+  /// In en, this message translates to:
+  /// **'January'**
+  String get budgetMonthJanuary;
+
+  /// No description provided for @budgetMonthJuly.
+  ///
+  /// In en, this message translates to:
+  /// **'July'**
+  String get budgetMonthJuly;
+
+  /// No description provided for @budgetMonthJune.
+  ///
+  /// In en, this message translates to:
+  /// **'June'**
+  String get budgetMonthJune;
+
+  /// No description provided for @budgetMonthMarch.
+  ///
+  /// In en, this message translates to:
+  /// **'March'**
+  String get budgetMonthMarch;
+
+  /// No description provided for @budgetMonthMay.
+  ///
+  /// In en, this message translates to:
+  /// **'May'**
+  String get budgetMonthMay;
+
+  /// No description provided for @budgetMonthNovember.
+  ///
+  /// In en, this message translates to:
+  /// **'November'**
+  String get budgetMonthNovember;
+
+  /// No description provided for @budgetMonthOctober.
+  ///
+  /// In en, this message translates to:
+  /// **'October'**
+  String get budgetMonthOctober;
+
+  /// No description provided for @budgetMonthSeptember.
+  ///
+  /// In en, this message translates to:
+  /// **'September'**
+  String get budgetMonthSeptember;
+
+  /// No description provided for @budgetOverspentWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'Overspent: {amount}'**
+  String budgetOverspentWarning(String amount);
+
+  /// No description provided for @budgetReadyToAssign.
+  ///
+  /// In en, this message translates to:
+  /// **'Ready to Assign'**
+  String get budgetReadyToAssign;
+
+  /// No description provided for @budgetReorderCategories.
+  ///
+  /// In en, this message translates to:
+  /// **'Reorder Categories'**
+  String get budgetReorderCategories;
+
+  /// No description provided for @budgetReorderDone.
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get budgetReorderDone;
+
+  /// No description provided for @budgetReorderError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not reorder categories'**
+  String get budgetReorderError;
+
+  /// No description provided for @budgetReorderHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Drag to reorder categories'**
+  String get budgetReorderHint;
+
+  /// No description provided for @budgetReorderSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Categories reordered'**
+  String get budgetReorderSuccess;
+
+  /// No description provided for @budgetViewAccounts.
+  ///
+  /// In en, this message translates to:
+  /// **'Accounts'**
+  String get budgetViewAccounts;
+
+  /// No description provided for @categoryTrendsEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add categorized transactions to see spending trends by category'**
+  String get categoryTrendsEmptySubtitle;
+
+  /// No description provided for @categoryTrendsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Category Data'**
+  String get categoryTrendsEmptyTitle;
+
+  /// No description provided for @categoryTrendsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load category trends'**
+  String get categoryTrendsLoadError;
+
+  /// No description provided for @categoryTrendsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Category Trends'**
+  String get categoryTrendsTitle;
+
+  /// No description provided for @createBudgetButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Create'**
+  String get createBudgetButton;
+
+  /// No description provided for @createBudgetCreating.
+  ///
+  /// In en, this message translates to:
+  /// **'Creating...'**
+  String get createBudgetCreating;
+
+  /// No description provided for @createBudgetCurrencyLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Primary Currency'**
+  String get createBudgetCurrencyLabel;
+
+  /// No description provided for @createBudgetError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not create budget. Please try again.'**
+  String get createBudgetError;
+
+  /// No description provided for @createBudgetNameLabel.
   ///
   /// In en, this message translates to:
   /// **'Budget Name'**
-  String get settingsBudgetName;
+  String get createBudgetNameLabel;
 
-  /// No description provided for @settingsCurrency.
+  /// No description provided for @createBudgetSuccess.
   ///
   /// In en, this message translates to:
-  /// **'Currency'**
-  String get settingsCurrency;
+  /// **'Budget created successfully'**
+  String get createBudgetSuccess;
 
-  /// No description provided for @settingsNavigationSection.
+  /// No description provided for @createBudgetTitle.
   ///
   /// In en, this message translates to:
-  /// **'Quick Access'**
-  String get settingsNavigationSection;
+  /// **'Create Budget'**
+  String get createBudgetTitle;
 
-  /// No description provided for @settingsAccountSection.
+  /// No description provided for @creditCardPaymentsTitle.
   ///
   /// In en, this message translates to:
-  /// **'Account'**
-  String get settingsAccountSection;
+  /// **'Credit Card Payments'**
+  String get creditCardPaymentsTitle;
 
-  /// No description provided for @settingsRenameBudget.
+  /// No description provided for @creditCardSpentThisMonth.
   ///
   /// In en, this message translates to:
-  /// **'Rename Budget'**
-  String get settingsRenameBudget;
+  /// **'Spent this month'**
+  String get creditCardSpentThisMonth;
 
-  /// No description provided for @settingsRenameSuccess.
+  /// No description provided for @deleteConfirmButton.
   ///
   /// In en, this message translates to:
-  /// **'Budget renamed'**
-  String get settingsRenameSuccess;
+  /// **'Delete'**
+  String get deleteConfirmButton;
 
-  /// No description provided for @settingsRenameError.
+  /// No description provided for @deleteConfirmMessage.
   ///
   /// In en, this message translates to:
-  /// **'Could not rename budget. Please try again.'**
-  String get settingsRenameError;
+  /// **'Are you sure you want to delete this?'**
+  String get deleteConfirmMessage;
 
-  /// No description provided for @settingsLogoutConfirm.
+  /// No description provided for @deleteConfirmTitle.
   ///
   /// In en, this message translates to:
-  /// **'Are you sure you want to sign out?'**
-  String get settingsLogoutConfirm;
+  /// **'Delete'**
+  String get deleteConfirmTitle;
 
-  /// No description provided for @settingsVersion.
+  /// No description provided for @deleteError.
   ///
   /// In en, this message translates to:
-  /// **'OpenBudget v1.0.0'**
-  String get settingsVersion;
+  /// **'Could not delete. Please try again.'**
+  String get deleteError;
+
+  /// No description provided for @deleteSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted successfully'**
+  String get deleteSuccess;
+
+  /// No description provided for @dialogCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get dialogCancel;
+
+  /// No description provided for @dialogSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get dialogSave;
+
+  /// No description provided for @dialogSaving.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving...'**
+  String get dialogSaving;
+
+  /// No description provided for @duplicateWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Possible duplicate: 1 similar transaction found} other{Possible duplicates: {count} similar transactions found}}'**
+  String duplicateWarning(int count);
+
+  /// No description provided for @editEnvelopeError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update envelope'**
+  String get editEnvelopeError;
+
+  /// No description provided for @editEnvelopeSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Envelope updated'**
+  String get editEnvelopeSaved;
+
+  /// No description provided for @editEnvelopeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Envelope'**
+  String get editEnvelopeTitle;
+
+  /// No description provided for @envelopeActivityTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Activity'**
+  String get envelopeActivityTitle;
+
+  /// No description provided for @envelopeNoActivity.
+  ///
+  /// In en, this message translates to:
+  /// **'No transactions this month'**
+  String get envelopeNoActivity;
+
+  /// No description provided for @envelopeReorderHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Long press an envelope to reorder within category'**
+  String get envelopeReorderHint;
+
+  /// No description provided for @goalAmountLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Target Amount'**
+  String get goalAmountLabel;
+
+  /// No description provided for @goalDateLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Target Date'**
+  String get goalDateLabel;
+
+  /// No description provided for @goalDateSelect.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a date'**
+  String get goalDateSelect;
+
+  /// No description provided for @goalError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save goal. Please try again.'**
+  String get goalError;
+
+  /// No description provided for @goalRemove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove Goal'**
+  String get goalRemove;
+
+  /// No description provided for @goalRemoved.
+  ///
+  /// In en, this message translates to:
+  /// **'Goal removed'**
+  String get goalRemoved;
+
+  /// No description provided for @goalSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Goal saved'**
+  String get goalSaved;
+
+  /// No description provided for @goalSetGoal.
+  ///
+  /// In en, this message translates to:
+  /// **'Set Goal'**
+  String get goalSetGoal;
+
+  /// No description provided for @goalSetTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Set Goal'**
+  String get goalSetTitle;
+
+  /// No description provided for @goalTypeBalance.
+  ///
+  /// In en, this message translates to:
+  /// **'Balance'**
+  String get goalTypeBalance;
+
+  /// No description provided for @goalTypeByDate.
+  ///
+  /// In en, this message translates to:
+  /// **'By Date'**
+  String get goalTypeByDate;
+
+  /// No description provided for @goalTypeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Goal Type'**
+  String get goalTypeLabel;
+
+  /// No description provided for @goalTypeMonthly.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly'**
+  String get goalTypeMonthly;
 
   /// No description provided for @homeBudgetAccounts.
   ///
@@ -1930,11 +916,311 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 account} other{{count} accounts}}'**
   String homeBudgetAccounts(int count);
 
+  /// No description provided for @homeBudgetCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 budget} other{{count} budgets}}'**
+  String homeBudgetCount(int count);
+
   /// No description provided for @homeBudgetTotalBalance.
   ///
   /// In en, this message translates to:
   /// **'Total Balance'**
   String get homeBudgetTotalBalance;
+
+  /// No description provided for @homeCreateBudget.
+  ///
+  /// In en, this message translates to:
+  /// **'Create Your First Budget'**
+  String get homeCreateBudget;
+
+  /// No description provided for @homeLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load budgets'**
+  String get homeLoadError;
+
+  /// No description provided for @homeLogout.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign Out'**
+  String get homeLogout;
+
+  /// No description provided for @homeNoBudgets.
+  ///
+  /// In en, this message translates to:
+  /// **'No Budgets Yet'**
+  String get homeNoBudgets;
+
+  /// No description provided for @homeRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get homeRetry;
+
+  /// No description provided for @importButton.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Import 1 Transaction} other{Import {count} Transactions}}'**
+  String importButton(int count);
+
+  /// No description provided for @importCsvHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00'**
+  String get importCsvHint;
+
+  /// No description provided for @importCsvLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'CSV Data'**
+  String get importCsvLabel;
+
+  /// No description provided for @importError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not import transactions. Please try again.'**
+  String get importError;
+
+  /// No description provided for @importImporting.
+  ///
+  /// In en, this message translates to:
+  /// **'Importing...'**
+  String get importImporting;
+
+  /// No description provided for @importInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Paste CSV data with columns for date, description, and amount. Headers are auto-detected.'**
+  String get importInstructions;
+
+  /// No description provided for @importMoreRows.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{...and 1 more row} other{...and {count} more rows}}'**
+  String importMoreRows(int count);
+
+  /// No description provided for @importPreview.
+  ///
+  /// In en, this message translates to:
+  /// **'Preview'**
+  String get importPreview;
+
+  /// No description provided for @importPreviewCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction to import} other{{count} transactions to import}}'**
+  String importPreviewCount(int count);
+
+  /// No description provided for @importSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction imported} other{{count} transactions imported}}'**
+  String importSuccess(int count);
+
+  /// No description provided for @importTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import Transactions'**
+  String get importTitle;
+
+  /// No description provided for @loginButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign In'**
+  String get loginButton;
+
+  /// No description provided for @loginCreateAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'Create Account'**
+  String get loginCreateAccount;
+
+  /// No description provided for @loginEmailLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Email'**
+  String get loginEmailLabel;
+
+  /// No description provided for @loginLoading.
+  ///
+  /// In en, this message translates to:
+  /// **'Signing In...'**
+  String get loginLoading;
+
+  /// No description provided for @loginPasswordLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Password'**
+  String get loginPasswordLabel;
+
+  /// No description provided for @loginTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome to OpenBudget'**
+  String get loginTitle;
+
+  /// No description provided for @moveMoneyButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Move'**
+  String get moveMoneyButton;
+
+  /// No description provided for @moveMoneyError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not move money. Please try again.'**
+  String get moveMoneyError;
+
+  /// No description provided for @moveMoneyFrom.
+  ///
+  /// In en, this message translates to:
+  /// **'From Envelope'**
+  String get moveMoneyFrom;
+
+  /// No description provided for @moveMoneySameError.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot move money to the same envelope'**
+  String get moveMoneySameError;
+
+  /// No description provided for @moveMoneySuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Money moved between envelopes'**
+  String get moveMoneySuccess;
+
+  /// No description provided for @moveMoneyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Move Money'**
+  String get moveMoneyTitle;
+
+  /// No description provided for @moveMoneyTo.
+  ///
+  /// In en, this message translates to:
+  /// **'To Envelope'**
+  String get moveMoneyTo;
+
+  /// No description provided for @netWorthAssets.
+  ///
+  /// In en, this message translates to:
+  /// **'Assets'**
+  String get netWorthAssets;
+
+  /// No description provided for @netWorthEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add accounts to see your net worth breakdown'**
+  String get netWorthEmptySubtitle;
+
+  /// No description provided for @netWorthEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Accounts Yet'**
+  String get netWorthEmptyTitle;
+
+  /// No description provided for @netWorthLiabilities.
+  ///
+  /// In en, this message translates to:
+  /// **'Liabilities'**
+  String get netWorthLiabilities;
+
+  /// No description provided for @netWorthLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load net worth data'**
+  String get netWorthLoadError;
+
+  /// No description provided for @netWorthTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Net Worth'**
+  String get netWorthTitle;
+
+  /// No description provided for @payeeAddButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Payee'**
+  String get payeeAddButton;
+
+  /// No description provided for @payeeAutoEnvelopeHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Envelope auto-suggested from last transaction with this payee'**
+  String get payeeAutoEnvelopeHint;
+
+  /// No description provided for @payeeCreateError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not create payee. Please try again.'**
+  String get payeeCreateError;
+
+  /// No description provided for @payeeCreateSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Payee created'**
+  String get payeeCreateSuccess;
+
+  /// No description provided for @payeeEditError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update payee. Please try again.'**
+  String get payeeEditError;
+
+  /// No description provided for @payeeEditSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Payee updated'**
+  String get payeeEditSuccess;
+
+  /// No description provided for @payeeEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Payee'**
+  String get payeeEditTitle;
+
+  /// No description provided for @payeeEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add payees to track who you transact with'**
+  String get payeeEmptySubtitle;
+
+  /// No description provided for @payeeEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Payees Yet'**
+  String get payeeEmptyTitle;
+
+  /// No description provided for @payeeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Payee'**
+  String get payeeLabel;
+
+  /// No description provided for @payeeListTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Payees'**
+  String get payeeListTitle;
+
+  /// No description provided for @payeeLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load payees'**
+  String get payeeLoadError;
+
+  /// No description provided for @payeeNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Payee Name'**
+  String get payeeNameLabel;
+
+  /// No description provided for @payeeNone.
+  ///
+  /// In en, this message translates to:
+  /// **'No Payee'**
+  String get payeeNone;
 
   /// No description provided for @payeeSearchHint.
   ///
@@ -1954,125 +1240,101 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 payee} other{{count} payees}}'**
   String payeeSearchResultCount(int count);
 
-  /// No description provided for @transactionExportCsv.
+  /// No description provided for @quickBudgetAverageBudgeted.
   ///
   /// In en, this message translates to:
-  /// **'Copy as CSV'**
-  String get transactionExportCsv;
+  /// **'Average Budgeted'**
+  String get quickBudgetAverageBudgeted;
 
-  /// No description provided for @transactionExportSuccess.
+  /// No description provided for @quickBudgetAverageSpent.
   ///
   /// In en, this message translates to:
-  /// **'{count, plural, =1{1 transaction copied to clipboard} other{{count} transactions copied to clipboard}}'**
-  String transactionExportSuccess(int count);
+  /// **'Average Spent'**
+  String get quickBudgetAverageSpent;
 
-  /// No description provided for @themeTitle.
+  /// No description provided for @quickBudgetError.
   ///
   /// In en, this message translates to:
-  /// **'Appearance'**
-  String get themeTitle;
+  /// **'Could not load budget suggestions'**
+  String get quickBudgetError;
 
-  /// No description provided for @themeSystem.
+  /// No description provided for @quickBudgetLastMonth.
   ///
   /// In en, this message translates to:
-  /// **'System'**
-  String get themeSystem;
+  /// **'Budgeted Last Month'**
+  String get quickBudgetLastMonth;
 
-  /// No description provided for @themeLight.
+  /// No description provided for @quickBudgetSpentLastMonth.
   ///
   /// In en, this message translates to:
-  /// **'Light'**
-  String get themeLight;
+  /// **'Spent Last Month'**
+  String get quickBudgetSpentLastMonth;
 
-  /// No description provided for @themeDark.
+  /// No description provided for @quickBudgetTitle.
   ///
   /// In en, this message translates to:
-  /// **'Dark'**
-  String get themeDark;
+  /// **'Quick Budget'**
+  String get quickBudgetTitle;
 
-  /// No description provided for @transactionDateToday.
+  /// No description provided for @reconcileButton.
   ///
   /// In en, this message translates to:
-  /// **'Today'**
-  String get transactionDateToday;
+  /// **'Reconcile'**
+  String get reconcileButton;
 
-  /// No description provided for @transactionDateYesterday.
+  /// No description provided for @reconcileError.
   ///
   /// In en, this message translates to:
-  /// **'Yesterday'**
-  String get transactionDateYesterday;
+  /// **'Could not reconcile account. Please try again.'**
+  String get reconcileError;
 
-  /// No description provided for @spendingByPayeeTitle.
+  /// No description provided for @reconcileMessage.
   ///
   /// In en, this message translates to:
-  /// **'Spending by Payee'**
-  String get spendingByPayeeTitle;
+  /// **'Mark all cleared transactions as reconciled? This locks them from further editing.'**
+  String get reconcileMessage;
 
-  /// No description provided for @spendingByPayeeEmptyTitle.
+  /// No description provided for @reconcileSuccess.
   ///
   /// In en, this message translates to:
-  /// **'No Payee Data'**
-  String get spendingByPayeeEmptyTitle;
+  /// **'{count, plural, =0{No transactions to reconcile} =1{1 transaction reconciled} other{{count} transactions reconciled}}'**
+  String reconcileSuccess(int count);
 
-  /// No description provided for @spendingByPayeeEmptySubtitle.
+  /// No description provided for @reconcileTitle.
   ///
   /// In en, this message translates to:
-  /// **'Add expense transactions to see spending by payee'**
-  String get spendingByPayeeEmptySubtitle;
+  /// **'Reconcile Account'**
+  String get reconcileTitle;
 
-  /// No description provided for @spendingByPayeeTotalSpent.
+  /// No description provided for @recurringAddButton.
   ///
   /// In en, this message translates to:
-  /// **'Total Spent'**
-  String get spendingByPayeeTotalSpent;
+  /// **'Add Recurring'**
+  String get recurringAddButton;
 
-  /// No description provided for @spendingByPayeePayeeCount.
+  /// No description provided for @recurringAddTitle.
   ///
   /// In en, this message translates to:
-  /// **'Payees'**
-  String get spendingByPayeePayeeCount;
+  /// **'Add Recurring Transaction'**
+  String get recurringAddTitle;
 
-  /// No description provided for @spendingByPayeeBreakdown.
+  /// No description provided for @recurringCreateError.
   ///
   /// In en, this message translates to:
-  /// **'Spending Breakdown'**
-  String get spendingByPayeeBreakdown;
+  /// **'Could not create recurring transaction. Please try again.'**
+  String get recurringCreateError;
 
-  /// No description provided for @spendingByPayeeTransactionCount.
+  /// No description provided for @recurringCreateSuccess.
   ///
   /// In en, this message translates to:
-  /// **'{count, plural, =1{1 transaction} other{{count} transactions}}'**
-  String spendingByPayeeTransactionCount(int count);
+  /// **'Recurring transaction created'**
+  String get recurringCreateSuccess;
 
-  /// No description provided for @budgetGoToToday.
+  /// No description provided for @recurringDueBanner.
   ///
   /// In en, this message translates to:
-  /// **'Back to Today'**
-  String get budgetGoToToday;
-
-  /// No description provided for @categoryTrendsTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Category Trends'**
-  String get categoryTrendsTitle;
-
-  /// No description provided for @categoryTrendsLoadError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not load category trends'**
-  String get categoryTrendsLoadError;
-
-  /// No description provided for @categoryTrendsEmptyTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'No Category Data'**
-  String get categoryTrendsEmptyTitle;
-
-  /// No description provided for @categoryTrendsEmptySubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Add categorized transactions to see spending trends by category'**
-  String get categoryTrendsEmptySubtitle;
+  /// **'{count, plural, =1{1 scheduled transaction is due} other{{count} scheduled transactions are due}}'**
+  String recurringDueBanner(int count);
 
   /// No description provided for @recurringDueLabel.
   ///
@@ -2080,11 +1342,125 @@ abstract class AppLocalizations {
   /// **'Due now'**
   String get recurringDueLabel;
 
+  /// No description provided for @recurringEditError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update recurring transaction. Please try again.'**
+  String get recurringEditError;
+
+  /// No description provided for @recurringEditSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Recurring transaction updated'**
+  String get recurringEditSuccess;
+
+  /// No description provided for @recurringEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Recurring Transaction'**
+  String get recurringEditTitle;
+
+  /// No description provided for @recurringEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Set up recurring transactions for bills, subscriptions, and regular income'**
+  String get recurringEmptySubtitle;
+
+  /// No description provided for @recurringEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Recurring Transactions'**
+  String get recurringEmptyTitle;
+
+  /// No description provided for @recurringFreqBiweekly.
+  ///
+  /// In en, this message translates to:
+  /// **'Biweekly'**
+  String get recurringFreqBiweekly;
+
+  /// No description provided for @recurringFreqDaily.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily'**
+  String get recurringFreqDaily;
+
+  /// No description provided for @recurringFreqMonthly.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly'**
+  String get recurringFreqMonthly;
+
+  /// No description provided for @recurringFreqWeekly.
+  ///
+  /// In en, this message translates to:
+  /// **'Weekly'**
+  String get recurringFreqWeekly;
+
+  /// No description provided for @recurringFreqYearly.
+  ///
+  /// In en, this message translates to:
+  /// **'Yearly'**
+  String get recurringFreqYearly;
+
+  /// No description provided for @recurringFrequencyLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Frequency'**
+  String get recurringFrequencyLabel;
+
+  /// No description provided for @recurringListTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Recurring Transactions'**
+  String get recurringListTitle;
+
+  /// No description provided for @recurringLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load recurring transactions'**
+  String get recurringLoadError;
+
+  /// No description provided for @recurringNextDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Next'**
+  String get recurringNextDate;
+
+  /// No description provided for @recurringPostDue.
+  ///
+  /// In en, this message translates to:
+  /// **'Post Now'**
+  String get recurringPostDue;
+
+  /// No description provided for @recurringPostError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not post scheduled transactions. Please try again.'**
+  String get recurringPostError;
+
+  /// No description provided for @recurringPostSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction posted} other{{count} transactions posted}}'**
+  String recurringPostSuccess(int count);
+
+  /// No description provided for @recurringPosting.
+  ///
+  /// In en, this message translates to:
+  /// **'Posting...'**
+  String get recurringPosting;
+
   /// No description provided for @recurringSkipButton.
   ///
   /// In en, this message translates to:
   /// **'Skip'**
   String get recurringSkipButton;
+
+  /// No description provided for @recurringSkipError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not skip occurrence. Please try again.'**
+  String get recurringSkipError;
 
   /// No description provided for @recurringSkipSuccess.
   ///
@@ -2092,11 +1468,191 @@ abstract class AppLocalizations {
   /// **'Occurrence skipped'**
   String get recurringSkipSuccess;
 
-  /// No description provided for @recurringSkipError.
+  /// No description provided for @recurringStartDate.
   ///
   /// In en, this message translates to:
-  /// **'Could not skip occurrence. Please try again.'**
-  String get recurringSkipError;
+  /// **'Start Date'**
+  String get recurringStartDate;
+
+  /// No description provided for @registerAlreadyHaveAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'Already have an account? Sign In'**
+  String get registerAlreadyHaveAccount;
+
+  /// No description provided for @registerCodeError.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid verification code. Please try again.'**
+  String get registerCodeError;
+
+  /// No description provided for @registerCodeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Verification Code'**
+  String get registerCodeLabel;
+
+  /// No description provided for @registerCodeRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter the verification code'**
+  String get registerCodeRequired;
+
+  /// No description provided for @registerConfirmPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm Password'**
+  String get registerConfirmPassword;
+
+  /// No description provided for @registerCreateAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'Create Account'**
+  String get registerCreateAccount;
+
+  /// No description provided for @registerEmailError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not start registration. Please try again.'**
+  String get registerEmailError;
+
+  /// No description provided for @registerEmailRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your email address'**
+  String get registerEmailRequired;
+
+  /// No description provided for @registerPasswordMismatch.
+  ///
+  /// In en, this message translates to:
+  /// **'Passwords do not match'**
+  String get registerPasswordMismatch;
+
+  /// No description provided for @registerPasswordRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a password'**
+  String get registerPasswordRequired;
+
+  /// No description provided for @registerSendCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Send Verification Code'**
+  String get registerSendCode;
+
+  /// No description provided for @registerStepCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter the verification code sent to your email'**
+  String get registerStepCode;
+
+  /// No description provided for @registerStepEmail.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your email to get started'**
+  String get registerStepEmail;
+
+  /// No description provided for @registerStepPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a password for your account'**
+  String get registerStepPassword;
+
+  /// No description provided for @registerSubmitting.
+  ///
+  /// In en, this message translates to:
+  /// **'Please wait...'**
+  String get registerSubmitting;
+
+  /// No description provided for @registerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Create Account'**
+  String get registerTitle;
+
+  /// No description provided for @registerVerifyCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Verify Code'**
+  String get registerVerifyCode;
+
+  /// No description provided for @reportsEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add transactions to see spending reports for this month'**
+  String get reportsEmptySubtitle;
+
+  /// No description provided for @reportsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Data Yet'**
+  String get reportsEmptyTitle;
+
+  /// No description provided for @reportsExpenses.
+  ///
+  /// In en, this message translates to:
+  /// **'Expenses'**
+  String get reportsExpenses;
+
+  /// No description provided for @reportsIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get reportsIncome;
+
+  /// No description provided for @reportsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load report data'**
+  String get reportsLoadError;
+
+  /// No description provided for @reportsNetIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Net Income'**
+  String get reportsNetIncome;
+
+  /// No description provided for @reportsSpendingByCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending by Category'**
+  String get reportsSpendingByCategory;
+
+  /// No description provided for @reportsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Reports'**
+  String get reportsTitle;
+
+  /// No description provided for @reportsTransactions.
+  ///
+  /// In en, this message translates to:
+  /// **'Transactions'**
+  String get reportsTransactions;
+
+  /// No description provided for @settingsAccountSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Account'**
+  String get settingsAccountSection;
+
+  /// No description provided for @settingsBudgetName.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget Name'**
+  String get settingsBudgetName;
+
+  /// No description provided for @settingsBudgetSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget'**
+  String get settingsBudgetSection;
+
+  /// No description provided for @settingsCurrency.
+  ///
+  /// In en, this message translates to:
+  /// **'Currency'**
+  String get settingsCurrency;
 
   /// No description provided for @settingsDataSection.
   ///
@@ -2116,59 +1672,233 @@ abstract class AppLocalizations {
   /// **'Copy all budget data as JSON to clipboard'**
   String get settingsExportDataHint;
 
-  /// No description provided for @settingsExportSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Budget data copied to clipboard'**
-  String get settingsExportSuccess;
-
   /// No description provided for @settingsExportError.
   ///
   /// In en, this message translates to:
   /// **'Could not export budget data. Please try again.'**
   String get settingsExportError;
 
-  /// No description provided for @envelopeReorderHint.
+  /// No description provided for @settingsExportSuccess.
   ///
   /// In en, this message translates to:
-  /// **'Long press an envelope to reorder within category'**
-  String get envelopeReorderHint;
+  /// **'Budget data copied to clipboard'**
+  String get settingsExportSuccess;
 
-  /// No description provided for @templateTitle.
+  /// No description provided for @settingsLoadError.
   ///
   /// In en, this message translates to:
-  /// **'Budget Templates'**
-  String get templateTitle;
+  /// **'Could not load settings'**
+  String get settingsLoadError;
 
-  /// No description provided for @templateSaveButton.
+  /// No description provided for @settingsLogoutConfirm.
   ///
   /// In en, this message translates to:
-  /// **'Save Current Month as Template'**
-  String get templateSaveButton;
+  /// **'Are you sure you want to sign out?'**
+  String get settingsLogoutConfirm;
 
-  /// No description provided for @templateNameLabel.
+  /// No description provided for @settingsNavigationSection.
   ///
   /// In en, this message translates to:
-  /// **'Template Name'**
-  String get templateNameLabel;
+  /// **'Quick Access'**
+  String get settingsNavigationSection;
 
-  /// No description provided for @templateNameHint.
+  /// No description provided for @settingsRenameBudget.
   ///
   /// In en, this message translates to:
-  /// **'e.g. Standard Month'**
-  String get templateNameHint;
+  /// **'Rename Budget'**
+  String get settingsRenameBudget;
 
-  /// No description provided for @templateSaveSuccess.
+  /// No description provided for @settingsRenameError.
   ///
   /// In en, this message translates to:
-  /// **'Template saved'**
-  String get templateSaveSuccess;
+  /// **'Could not rename budget. Please try again.'**
+  String get settingsRenameError;
 
-  /// No description provided for @templateSaveError.
+  /// No description provided for @settingsRenameSuccess.
   ///
   /// In en, this message translates to:
-  /// **'Could not save template. Please try again.'**
-  String get templateSaveError;
+  /// **'Budget renamed'**
+  String get settingsRenameSuccess;
+
+  /// No description provided for @settingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settingsTitle;
+
+  /// No description provided for @settingsVersion.
+  ///
+  /// In en, this message translates to:
+  /// **'OpenBudget v1.0.0'**
+  String get settingsVersion;
+
+  /// No description provided for @spendingByPayeeBreakdown.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending Breakdown'**
+  String get spendingByPayeeBreakdown;
+
+  /// No description provided for @spendingByPayeeEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add expense transactions to see spending by payee'**
+  String get spendingByPayeeEmptySubtitle;
+
+  /// No description provided for @spendingByPayeeEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Payee Data'**
+  String get spendingByPayeeEmptyTitle;
+
+  /// No description provided for @spendingByPayeePayeeCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Payees'**
+  String get spendingByPayeePayeeCount;
+
+  /// No description provided for @spendingByPayeeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending by Payee'**
+  String get spendingByPayeeTitle;
+
+  /// No description provided for @spendingByPayeeTotalSpent.
+  ///
+  /// In en, this message translates to:
+  /// **'Total Spent'**
+  String get spendingByPayeeTotalSpent;
+
+  /// No description provided for @spendingByPayeeTransactionCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction} other{{count} transactions}}'**
+  String spendingByPayeeTransactionCount(int count);
+
+  /// No description provided for @spendingTrendsAvgExpenses.
+  ///
+  /// In en, this message translates to:
+  /// **'Avg. Expenses'**
+  String get spendingTrendsAvgExpenses;
+
+  /// No description provided for @spendingTrendsAvgIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Avg. Income'**
+  String get spendingTrendsAvgIncome;
+
+  /// No description provided for @spendingTrendsBreakdown.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly Breakdown'**
+  String get spendingTrendsBreakdown;
+
+  /// No description provided for @spendingTrendsEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add transactions to see spending trends over time'**
+  String get spendingTrendsEmptySubtitle;
+
+  /// No description provided for @spendingTrendsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Spending Data'**
+  String get spendingTrendsEmptyTitle;
+
+  /// No description provided for @spendingTrendsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load spending trends'**
+  String get spendingTrendsLoadError;
+
+  /// No description provided for @spendingTrendsMonthly.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly Comparison'**
+  String get spendingTrendsMonthly;
+
+  /// No description provided for @spendingTrendsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending Trends'**
+  String get spendingTrendsTitle;
+
+  /// No description provided for @splitAddSplit.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Split'**
+  String get splitAddSplit;
+
+  /// No description provided for @splitAmountLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Amount'**
+  String get splitAmountLabel;
+
+  /// No description provided for @splitCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 split} other{{count} splits}}'**
+  String splitCount(int count);
+
+  /// No description provided for @splitEnvelopeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Envelope'**
+  String get splitEnvelopeLabel;
+
+  /// No description provided for @splitLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Split'**
+  String get splitLabel;
+
+  /// No description provided for @splitMemoLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Memo (optional)'**
+  String get splitMemoLabel;
+
+  /// No description provided for @splitMinimumError.
+  ///
+  /// In en, this message translates to:
+  /// **'At least two splits are required'**
+  String get splitMinimumError;
+
+  /// No description provided for @splitMismatchError.
+  ///
+  /// In en, this message translates to:
+  /// **'Split amounts must equal the total'**
+  String get splitMismatchError;
+
+  /// No description provided for @splitRemainingLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Remaining to assign'**
+  String get splitRemainingLabel;
+
+  /// No description provided for @splitRemoveSplit.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get splitRemoveSplit;
+
+  /// No description provided for @splitSaveError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save split transaction. Please try again.'**
+  String get splitSaveError;
+
+  /// No description provided for @splitSaveSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Split transaction saved'**
+  String get splitSaveSuccess;
+
+  /// No description provided for @splitTransactionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Split Transaction'**
+  String get splitTransactionTitle;
 
   /// No description provided for @templateApplyButton.
   ///
@@ -2176,23 +1906,17 @@ abstract class AppLocalizations {
   /// **'Apply'**
   String get templateApplyButton;
 
-  /// No description provided for @templateApplySuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Template applied to current month'**
-  String get templateApplySuccess;
-
   /// No description provided for @templateApplyError.
   ///
   /// In en, this message translates to:
   /// **'Could not apply template. Please try again.'**
   String get templateApplyError;
 
-  /// No description provided for @templateDeleteSuccess.
+  /// No description provided for @templateApplySuccess.
   ///
   /// In en, this message translates to:
-  /// **'Template deleted'**
-  String get templateDeleteSuccess;
+  /// **'Template applied to current month'**
+  String get templateApplySuccess;
 
   /// No description provided for @templateDeleteError.
   ///
@@ -2200,11 +1924,11 @@ abstract class AppLocalizations {
   /// **'Could not delete template. Please try again.'**
   String get templateDeleteError;
 
-  /// No description provided for @templateEmptyTitle.
+  /// No description provided for @templateDeleteSuccess.
   ///
   /// In en, this message translates to:
-  /// **'No Templates'**
-  String get templateEmptyTitle;
+  /// **'Template deleted'**
+  String get templateDeleteSuccess;
 
   /// No description provided for @templateEmptySubtitle.
   ///
@@ -2212,11 +1936,311 @@ abstract class AppLocalizations {
   /// **'Save your current month allocations as a template to quickly set up future months.'**
   String get templateEmptySubtitle;
 
-  /// No description provided for @duplicateWarning.
+  /// No description provided for @templateEmptyTitle.
   ///
   /// In en, this message translates to:
-  /// **'{count, plural, =1{Possible duplicate: 1 similar transaction found} other{Possible duplicates: {count} similar transactions found}}'**
-  String duplicateWarning(int count);
+  /// **'No Templates'**
+  String get templateEmptyTitle;
+
+  /// No description provided for @templateNameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. Standard Month'**
+  String get templateNameHint;
+
+  /// No description provided for @templateNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Template Name'**
+  String get templateNameLabel;
+
+  /// No description provided for @templateSaveButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Current Month as Template'**
+  String get templateSaveButton;
+
+  /// No description provided for @templateSaveError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save template. Please try again.'**
+  String get templateSaveError;
+
+  /// No description provided for @templateSaveSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Template saved'**
+  String get templateSaveSuccess;
+
+  /// No description provided for @templateTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget Templates'**
+  String get templateTitle;
+
+  /// No description provided for @themeDark.
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeDark;
+
+  /// No description provided for @themeLight.
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeLight;
+
+  /// No description provided for @themeSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'System'**
+  String get themeSystem;
+
+  /// No description provided for @themeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Appearance'**
+  String get themeTitle;
+
+  /// No description provided for @transactionAddExpense.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Expense'**
+  String get transactionAddExpense;
+
+  /// No description provided for @transactionAddIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Income'**
+  String get transactionAddIncome;
+
+  /// No description provided for @transactionAmountLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Amount'**
+  String get transactionAmountLabel;
+
+  /// No description provided for @transactionCleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Cleared'**
+  String get transactionCleared;
+
+  /// No description provided for @transactionDateToday.
+  ///
+  /// In en, this message translates to:
+  /// **'Today'**
+  String get transactionDateToday;
+
+  /// No description provided for @transactionDateYesterday.
+  ///
+  /// In en, this message translates to:
+  /// **'Yesterday'**
+  String get transactionDateYesterday;
+
+  /// No description provided for @transactionDescriptionLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Description'**
+  String get transactionDescriptionLabel;
+
+  /// No description provided for @transactionEditError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update transaction. Please try again.'**
+  String get transactionEditError;
+
+  /// No description provided for @transactionEditSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Transaction updated'**
+  String get transactionEditSuccess;
+
+  /// No description provided for @transactionEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Transaction'**
+  String get transactionEditTitle;
+
+  /// No description provided for @transactionEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No transactions yet'**
+  String get transactionEmpty;
+
+  /// No description provided for @transactionError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save transaction. Please try again.'**
+  String get transactionError;
+
+  /// No description provided for @transactionExportCsv.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy as CSV'**
+  String get transactionExportCsv;
+
+  /// No description provided for @transactionExportSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction copied to clipboard} other{{count} transactions copied to clipboard}}'**
+  String transactionExportSuccess(int count);
+
+  /// No description provided for @transactionFilterAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get transactionFilterAll;
+
+  /// No description provided for @transactionFilterExpense.
+  ///
+  /// In en, this message translates to:
+  /// **'Expense'**
+  String get transactionFilterExpense;
+
+  /// No description provided for @transactionFilterIncome.
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get transactionFilterIncome;
+
+  /// No description provided for @transactionListTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Transactions'**
+  String get transactionListTitle;
+
+  /// No description provided for @transactionLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load transactions'**
+  String get transactionLoadError;
+
+  /// No description provided for @transactionMemoHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a note (optional)'**
+  String get transactionMemoHint;
+
+  /// No description provided for @transactionMemoLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Memo'**
+  String get transactionMemoLabel;
+
+  /// No description provided for @transactionNoResults.
+  ///
+  /// In en, this message translates to:
+  /// **'No matching transactions'**
+  String get transactionNoResults;
+
+  /// No description provided for @transactionReconciled.
+  ///
+  /// In en, this message translates to:
+  /// **'Reconciled'**
+  String get transactionReconciled;
+
+  /// No description provided for @transactionResultCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 result} other{{count} results}}'**
+  String transactionResultCount(int count);
+
+  /// No description provided for @transactionSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Transaction'**
+  String get transactionSave;
+
+  /// No description provided for @transactionSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search transactions...'**
+  String get transactionSearchHint;
+
+  /// No description provided for @transactionSubmitting.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving...'**
+  String get transactionSubmitting;
+
+  /// No description provided for @transactionSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Transaction saved'**
+  String get transactionSuccess;
+
+  /// No description provided for @transactionUnassigned.
+  ///
+  /// In en, this message translates to:
+  /// **'Unassigned'**
+  String get transactionUnassigned;
+
+  /// No description provided for @transactionUncleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Uncleared'**
+  String get transactionUncleared;
+
+  /// No description provided for @transferButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Transfer'**
+  String get transferButton;
+
+  /// No description provided for @transferDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Transfer Date'**
+  String get transferDate;
+
+  /// No description provided for @transferDefaultDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Account Transfer'**
+  String get transferDefaultDescription;
+
+  /// No description provided for @transferError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not complete transfer. Please try again.'**
+  String get transferError;
+
+  /// No description provided for @transferFromAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'From Account'**
+  String get transferFromAccount;
+
+  /// No description provided for @transferNeedTwoAccounts.
+  ///
+  /// In en, this message translates to:
+  /// **'You need at least two accounts to make a transfer'**
+  String get transferNeedTwoAccounts;
+
+  /// No description provided for @transferSameAccountError.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot transfer to the same account'**
+  String get transferSameAccountError;
+
+  /// No description provided for @transferSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Transfer completed'**
+  String get transferSuccess;
+
+  /// No description provided for @transferTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Transfer'**
+  String get transferTitle;
+
+  /// No description provided for @transferToAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'To Account'**
+  String get transferToAccount;
 }
 
 class _AppLocalizationsDelegate

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -9,254 +9,51 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get appTitle => 'OpenBudget';
+  String get accountAddButton => 'Add Account';
 
   @override
-  String get loginTitle => 'Welcome to OpenBudget';
+  String get accountAddTitle => 'Add Account';
 
   @override
-  String get loginEmailLabel => 'Email';
+  String get accountBalanceLabel => 'Starting Balance';
 
   @override
-  String get loginPasswordLabel => 'Password';
+  String get accountCloseButton => 'Close Account';
 
   @override
-  String get loginButton => 'Sign In';
+  String get accountCloseConfirm =>
+      'Close this account? It will be moved to Closed Accounts.';
 
   @override
-  String get loginLoading => 'Signing In...';
+  String get accountCloseSuccess => 'Account closed';
 
   @override
-  String get loginCreateAccount => 'Create Account';
+  String get accountClosed => 'Closed Accounts';
 
   @override
-  String get registerTitle => 'Create Account';
+  String get accountCreateError =>
+      'Could not create account. Please try again.';
 
   @override
-  String get registerStepEmail => 'Enter your email to get started';
+  String get accountCreateSuccess => 'Account created';
 
   @override
-  String get registerStepCode =>
-      'Enter the verification code sent to your email';
+  String get accountDetailBalance => 'Balance';
 
   @override
-  String get registerStepPassword => 'Choose a password for your account';
+  String get accountEditError => 'Could not update account. Please try again.';
 
   @override
-  String get registerSendCode => 'Send Verification Code';
+  String get accountEditSuccess => 'Account updated';
 
   @override
-  String get registerCodeLabel => 'Verification Code';
+  String get accountEditTitle => 'Edit Account';
 
   @override
-  String get registerVerifyCode => 'Verify Code';
+  String get accountEmptySubtitle => 'Add your first account to track balances';
 
   @override
-  String get registerConfirmPassword => 'Confirm Password';
-
-  @override
-  String get registerCreateAccount => 'Create Account';
-
-  @override
-  String get registerSubmitting => 'Please wait...';
-
-  @override
-  String get registerAlreadyHaveAccount => 'Already have an account? Sign In';
-
-  @override
-  String get registerEmailRequired => 'Please enter your email address';
-
-  @override
-  String get registerEmailError =>
-      'Could not start registration. Please try again.';
-
-  @override
-  String get registerCodeRequired => 'Please enter the verification code';
-
-  @override
-  String get registerCodeError =>
-      'Invalid verification code. Please try again.';
-
-  @override
-  String get registerPasswordRequired => 'Please enter a password';
-
-  @override
-  String get registerPasswordMismatch => 'Passwords do not match';
-
-  @override
-  String get homeLogout => 'Sign Out';
-
-  @override
-  String get homeNoBudgets => 'No Budgets Yet';
-
-  @override
-  String get homeCreateBudget => 'Create Your First Budget';
-
-  @override
-  String get homeLoadError => 'Could not load budgets';
-
-  @override
-  String get homeRetry => 'Retry';
-
-  @override
-  String homeBudgetCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count budgets',
-      one: '1 budget',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get createBudgetTitle => 'Create Budget';
-
-  @override
-  String get createBudgetNameLabel => 'Budget Name';
-
-  @override
-  String get createBudgetCurrencyLabel => 'Primary Currency';
-
-  @override
-  String get createBudgetButton => 'Create';
-
-  @override
-  String get budgetEmptyTitle => 'No Categories Yet';
-
-  @override
-  String get budgetEmptySubtitle =>
-      'Add your first envelope category to start budgeting';
-
-  @override
-  String get budgetReadyToAssign => 'Ready to Assign';
-
-  @override
-  String get budgetColumnBudgeted => 'Budgeted';
-
-  @override
-  String get budgetColumnSpent => 'Spent';
-
-  @override
-  String get budgetColumnAvailable => 'Available';
-
-  @override
-  String get budgetAddCategory => 'Add Category';
-
-  @override
-  String get budgetAddEnvelope => 'Add Envelope';
-
-  @override
-  String get budgetAddIncome => 'Add Income';
-
-  @override
-  String get budgetAddExpense => 'Add Expense';
-
-  @override
-  String get budgetCategoryTotal => 'Total';
-
-  @override
-  String get budgetCategoryNameLabel => 'Category Name';
-
-  @override
-  String get budgetEnvelopeNameLabel => 'Envelope Name';
-
-  @override
-  String get budgetEnvelopeAmountLabel => 'Budgeted Amount';
-
-  @override
-  String get budgetLoadError => 'Could not load budget details';
-
-  @override
-  String get dialogSave => 'Save';
-
-  @override
-  String get dialogSaving => 'Saving...';
-
-  @override
-  String get dialogCancel => 'Cancel';
-
-  @override
-  String get transactionAddIncome => 'Add Income';
-
-  @override
-  String get transactionAddExpense => 'Add Expense';
-
-  @override
-  String get transactionDescriptionLabel => 'Description';
-
-  @override
-  String get transactionAmountLabel => 'Amount';
-
-  @override
-  String get transactionSave => 'Save Transaction';
-
-  @override
-  String get transactionSubmitting => 'Saving...';
-
-  @override
-  String get transactionUnassigned => 'Unassigned';
-
-  @override
-  String get transactionListTitle => 'Transactions';
-
-  @override
-  String get transactionLoadError => 'Could not load transactions';
-
-  @override
-  String get transactionEmpty => 'No transactions yet';
-
-  @override
-  String get createBudgetCreating => 'Creating...';
-
-  @override
-  String get createBudgetSuccess => 'Budget created successfully';
-
-  @override
-  String get createBudgetError => 'Could not create budget. Please try again.';
-
-  @override
-  String get budgetCategoryCreated => 'Category created';
-
-  @override
-  String get budgetEnvelopeCreated => 'Envelope created';
-
-  @override
-  String get budgetCategoryCreateError => 'Could not create category';
-
-  @override
-  String get budgetEnvelopeCreateError => 'Could not create envelope';
-
-  @override
-  String get transactionSuccess => 'Transaction saved';
-
-  @override
-  String get transactionError =>
-      'Could not save transaction. Please try again.';
-
-  @override
-  String get deleteConfirmTitle => 'Delete';
-
-  @override
-  String get deleteConfirmMessage => 'Are you sure you want to delete this?';
-
-  @override
-  String get deleteConfirmButton => 'Delete';
-
-  @override
-  String get deleteSuccess => 'Deleted successfully';
-
-  @override
-  String get deleteError => 'Could not delete. Please try again.';
-
-  @override
-  String get editEnvelopeTitle => 'Edit Envelope';
-
-  @override
-  String get editEnvelopeSaved => 'Envelope updated';
-
-  @override
-  String get editEnvelopeError => 'Could not update envelope';
+  String get accountEmptyTitle => 'No Accounts Yet';
 
   @override
   String get accountListTitle => 'Accounts';
@@ -265,401 +62,49 @@ class AppLocalizationsEn extends AppLocalizations {
   String get accountLoadError => 'Could not load accounts';
 
   @override
-  String get accountEmptyTitle => 'No Accounts Yet';
-
-  @override
-  String get accountEmptySubtitle => 'Add your first account to track balances';
-
-  @override
-  String get accountAddTitle => 'Add Account';
-
-  @override
-  String get accountAddButton => 'Add Account';
-
-  @override
   String get accountNameLabel => 'Account Name';
-
-  @override
-  String get accountTypeLabel => 'Account Type';
-
-  @override
-  String get accountBalanceLabel => 'Starting Balance';
-
-  @override
-  String get accountOnBudgetLabel => 'On Budget';
-
-  @override
-  String get accountOnBudgetHint => 'Include in budget calculations';
-
-  @override
-  String get accountTypeChecking => 'Checking';
-
-  @override
-  String get accountTypeSavings => 'Savings';
-
-  @override
-  String get accountTypeCreditCard => 'Credit Card';
-
-  @override
-  String get accountTypeCash => 'Cash';
-
-  @override
-  String get accountTypeInvestment => 'Investment';
-
-  @override
-  String get accountTypeOther => 'Other';
-
-  @override
-  String get accountOnBudget => 'Budget Accounts';
 
   @override
   String get accountOffBudget => 'Tracking Accounts';
 
   @override
-  String get accountClosed => 'Closed Accounts';
+  String get accountOnBudget => 'Budget Accounts';
 
   @override
-  String get accountCreateSuccess => 'Account created';
+  String get accountOnBudgetHint => 'Include in budget calculations';
 
   @override
-  String get accountCreateError =>
-      'Could not create account. Please try again.';
+  String get accountOnBudgetLabel => 'On Budget';
 
   @override
-  String get budgetViewAccounts => 'Accounts';
+  String get accountReopenButton => 'Reopen Account';
 
   @override
-  String get transactionEditTitle => 'Edit Transaction';
+  String get accountReopenSuccess => 'Account reopened';
 
   @override
-  String get transactionEditSuccess => 'Transaction updated';
+  String get accountRunningBalance => 'Running Balance';
 
   @override
-  String get transactionEditError =>
-      'Could not update transaction. Please try again.';
+  String get accountTypeCash => 'Cash';
 
   @override
-  String get budgetMonthJanuary => 'January';
+  String get accountTypeChecking => 'Checking';
 
   @override
-  String get budgetMonthFebruary => 'February';
+  String get accountTypeCreditCard => 'Credit Card';
 
   @override
-  String get budgetMonthMarch => 'March';
+  String get accountTypeInvestment => 'Investment';
 
   @override
-  String get budgetMonthApril => 'April';
+  String get accountTypeLabel => 'Account Type';
 
   @override
-  String get budgetMonthMay => 'May';
+  String get accountTypeOther => 'Other';
 
   @override
-  String get budgetMonthJune => 'June';
-
-  @override
-  String get budgetMonthJuly => 'July';
-
-  @override
-  String get budgetMonthAugust => 'August';
-
-  @override
-  String get budgetMonthSeptember => 'September';
-
-  @override
-  String get budgetMonthOctober => 'October';
-
-  @override
-  String get budgetMonthNovember => 'November';
-
-  @override
-  String get budgetMonthDecember => 'December';
-
-  @override
-  String get budgetAllocationUpdated => 'Allocation updated';
-
-  @override
-  String get budgetAllocationError => 'Could not update allocation';
-
-  @override
-  String get transactionSearchHint => 'Search transactions...';
-
-  @override
-  String get transactionFilterAll => 'All';
-
-  @override
-  String get transactionFilterIncome => 'Income';
-
-  @override
-  String get transactionFilterExpense => 'Expense';
-
-  @override
-  String get transactionNoResults => 'No matching transactions';
-
-  @override
-  String transactionResultCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count results',
-      one: '1 result',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get payeeListTitle => 'Payees';
-
-  @override
-  String get payeeLoadError => 'Could not load payees';
-
-  @override
-  String get payeeEmptyTitle => 'No Payees Yet';
-
-  @override
-  String get payeeEmptySubtitle => 'Add payees to track who you transact with';
-
-  @override
-  String get payeeAddButton => 'Add Payee';
-
-  @override
-  String get payeeNameLabel => 'Payee Name';
-
-  @override
-  String get payeeCreateSuccess => 'Payee created';
-
-  @override
-  String get payeeCreateError => 'Could not create payee. Please try again.';
-
-  @override
-  String get payeeEditTitle => 'Edit Payee';
-
-  @override
-  String get payeeEditSuccess => 'Payee updated';
-
-  @override
-  String get payeeEditError => 'Could not update payee. Please try again.';
-
-  @override
-  String get goalSetTitle => 'Set Goal';
-
-  @override
-  String get goalTypeLabel => 'Goal Type';
-
-  @override
-  String get goalTypeBalance => 'Balance';
-
-  @override
-  String get goalTypeByDate => 'By Date';
-
-  @override
-  String get goalTypeMonthly => 'Monthly';
-
-  @override
-  String get goalAmountLabel => 'Target Amount';
-
-  @override
-  String get goalDateLabel => 'Target Date';
-
-  @override
-  String get goalDateSelect => 'Select a date';
-
-  @override
-  String get goalSaved => 'Goal saved';
-
-  @override
-  String get goalRemoved => 'Goal removed';
-
-  @override
-  String get goalRemove => 'Remove Goal';
-
-  @override
-  String get goalError => 'Could not save goal. Please try again.';
-
-  @override
-  String get goalSetGoal => 'Set Goal';
-
-  @override
-  String get transferTitle => 'Transfer';
-
-  @override
-  String get transferFromAccount => 'From Account';
-
-  @override
-  String get transferToAccount => 'To Account';
-
-  @override
-  String get transferDate => 'Transfer Date';
-
-  @override
-  String get transferButton => 'Transfer';
-
-  @override
-  String get transferDefaultDescription => 'Account Transfer';
-
-  @override
-  String get transferSuccess => 'Transfer completed';
-
-  @override
-  String get transferError => 'Could not complete transfer. Please try again.';
-
-  @override
-  String get transferSameAccountError => 'Cannot transfer to the same account';
-
-  @override
-  String get transferNeedTwoAccounts =>
-      'You need at least two accounts to make a transfer';
-
-  @override
-  String get reportsTitle => 'Reports';
-
-  @override
-  String get reportsLoadError => 'Could not load report data';
-
-  @override
-  String get reportsIncome => 'Income';
-
-  @override
-  String get reportsExpenses => 'Expenses';
-
-  @override
-  String get reportsNetIncome => 'Net Income';
-
-  @override
-  String get reportsTransactions => 'Transactions';
-
-  @override
-  String get reportsSpendingByCategory => 'Spending by Category';
-
-  @override
-  String get reportsEmptyTitle => 'No Data Yet';
-
-  @override
-  String get reportsEmptySubtitle =>
-      'Add transactions to see spending reports for this month';
-
-  @override
-  String get moveMoneyTitle => 'Move Money';
-
-  @override
-  String get moveMoneyFrom => 'From Envelope';
-
-  @override
-  String get moveMoneyTo => 'To Envelope';
-
-  @override
-  String get moveMoneyButton => 'Move';
-
-  @override
-  String get moveMoneySuccess => 'Money moved between envelopes';
-
-  @override
-  String get moveMoneyError => 'Could not move money. Please try again.';
-
-  @override
-  String get moveMoneySameError => 'Cannot move money to the same envelope';
-
-  @override
-  String get creditCardPaymentsTitle => 'Credit Card Payments';
-
-  @override
-  String get creditCardSpentThisMonth => 'Spent this month';
-
-  @override
-  String get accountDetailBalance => 'Balance';
-
-  @override
-  String get transactionUncleared => 'Uncleared';
-
-  @override
-  String get transactionCleared => 'Cleared';
-
-  @override
-  String get transactionReconciled => 'Reconciled';
-
-  @override
-  String get reconcileTitle => 'Reconcile Account';
-
-  @override
-  String get reconcileMessage =>
-      'Mark all cleared transactions as reconciled? This locks them from further editing.';
-
-  @override
-  String get reconcileButton => 'Reconcile';
-
-  @override
-  String reconcileSuccess(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count transactions reconciled',
-      one: '1 transaction reconciled',
-      zero: 'No transactions to reconcile',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get reconcileError => 'Could not reconcile account. Please try again.';
-
-  @override
-  String get recurringListTitle => 'Recurring Transactions';
-
-  @override
-  String get recurringLoadError => 'Could not load recurring transactions';
-
-  @override
-  String get recurringEmptyTitle => 'No Recurring Transactions';
-
-  @override
-  String get recurringEmptySubtitle =>
-      'Set up recurring transactions for bills, subscriptions, and regular income';
-
-  @override
-  String get recurringAddButton => 'Add Recurring';
-
-  @override
-  String get recurringAddTitle => 'Add Recurring Transaction';
-
-  @override
-  String get recurringEditTitle => 'Edit Recurring Transaction';
-
-  @override
-  String get recurringFrequencyLabel => 'Frequency';
-
-  @override
-  String get recurringFreqDaily => 'Daily';
-
-  @override
-  String get recurringFreqWeekly => 'Weekly';
-
-  @override
-  String get recurringFreqBiweekly => 'Biweekly';
-
-  @override
-  String get recurringFreqMonthly => 'Monthly';
-
-  @override
-  String get recurringFreqYearly => 'Yearly';
-
-  @override
-  String get recurringStartDate => 'Start Date';
-
-  @override
-  String get recurringNextDate => 'Next';
-
-  @override
-  String get recurringCreateSuccess => 'Recurring transaction created';
-
-  @override
-  String get recurringCreateError =>
-      'Could not create recurring transaction. Please try again.';
-
-  @override
-  String get recurringEditSuccess => 'Recurring transaction updated';
-
-  @override
-  String get recurringEditError =>
-      'Could not update recurring transaction. Please try again.';
+  String get accountTypeSavings => 'Savings';
 
   @override
   String ageOfMoneyLabel(int days) {
@@ -673,83 +118,190 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get quickBudgetTitle => 'Quick Budget';
+  String get appTitle => 'OpenBudget';
 
   @override
-  String get quickBudgetLastMonth => 'Budgeted Last Month';
+  String get autoAssignAssigning => 'Assigning...';
 
   @override
-  String get quickBudgetSpentLastMonth => 'Spent Last Month';
+  String get autoAssignButton => 'Auto-Assign';
 
   @override
-  String get quickBudgetAverageBudgeted => 'Average Budgeted';
+  String get autoAssignDistributing => 'Distributing to underfunded envelopes';
 
   @override
-  String get quickBudgetAverageSpent => 'Average Spent';
-
-  @override
-  String get quickBudgetError => 'Could not load budget suggestions';
-
-  @override
-  String get splitTransactionTitle => 'Split Transaction';
-
-  @override
-  String get splitAddSplit => 'Add Split';
-
-  @override
-  String get splitRemoveSplit => 'Remove';
-
-  @override
-  String get splitEnvelopeLabel => 'Envelope';
-
-  @override
-  String get splitAmountLabel => 'Amount';
-
-  @override
-  String get splitMemoLabel => 'Memo (optional)';
-
-  @override
-  String get splitRemainingLabel => 'Remaining to assign';
-
-  @override
-  String get splitMismatchError => 'Split amounts must equal the total';
-
-  @override
-  String get splitMinimumError => 'At least two splits are required';
-
-  @override
-  String get splitSaveSuccess => 'Split transaction saved';
-
-  @override
-  String get splitSaveError =>
-      'Could not save split transaction. Please try again.';
-
-  @override
-  String get splitLabel => 'Split';
-
-  @override
-  String splitCount(int count) {
+  String autoAssignEnvelopeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count splits',
-      one: '1 split',
+      other: '$count envelopes',
+      one: '1 envelope',
     );
     return '$_temp0';
   }
 
   @override
-  String get payeeNone => 'No Payee';
+  String get autoAssignError => 'Could not auto-assign. Please try again.';
 
   @override
-  String get payeeLabel => 'Payee';
+  String get autoAssignNothingToAssign =>
+      'All envelopes with goals are fully funded!';
 
   @override
-  String get payeeAutoEnvelopeHint =>
-      'Envelope auto-suggested from last transaction with this payee';
+  String autoAssignSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Auto-assigned to $count envelopes',
+      one: 'Auto-assigned to 1 envelope',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String get accountRunningBalance => 'Running Balance';
+  String get autoAssignTitle => 'Auto-Assign';
+
+  @override
+  String get budgetAddCategory => 'Add Category';
+
+  @override
+  String get budgetAddEnvelope => 'Add Envelope';
+
+  @override
+  String get budgetAddExpense => 'Add Expense';
+
+  @override
+  String get budgetAddIncome => 'Add Income';
+
+  @override
+  String get budgetAllocationError => 'Could not update allocation';
+
+  @override
+  String get budgetAllocationUpdated => 'Allocation updated';
+
+  @override
+  String get budgetCategoryCreateError => 'Could not create category';
+
+  @override
+  String get budgetCategoryCreated => 'Category created';
+
+  @override
+  String get budgetCategoryNameLabel => 'Category Name';
+
+  @override
+  String get budgetCategoryTotal => 'Total';
+
+  @override
+  String get budgetColumnAvailable => 'Available';
+
+  @override
+  String get budgetColumnBudgeted => 'Budgeted';
+
+  @override
+  String get budgetColumnSpent => 'Spent';
+
+  @override
+  String get budgetCopyLastMonth => 'Copy Last Month';
+
+  @override
+  String get budgetCopyLastMonthConfirm =>
+      'Copy all budget allocations from last month to the current month? This will overwrite any existing allocations.';
+
+  @override
+  String get budgetCopyLastMonthError =>
+      'Could not copy previous month. Please try again.';
+
+  @override
+  String get budgetCopyLastMonthSuccess =>
+      'Allocations copied from previous month';
+
+  @override
+  String get budgetDeleteButton => 'Delete';
+
+  @override
+  String budgetDeleteConfirm(String name) {
+    return 'Delete \"$name\"? This will permanently remove the budget and all its data.';
+  }
+
+  @override
+  String get budgetDeleteError => 'Could not delete budget. Please try again.';
+
+  @override
+  String get budgetDeleteSuccess => 'Budget deleted';
+
+  @override
+  String get budgetDeleteTitle => 'Delete Budget';
+
+  @override
+  String get budgetEditCategoryError =>
+      'Could not rename category. Please try again.';
+
+  @override
+  String get budgetEditCategorySuccess => 'Category renamed';
+
+  @override
+  String get budgetEditCategoryTitle => 'Rename Category';
+
+  @override
+  String get budgetEmptySubtitle =>
+      'Add your first envelope category to start budgeting';
+
+  @override
+  String get budgetEmptyTitle => 'No Categories Yet';
+
+  @override
+  String get budgetEnvelopeAmountLabel => 'Budgeted Amount';
+
+  @override
+  String get budgetEnvelopeCreateError => 'Could not create envelope';
+
+  @override
+  String get budgetEnvelopeCreated => 'Envelope created';
+
+  @override
+  String get budgetEnvelopeNameLabel => 'Envelope Name';
+
+  @override
+  String get budgetGoToToday => 'Back to Today';
+
+  @override
+  String get budgetLoadError => 'Could not load budget details';
+
+  @override
+  String get budgetMonthApril => 'April';
+
+  @override
+  String get budgetMonthAugust => 'August';
+
+  @override
+  String get budgetMonthDecember => 'December';
+
+  @override
+  String get budgetMonthFebruary => 'February';
+
+  @override
+  String get budgetMonthJanuary => 'January';
+
+  @override
+  String get budgetMonthJuly => 'July';
+
+  @override
+  String get budgetMonthJune => 'June';
+
+  @override
+  String get budgetMonthMarch => 'March';
+
+  @override
+  String get budgetMonthMay => 'May';
+
+  @override
+  String get budgetMonthNovember => 'November';
+
+  @override
+  String get budgetMonthOctober => 'October';
+
+  @override
+  String get budgetMonthSeptember => 'September';
 
   @override
   String budgetOverspentWarning(String amount) {
@@ -757,18 +309,237 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get importTitle => 'Import Transactions';
+  String get budgetReadyToAssign => 'Ready to Assign';
+
+  @override
+  String get budgetReorderCategories => 'Reorder Categories';
+
+  @override
+  String get budgetReorderDone => 'Done';
+
+  @override
+  String get budgetReorderError => 'Could not reorder categories';
+
+  @override
+  String get budgetReorderHint => 'Drag to reorder categories';
+
+  @override
+  String get budgetReorderSuccess => 'Categories reordered';
+
+  @override
+  String get budgetViewAccounts => 'Accounts';
+
+  @override
+  String get categoryTrendsEmptySubtitle =>
+      'Add categorized transactions to see spending trends by category';
+
+  @override
+  String get categoryTrendsEmptyTitle => 'No Category Data';
+
+  @override
+  String get categoryTrendsLoadError => 'Could not load category trends';
+
+  @override
+  String get categoryTrendsTitle => 'Category Trends';
+
+  @override
+  String get createBudgetButton => 'Create';
+
+  @override
+  String get createBudgetCreating => 'Creating...';
+
+  @override
+  String get createBudgetCurrencyLabel => 'Primary Currency';
+
+  @override
+  String get createBudgetError => 'Could not create budget. Please try again.';
+
+  @override
+  String get createBudgetNameLabel => 'Budget Name';
+
+  @override
+  String get createBudgetSuccess => 'Budget created successfully';
+
+  @override
+  String get createBudgetTitle => 'Create Budget';
+
+  @override
+  String get creditCardPaymentsTitle => 'Credit Card Payments';
+
+  @override
+  String get creditCardSpentThisMonth => 'Spent this month';
+
+  @override
+  String get deleteConfirmButton => 'Delete';
+
+  @override
+  String get deleteConfirmMessage => 'Are you sure you want to delete this?';
+
+  @override
+  String get deleteConfirmTitle => 'Delete';
+
+  @override
+  String get deleteError => 'Could not delete. Please try again.';
+
+  @override
+  String get deleteSuccess => 'Deleted successfully';
+
+  @override
+  String get dialogCancel => 'Cancel';
+
+  @override
+  String get dialogSave => 'Save';
+
+  @override
+  String get dialogSaving => 'Saving...';
+
+  @override
+  String duplicateWarning(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Possible duplicates: $count similar transactions found',
+      one: 'Possible duplicate: 1 similar transaction found',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get editEnvelopeError => 'Could not update envelope';
+
+  @override
+  String get editEnvelopeSaved => 'Envelope updated';
+
+  @override
+  String get editEnvelopeTitle => 'Edit Envelope';
+
+  @override
+  String get envelopeActivityTitle => 'Activity';
+
+  @override
+  String get envelopeNoActivity => 'No transactions this month';
+
+  @override
+  String get envelopeReorderHint =>
+      'Long press an envelope to reorder within category';
+
+  @override
+  String get goalAmountLabel => 'Target Amount';
+
+  @override
+  String get goalDateLabel => 'Target Date';
+
+  @override
+  String get goalDateSelect => 'Select a date';
+
+  @override
+  String get goalError => 'Could not save goal. Please try again.';
+
+  @override
+  String get goalRemove => 'Remove Goal';
+
+  @override
+  String get goalRemoved => 'Goal removed';
+
+  @override
+  String get goalSaved => 'Goal saved';
+
+  @override
+  String get goalSetGoal => 'Set Goal';
+
+  @override
+  String get goalSetTitle => 'Set Goal';
+
+  @override
+  String get goalTypeBalance => 'Balance';
+
+  @override
+  String get goalTypeByDate => 'By Date';
+
+  @override
+  String get goalTypeLabel => 'Goal Type';
+
+  @override
+  String get goalTypeMonthly => 'Monthly';
+
+  @override
+  String homeBudgetAccounts(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count accounts',
+      one: '1 account',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String homeBudgetCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count budgets',
+      one: '1 budget',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get homeBudgetTotalBalance => 'Total Balance';
+
+  @override
+  String get homeCreateBudget => 'Create Your First Budget';
+
+  @override
+  String get homeLoadError => 'Could not load budgets';
+
+  @override
+  String get homeLogout => 'Sign Out';
+
+  @override
+  String get homeNoBudgets => 'No Budgets Yet';
+
+  @override
+  String get homeRetry => 'Retry';
+
+  @override
+  String importButton(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Import $count Transactions',
+      one: 'Import 1 Transaction',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get importCsvHint =>
+      'Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00';
+
+  @override
+  String get importCsvLabel => 'CSV Data';
+
+  @override
+  String get importError => 'Could not import transactions. Please try again.';
+
+  @override
+  String get importImporting => 'Importing...';
 
   @override
   String get importInstructions =>
       'Paste CSV data with columns for date, description, and amount. Headers are auto-detected.';
 
   @override
-  String get importCsvLabel => 'CSV Data';
-
-  @override
-  String get importCsvHint =>
-      'Date,Description,Amount\n2026-01-15,Grocery Store,-45.50\n2026-01-16,Paycheck,2500.00';
+  String importMoreRows(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '...and $count more rows',
+      one: '...and 1 more row',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get importPreview => 'Preview';
@@ -785,20 +556,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String importButton(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Import $count Transactions',
-      one: 'Import 1 Transaction',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get importImporting => 'Importing...';
-
-  @override
   String importSuccess(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -810,103 +567,56 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get importError => 'Could not import transactions. Please try again.';
+  String get importTitle => 'Import Transactions';
 
   @override
-  String importMoreRows(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '...and $count more rows',
-      one: '...and 1 more row',
-    );
-    return '$_temp0';
-  }
+  String get loginButton => 'Sign In';
 
   @override
-  String recurringDueBanner(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count scheduled transactions are due',
-      one: '1 scheduled transaction is due',
-    );
-    return '$_temp0';
-  }
+  String get loginCreateAccount => 'Create Account';
 
   @override
-  String get recurringPostDue => 'Post Now';
+  String get loginEmailLabel => 'Email';
 
   @override
-  String get recurringPosting => 'Posting...';
+  String get loginLoading => 'Signing In...';
 
   @override
-  String recurringPostSuccess(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count transactions posted',
-      one: '1 transaction posted',
-    );
-    return '$_temp0';
-  }
+  String get loginPasswordLabel => 'Password';
 
   @override
-  String get recurringPostError =>
-      'Could not post scheduled transactions. Please try again.';
+  String get loginTitle => 'Welcome to OpenBudget';
 
   @override
-  String get autoAssignTitle => 'Auto-Assign';
+  String get moveMoneyButton => 'Move';
 
   @override
-  String get autoAssignButton => 'Auto-Assign';
+  String get moveMoneyError => 'Could not move money. Please try again.';
 
   @override
-  String get autoAssignAssigning => 'Assigning...';
+  String get moveMoneyFrom => 'From Envelope';
 
   @override
-  String get autoAssignDistributing => 'Distributing to underfunded envelopes';
+  String get moveMoneySameError => 'Cannot move money to the same envelope';
 
   @override
-  String get autoAssignNothingToAssign =>
-      'All envelopes with goals are fully funded!';
+  String get moveMoneySuccess => 'Money moved between envelopes';
 
   @override
-  String autoAssignEnvelopeCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count envelopes',
-      one: '1 envelope',
-    );
-    return '$_temp0';
-  }
+  String get moveMoneyTitle => 'Move Money';
 
   @override
-  String autoAssignSuccess(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Auto-assigned to $count envelopes',
-      one: 'Auto-assigned to 1 envelope',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get autoAssignError => 'Could not auto-assign. Please try again.';
-
-  @override
-  String get envelopeActivityTitle => 'Activity';
-
-  @override
-  String get envelopeNoActivity => 'No transactions this month';
-
-  @override
-  String get netWorthTitle => 'Net Worth';
+  String get moveMoneyTo => 'To Envelope';
 
   @override
   String get netWorthAssets => 'Assets';
+
+  @override
+  String get netWorthEmptySubtitle =>
+      'Add accounts to see your net worth breakdown';
+
+  @override
+  String get netWorthEmptyTitle => 'No Accounts Yet';
 
   @override
   String get netWorthLiabilities => 'Liabilities';
@@ -915,160 +625,50 @@ class AppLocalizationsEn extends AppLocalizations {
   String get netWorthLoadError => 'Could not load net worth data';
 
   @override
-  String get netWorthEmptyTitle => 'No Accounts Yet';
+  String get netWorthTitle => 'Net Worth';
 
   @override
-  String get netWorthEmptySubtitle =>
-      'Add accounts to see your net worth breakdown';
+  String get payeeAddButton => 'Add Payee';
 
   @override
-  String get spendingTrendsTitle => 'Spending Trends';
+  String get payeeAutoEnvelopeHint =>
+      'Envelope auto-suggested from last transaction with this payee';
 
   @override
-  String get spendingTrendsLoadError => 'Could not load spending trends';
+  String get payeeCreateError => 'Could not create payee. Please try again.';
 
   @override
-  String get spendingTrendsEmptyTitle => 'No Spending Data';
+  String get payeeCreateSuccess => 'Payee created';
 
   @override
-  String get spendingTrendsEmptySubtitle =>
-      'Add transactions to see spending trends over time';
+  String get payeeEditError => 'Could not update payee. Please try again.';
 
   @override
-  String get spendingTrendsAvgIncome => 'Avg. Income';
+  String get payeeEditSuccess => 'Payee updated';
 
   @override
-  String get spendingTrendsAvgExpenses => 'Avg. Expenses';
+  String get payeeEditTitle => 'Edit Payee';
 
   @override
-  String get spendingTrendsMonthly => 'Monthly Comparison';
+  String get payeeEmptySubtitle => 'Add payees to track who you transact with';
 
   @override
-  String get spendingTrendsBreakdown => 'Monthly Breakdown';
+  String get payeeEmptyTitle => 'No Payees Yet';
 
   @override
-  String get budgetEditCategoryTitle => 'Rename Category';
+  String get payeeLabel => 'Payee';
 
   @override
-  String get budgetEditCategorySuccess => 'Category renamed';
+  String get payeeListTitle => 'Payees';
 
   @override
-  String get budgetEditCategoryError =>
-      'Could not rename category. Please try again.';
+  String get payeeLoadError => 'Could not load payees';
 
   @override
-  String get budgetReorderCategories => 'Reorder Categories';
+  String get payeeNameLabel => 'Payee Name';
 
   @override
-  String get budgetReorderDone => 'Done';
-
-  @override
-  String get budgetReorderHint => 'Drag to reorder categories';
-
-  @override
-  String get budgetReorderSuccess => 'Categories reordered';
-
-  @override
-  String get budgetReorderError => 'Could not reorder categories';
-
-  @override
-  String get transactionMemoLabel => 'Memo';
-
-  @override
-  String get transactionMemoHint => 'Add a note (optional)';
-
-  @override
-  String get accountEditTitle => 'Edit Account';
-
-  @override
-  String get accountEditSuccess => 'Account updated';
-
-  @override
-  String get accountEditError => 'Could not update account. Please try again.';
-
-  @override
-  String get accountCloseButton => 'Close Account';
-
-  @override
-  String get accountCloseConfirm =>
-      'Close this account? It will be moved to Closed Accounts.';
-
-  @override
-  String get accountCloseSuccess => 'Account closed';
-
-  @override
-  String get accountReopenButton => 'Reopen Account';
-
-  @override
-  String get accountReopenSuccess => 'Account reopened';
-
-  @override
-  String get budgetDeleteTitle => 'Delete Budget';
-
-  @override
-  String budgetDeleteConfirm(String name) {
-    return 'Delete \"$name\"? This will permanently remove the budget and all its data.';
-  }
-
-  @override
-  String get budgetDeleteButton => 'Delete';
-
-  @override
-  String get budgetDeleteSuccess => 'Budget deleted';
-
-  @override
-  String get budgetDeleteError => 'Could not delete budget. Please try again.';
-
-  @override
-  String get settingsTitle => 'Settings';
-
-  @override
-  String get settingsLoadError => 'Could not load settings';
-
-  @override
-  String get settingsBudgetSection => 'Budget';
-
-  @override
-  String get settingsBudgetName => 'Budget Name';
-
-  @override
-  String get settingsCurrency => 'Currency';
-
-  @override
-  String get settingsNavigationSection => 'Quick Access';
-
-  @override
-  String get settingsAccountSection => 'Account';
-
-  @override
-  String get settingsRenameBudget => 'Rename Budget';
-
-  @override
-  String get settingsRenameSuccess => 'Budget renamed';
-
-  @override
-  String get settingsRenameError =>
-      'Could not rename budget. Please try again.';
-
-  @override
-  String get settingsLogoutConfirm => 'Are you sure you want to sign out?';
-
-  @override
-  String get settingsVersion => 'OpenBudget v1.0.0';
-
-  @override
-  String homeBudgetAccounts(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count accounts',
-      one: '1 account',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get homeBudgetTotalBalance => 'Total Balance';
+  String get payeeNone => 'No Payee';
 
   @override
   String get payeeSearchHint => 'Search payees...';
@@ -1088,6 +688,485 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get quickBudgetAverageBudgeted => 'Average Budgeted';
+
+  @override
+  String get quickBudgetAverageSpent => 'Average Spent';
+
+  @override
+  String get quickBudgetError => 'Could not load budget suggestions';
+
+  @override
+  String get quickBudgetLastMonth => 'Budgeted Last Month';
+
+  @override
+  String get quickBudgetSpentLastMonth => 'Spent Last Month';
+
+  @override
+  String get quickBudgetTitle => 'Quick Budget';
+
+  @override
+  String get reconcileButton => 'Reconcile';
+
+  @override
+  String get reconcileError => 'Could not reconcile account. Please try again.';
+
+  @override
+  String get reconcileMessage =>
+      'Mark all cleared transactions as reconciled? This locks them from further editing.';
+
+  @override
+  String reconcileSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions reconciled',
+      one: '1 transaction reconciled',
+      zero: 'No transactions to reconcile',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get reconcileTitle => 'Reconcile Account';
+
+  @override
+  String get recurringAddButton => 'Add Recurring';
+
+  @override
+  String get recurringAddTitle => 'Add Recurring Transaction';
+
+  @override
+  String get recurringCreateError =>
+      'Could not create recurring transaction. Please try again.';
+
+  @override
+  String get recurringCreateSuccess => 'Recurring transaction created';
+
+  @override
+  String recurringDueBanner(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count scheduled transactions are due',
+      one: '1 scheduled transaction is due',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringDueLabel => 'Due now';
+
+  @override
+  String get recurringEditError =>
+      'Could not update recurring transaction. Please try again.';
+
+  @override
+  String get recurringEditSuccess => 'Recurring transaction updated';
+
+  @override
+  String get recurringEditTitle => 'Edit Recurring Transaction';
+
+  @override
+  String get recurringEmptySubtitle =>
+      'Set up recurring transactions for bills, subscriptions, and regular income';
+
+  @override
+  String get recurringEmptyTitle => 'No Recurring Transactions';
+
+  @override
+  String get recurringFreqBiweekly => 'Biweekly';
+
+  @override
+  String get recurringFreqDaily => 'Daily';
+
+  @override
+  String get recurringFreqMonthly => 'Monthly';
+
+  @override
+  String get recurringFreqWeekly => 'Weekly';
+
+  @override
+  String get recurringFreqYearly => 'Yearly';
+
+  @override
+  String get recurringFrequencyLabel => 'Frequency';
+
+  @override
+  String get recurringListTitle => 'Recurring Transactions';
+
+  @override
+  String get recurringLoadError => 'Could not load recurring transactions';
+
+  @override
+  String get recurringNextDate => 'Next';
+
+  @override
+  String get recurringPostDue => 'Post Now';
+
+  @override
+  String get recurringPostError =>
+      'Could not post scheduled transactions. Please try again.';
+
+  @override
+  String recurringPostSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions posted',
+      one: '1 transaction posted',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get recurringPosting => 'Posting...';
+
+  @override
+  String get recurringSkipButton => 'Skip';
+
+  @override
+  String get recurringSkipError =>
+      'Could not skip occurrence. Please try again.';
+
+  @override
+  String get recurringSkipSuccess => 'Occurrence skipped';
+
+  @override
+  String get recurringStartDate => 'Start Date';
+
+  @override
+  String get registerAlreadyHaveAccount => 'Already have an account? Sign In';
+
+  @override
+  String get registerCodeError =>
+      'Invalid verification code. Please try again.';
+
+  @override
+  String get registerCodeLabel => 'Verification Code';
+
+  @override
+  String get registerCodeRequired => 'Please enter the verification code';
+
+  @override
+  String get registerConfirmPassword => 'Confirm Password';
+
+  @override
+  String get registerCreateAccount => 'Create Account';
+
+  @override
+  String get registerEmailError =>
+      'Could not start registration. Please try again.';
+
+  @override
+  String get registerEmailRequired => 'Please enter your email address';
+
+  @override
+  String get registerPasswordMismatch => 'Passwords do not match';
+
+  @override
+  String get registerPasswordRequired => 'Please enter a password';
+
+  @override
+  String get registerSendCode => 'Send Verification Code';
+
+  @override
+  String get registerStepCode =>
+      'Enter the verification code sent to your email';
+
+  @override
+  String get registerStepEmail => 'Enter your email to get started';
+
+  @override
+  String get registerStepPassword => 'Choose a password for your account';
+
+  @override
+  String get registerSubmitting => 'Please wait...';
+
+  @override
+  String get registerTitle => 'Create Account';
+
+  @override
+  String get registerVerifyCode => 'Verify Code';
+
+  @override
+  String get reportsEmptySubtitle =>
+      'Add transactions to see spending reports for this month';
+
+  @override
+  String get reportsEmptyTitle => 'No Data Yet';
+
+  @override
+  String get reportsExpenses => 'Expenses';
+
+  @override
+  String get reportsIncome => 'Income';
+
+  @override
+  String get reportsLoadError => 'Could not load report data';
+
+  @override
+  String get reportsNetIncome => 'Net Income';
+
+  @override
+  String get reportsSpendingByCategory => 'Spending by Category';
+
+  @override
+  String get reportsTitle => 'Reports';
+
+  @override
+  String get reportsTransactions => 'Transactions';
+
+  @override
+  String get settingsAccountSection => 'Account';
+
+  @override
+  String get settingsBudgetName => 'Budget Name';
+
+  @override
+  String get settingsBudgetSection => 'Budget';
+
+  @override
+  String get settingsCurrency => 'Currency';
+
+  @override
+  String get settingsDataSection => 'Data';
+
+  @override
+  String get settingsExportData => 'Export Budget';
+
+  @override
+  String get settingsExportDataHint =>
+      'Copy all budget data as JSON to clipboard';
+
+  @override
+  String get settingsExportError =>
+      'Could not export budget data. Please try again.';
+
+  @override
+  String get settingsExportSuccess => 'Budget data copied to clipboard';
+
+  @override
+  String get settingsLoadError => 'Could not load settings';
+
+  @override
+  String get settingsLogoutConfirm => 'Are you sure you want to sign out?';
+
+  @override
+  String get settingsNavigationSection => 'Quick Access';
+
+  @override
+  String get settingsRenameBudget => 'Rename Budget';
+
+  @override
+  String get settingsRenameError =>
+      'Could not rename budget. Please try again.';
+
+  @override
+  String get settingsRenameSuccess => 'Budget renamed';
+
+  @override
+  String get settingsTitle => 'Settings';
+
+  @override
+  String get settingsVersion => 'OpenBudget v1.0.0';
+
+  @override
+  String get spendingByPayeeBreakdown => 'Spending Breakdown';
+
+  @override
+  String get spendingByPayeeEmptySubtitle =>
+      'Add expense transactions to see spending by payee';
+
+  @override
+  String get spendingByPayeeEmptyTitle => 'No Payee Data';
+
+  @override
+  String get spendingByPayeePayeeCount => 'Payees';
+
+  @override
+  String get spendingByPayeeTitle => 'Spending by Payee';
+
+  @override
+  String get spendingByPayeeTotalSpent => 'Total Spent';
+
+  @override
+  String spendingByPayeeTransactionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions',
+      one: '1 transaction',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get spendingTrendsAvgExpenses => 'Avg. Expenses';
+
+  @override
+  String get spendingTrendsAvgIncome => 'Avg. Income';
+
+  @override
+  String get spendingTrendsBreakdown => 'Monthly Breakdown';
+
+  @override
+  String get spendingTrendsEmptySubtitle =>
+      'Add transactions to see spending trends over time';
+
+  @override
+  String get spendingTrendsEmptyTitle => 'No Spending Data';
+
+  @override
+  String get spendingTrendsLoadError => 'Could not load spending trends';
+
+  @override
+  String get spendingTrendsMonthly => 'Monthly Comparison';
+
+  @override
+  String get spendingTrendsTitle => 'Spending Trends';
+
+  @override
+  String get splitAddSplit => 'Add Split';
+
+  @override
+  String get splitAmountLabel => 'Amount';
+
+  @override
+  String splitCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count splits',
+      one: '1 split',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get splitEnvelopeLabel => 'Envelope';
+
+  @override
+  String get splitLabel => 'Split';
+
+  @override
+  String get splitMemoLabel => 'Memo (optional)';
+
+  @override
+  String get splitMinimumError => 'At least two splits are required';
+
+  @override
+  String get splitMismatchError => 'Split amounts must equal the total';
+
+  @override
+  String get splitRemainingLabel => 'Remaining to assign';
+
+  @override
+  String get splitRemoveSplit => 'Remove';
+
+  @override
+  String get splitSaveError =>
+      'Could not save split transaction. Please try again.';
+
+  @override
+  String get splitSaveSuccess => 'Split transaction saved';
+
+  @override
+  String get splitTransactionTitle => 'Split Transaction';
+
+  @override
+  String get templateApplyButton => 'Apply';
+
+  @override
+  String get templateApplyError =>
+      'Could not apply template. Please try again.';
+
+  @override
+  String get templateApplySuccess => 'Template applied to current month';
+
+  @override
+  String get templateDeleteError =>
+      'Could not delete template. Please try again.';
+
+  @override
+  String get templateDeleteSuccess => 'Template deleted';
+
+  @override
+  String get templateEmptySubtitle =>
+      'Save your current month allocations as a template to quickly set up future months.';
+
+  @override
+  String get templateEmptyTitle => 'No Templates';
+
+  @override
+  String get templateNameHint => 'e.g. Standard Month';
+
+  @override
+  String get templateNameLabel => 'Template Name';
+
+  @override
+  String get templateSaveButton => 'Save Current Month as Template';
+
+  @override
+  String get templateSaveError => 'Could not save template. Please try again.';
+
+  @override
+  String get templateSaveSuccess => 'Template saved';
+
+  @override
+  String get templateTitle => 'Budget Templates';
+
+  @override
+  String get themeDark => 'Dark';
+
+  @override
+  String get themeLight => 'Light';
+
+  @override
+  String get themeSystem => 'System';
+
+  @override
+  String get themeTitle => 'Appearance';
+
+  @override
+  String get transactionAddExpense => 'Add Expense';
+
+  @override
+  String get transactionAddIncome => 'Add Income';
+
+  @override
+  String get transactionAmountLabel => 'Amount';
+
+  @override
+  String get transactionCleared => 'Cleared';
+
+  @override
+  String get transactionDateToday => 'Today';
+
+  @override
+  String get transactionDateYesterday => 'Yesterday';
+
+  @override
+  String get transactionDescriptionLabel => 'Description';
+
+  @override
+  String get transactionEditError =>
+      'Could not update transaction. Please try again.';
+
+  @override
+  String get transactionEditSuccess => 'Transaction updated';
+
+  @override
+  String get transactionEditTitle => 'Edit Transaction';
+
+  @override
+  String get transactionEmpty => 'No transactions yet';
+
+  @override
+  String get transactionError =>
+      'Could not save transaction. Please try again.';
+
+  @override
   String get transactionExportCsv => 'Copy as CSV';
 
   @override
@@ -1102,153 +1181,89 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get themeTitle => 'Appearance';
+  String get transactionFilterAll => 'All';
 
   @override
-  String get themeSystem => 'System';
+  String get transactionFilterExpense => 'Expense';
 
   @override
-  String get themeLight => 'Light';
+  String get transactionFilterIncome => 'Income';
 
   @override
-  String get themeDark => 'Dark';
+  String get transactionListTitle => 'Transactions';
 
   @override
-  String get transactionDateToday => 'Today';
+  String get transactionLoadError => 'Could not load transactions';
 
   @override
-  String get transactionDateYesterday => 'Yesterday';
+  String get transactionMemoHint => 'Add a note (optional)';
 
   @override
-  String get spendingByPayeeTitle => 'Spending by Payee';
+  String get transactionMemoLabel => 'Memo';
 
   @override
-  String get spendingByPayeeEmptyTitle => 'No Payee Data';
+  String get transactionNoResults => 'No matching transactions';
 
   @override
-  String get spendingByPayeeEmptySubtitle =>
-      'Add expense transactions to see spending by payee';
+  String get transactionReconciled => 'Reconciled';
 
   @override
-  String get spendingByPayeeTotalSpent => 'Total Spent';
-
-  @override
-  String get spendingByPayeePayeeCount => 'Payees';
-
-  @override
-  String get spendingByPayeeBreakdown => 'Spending Breakdown';
-
-  @override
-  String spendingByPayeeTransactionCount(int count) {
+  String transactionResultCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count transactions',
-      one: '1 transaction',
+      other: '$count results',
+      one: '1 result',
     );
     return '$_temp0';
   }
 
   @override
-  String get budgetGoToToday => 'Back to Today';
+  String get transactionSave => 'Save Transaction';
 
   @override
-  String get categoryTrendsTitle => 'Category Trends';
+  String get transactionSearchHint => 'Search transactions...';
 
   @override
-  String get categoryTrendsLoadError => 'Could not load category trends';
+  String get transactionSubmitting => 'Saving...';
 
   @override
-  String get categoryTrendsEmptyTitle => 'No Category Data';
+  String get transactionSuccess => 'Transaction saved';
 
   @override
-  String get categoryTrendsEmptySubtitle =>
-      'Add categorized transactions to see spending trends by category';
+  String get transactionUnassigned => 'Unassigned';
 
   @override
-  String get recurringDueLabel => 'Due now';
+  String get transactionUncleared => 'Uncleared';
 
   @override
-  String get recurringSkipButton => 'Skip';
+  String get transferButton => 'Transfer';
 
   @override
-  String get recurringSkipSuccess => 'Occurrence skipped';
+  String get transferDate => 'Transfer Date';
 
   @override
-  String get recurringSkipError =>
-      'Could not skip occurrence. Please try again.';
+  String get transferDefaultDescription => 'Account Transfer';
 
   @override
-  String get settingsDataSection => 'Data';
+  String get transferError => 'Could not complete transfer. Please try again.';
 
   @override
-  String get settingsExportData => 'Export Budget';
+  String get transferFromAccount => 'From Account';
 
   @override
-  String get settingsExportDataHint =>
-      'Copy all budget data as JSON to clipboard';
+  String get transferNeedTwoAccounts =>
+      'You need at least two accounts to make a transfer';
 
   @override
-  String get settingsExportSuccess => 'Budget data copied to clipboard';
+  String get transferSameAccountError => 'Cannot transfer to the same account';
 
   @override
-  String get settingsExportError =>
-      'Could not export budget data. Please try again.';
+  String get transferSuccess => 'Transfer completed';
 
   @override
-  String get envelopeReorderHint =>
-      'Long press an envelope to reorder within category';
+  String get transferTitle => 'Transfer';
 
   @override
-  String get templateTitle => 'Budget Templates';
-
-  @override
-  String get templateSaveButton => 'Save Current Month as Template';
-
-  @override
-  String get templateNameLabel => 'Template Name';
-
-  @override
-  String get templateNameHint => 'e.g. Standard Month';
-
-  @override
-  String get templateSaveSuccess => 'Template saved';
-
-  @override
-  String get templateSaveError => 'Could not save template. Please try again.';
-
-  @override
-  String get templateApplyButton => 'Apply';
-
-  @override
-  String get templateApplySuccess => 'Template applied to current month';
-
-  @override
-  String get templateApplyError =>
-      'Could not apply template. Please try again.';
-
-  @override
-  String get templateDeleteSuccess => 'Template deleted';
-
-  @override
-  String get templateDeleteError =>
-      'Could not delete template. Please try again.';
-
-  @override
-  String get templateEmptyTitle => 'No Templates';
-
-  @override
-  String get templateEmptySubtitle =>
-      'Save your current month allocations as a template to quickly set up future months.';
-
-  @override
-  String duplicateWarning(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Possible duplicates: $count similar transactions found',
-      one: 'Possible duplicate: 1 similar transaction found',
-    );
-    return '$_temp0';
-  }
+  String get transferToAccount => 'To Account';
 }

--- a/openbudget_app/lib/src/features/budget/providers/budget_template_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/budget_template_provider.g.dart
@@ -120,7 +120,7 @@ final class BudgetTemplateActionsProvider
 }
 
 String _$budgetTemplateActionsHash() =>
-    r'99ee15a269a726522c60e792d7e17f3695d1fade';
+    r'f499f908e5aa8be80360e07566bc9c33e239d738';
 
 abstract class _$BudgetTemplateActions extends $Notifier<void> {
   void build();

--- a/openbudget_app/lib/src/features/budget/providers/envelope_actions_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/envelope_actions_provider.g.dart
@@ -41,7 +41,7 @@ final class EnvelopeActionsProvider
   }
 }
 
-String _$envelopeActionsHash() => r'160e3aef7f369c112a1ff715c0b2d01f5933eb14';
+String _$envelopeActionsHash() => r'af203e694b9951475320b57358408f4d1e15d5fb';
 
 abstract class _$EnvelopeActions extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.dart
+++ b/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.dart
@@ -90,6 +90,45 @@ class MonthlyAllocationActions extends _$MonthlyAllocationActions {
     }
   }
 
+  Future<List<MonthlyAllocation>> copyPreviousMonth({
+    required String budgetId,
+    required int currentYear,
+    required int currentMonth,
+  }) async {
+    state = const AsyncValue.loading();
+    final client = ref.read(serverpodClientProvider);
+
+    // Calculate previous month.
+    final prevYear = currentMonth == 1 ? currentYear - 1 : currentYear;
+    final prevMonth = currentMonth == 1 ? 12 : currentMonth - 1;
+
+    try {
+      final result = await client.monthlyAllocation.copyMonth(
+        // Serverpod API requires UuidValue which is experimental in uuid package.
+        // ignore: experimental_member_use
+        UuidValue.fromString(budgetId),
+        prevYear,
+        prevMonth,
+        currentYear,
+        currentMonth,
+      );
+      if (ref.mounted) {
+        ref
+          ..invalidate(
+            monthlyAllocationsProvider(budgetId, currentYear, currentMonth),
+          )
+          ..invalidate(budgetMonthlySummaryProvider(budgetId));
+        state = const AsyncValue.data(null);
+      }
+      return result;
+    } on Exception catch (e, st) {
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
+      rethrow;
+    }
+  }
+
   Future<MonthlyAllocation> upsertAllocation({
     required String envelopeId,
     required String budgetId,

--- a/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.g.dart
+++ b/openbudget_app/lib/src/features/budget/providers/monthly_allocation_provider.g.dart
@@ -212,7 +212,7 @@ final class MonthlyAllocationActionsProvider
 }
 
 String _$monthlyAllocationActionsHash() =>
-    r'9b96e3434f1699b02f0bc6be98794233908ec309';
+    r'8373f3334a2565b7780200ae4979b824dcdaead7';
 
 abstract class _$MonthlyAllocationActions extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -187,6 +187,12 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   year: summary.year,
                   month: summary.month,
                   totalOverspentCents: totalOverspentCents,
+                  onCopyLastMonth: () => _copyPreviousMonth(
+                    context,
+                    ref,
+                    year: summary.year,
+                    month: summary.month,
+                  ),
                 ),
                 const SizedBox(height: SpacingTokens.md),
                 if (dueCountAsync.hasValue && dueCountAsync.value! > 0)
@@ -383,6 +389,60 @@ class BudgetDetailScreen extends HookConsumerWidget {
         );
       },
     );
+  }
+
+  Future<void> _copyPreviousMonth(
+    BuildContext context,
+    WidgetRef ref, {
+    required int year,
+    required int month,
+  }) async {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.budgetCopyLastMonth),
+        content: Text(l10n.budgetCopyLastMonthConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(l10n.budgetCopyLastMonth),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    try {
+      await ref
+          .read(monthlyAllocationActionsProvider.notifier)
+          .copyPreviousMonth(
+            budgetId: budgetId,
+            currentYear: year,
+            currentMonth: month,
+          );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.budgetCopyLastMonthSuccess)),
+        );
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.budgetCopyLastMonthError),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      }
+    }
   }
 
   void _showEnvelopeActivity(

--- a/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/budget_header.dart
@@ -16,6 +16,7 @@ class BudgetHeader extends HookConsumerWidget {
     required this.year,
     required this.month,
     this.totalOverspentCents = 0,
+    this.onCopyLastMonth,
     super.key,
   });
 
@@ -25,6 +26,7 @@ class BudgetHeader extends HookConsumerWidget {
   final int year;
   final int month;
   final int totalOverspentCents;
+  final VoidCallback? onCopyLastMonth;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -167,6 +169,24 @@ class BudgetHeader extends HookConsumerWidget {
               style: FilledButton.styleFrom(
                 backgroundColor: ColorTokens.secondary,
                 foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SpacingTokens.md,
+                  vertical: SpacingTokens.xs,
+                ),
+                minimumSize: Size.zero,
+                textStyle: theme.textTheme.labelMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+          if (onCopyLastMonth != null) ...[
+            const SizedBox(height: SpacingTokens.sm),
+            OutlinedButton.icon(
+              onPressed: onCopyLastMonth,
+              icon: const Icon(Icons.content_copy_rounded, size: 16),
+              label: Text(l10n.budgetCopyLastMonth),
+              style: OutlinedButton.styleFrom(
                 padding: const EdgeInsets.symmetric(
                   horizontal: SpacingTokens.md,
                   vertical: SpacingTokens.xs,

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -653,6 +653,25 @@ class EndpointMonthlyAllocation extends _i1.EndpointRef {
     {'budgetId': budgetId, 'year': year, 'month': month},
   );
 
+  /// Copies all allocations from a source month to a target month.
+  _i2.Future<List<_i7.MonthlyAllocation>> copyMonth(
+    _i1.UuidValue budgetId,
+    int sourceYear,
+    int sourceMonth,
+    int targetYear,
+    int targetMonth,
+  ) => caller.callServerEndpoint<List<_i7.MonthlyAllocation>>(
+    'monthlyAllocation',
+    'copyMonth',
+    {
+      'budgetId': budgetId,
+      'sourceYear': sourceYear,
+      'sourceMonth': sourceMonth,
+      'targetYear': targetYear,
+      'targetMonth': targetMonth,
+    },
+  );
+
   /// Moves money between two envelopes in the same budget and month.
   _i2.Future<List<_i7.MonthlyAllocation>> moveMoney(
     _i1.UuidValue fromEnvelopeId,

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -1047,6 +1047,46 @@ class Endpoints extends _i1.EndpointDispatch {
                     params['month'],
                   ),
         ),
+        'copyMonth': _i1.MethodConnector(
+          name: 'copyMonth',
+          params: {
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'sourceYear': _i1.ParameterDescription(
+              name: 'sourceYear',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+            'sourceMonth': _i1.ParameterDescription(
+              name: 'sourceMonth',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+            'targetYear': _i1.ParameterDescription(
+              name: 'targetYear',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+            'targetMonth': _i1.ParameterDescription(
+              name: 'targetMonth',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['monthlyAllocation'] as _i11.MonthlyAllocationEndpoint)
+                  .copyMonth(
+                    session,
+                    params['budgetId'],
+                    params['sourceYear'],
+                    params['sourceMonth'],
+                    params['targetYear'],
+                    params['targetMonth'],
+                  ),
+        ),
         'moveMoney': _i1.MethodConnector(
           name: 'moveMoney',
           params: {

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -51,6 +51,7 @@ envelope:
 monthlyAllocation:
   - upsert:
   - list:
+  - copyMonth:
   - moveMoney:
   - delete:
 payee:

--- a/openbudget_server/lib/src/monthly_allocations/monthly_allocation_endpoint.dart
+++ b/openbudget_server/lib/src/monthly_allocations/monthly_allocation_endpoint.dart
@@ -45,6 +45,25 @@ class MonthlyAllocationEndpoint extends Endpoint {
     );
   }
 
+  /// Copies all allocations from a source month to a target month.
+  Future<List<MonthlyAllocation>> copyMonth(
+    Session session,
+    UuidValue budgetId,
+    int sourceYear,
+    int sourceMonth,
+    int targetYear,
+    int targetMonth,
+  ) async {
+    return MonthlyAllocationService.copyMonth(
+      session,
+      budgetId: budgetId,
+      sourceYear: sourceYear,
+      sourceMonth: sourceMonth,
+      targetYear: targetYear,
+      targetMonth: targetMonth,
+    );
+  }
+
   /// Moves money between two envelopes in the same budget and month.
   Future<List<MonthlyAllocation>> moveMoney(
     Session session,

--- a/openbudget_server/lib/src/monthly_allocations/monthly_allocation_service.dart
+++ b/openbudget_server/lib/src/monthly_allocations/monthly_allocation_service.dart
@@ -72,6 +72,42 @@ class MonthlyAllocationService {
     );
   }
 
+  /// Copies all allocations from a source month to a target month.
+  ///
+  /// Existing allocations in the target month are overwritten.
+  static Future<List<MonthlyAllocation>> copyMonth(
+    Session session, {
+    required UuidValue budgetId,
+    required int sourceYear,
+    required int sourceMonth,
+    required int targetYear,
+    required int targetMonth,
+  }) async {
+    await BudgetService.getById(session, budgetId: budgetId);
+
+    final sourceAllocations = await listForBudgetMonth(
+      session,
+      budgetId: budgetId,
+      year: sourceYear,
+      month: sourceMonth,
+    );
+
+    final results = <MonthlyAllocation>[];
+    for (final alloc in sourceAllocations) {
+      final copied = await upsert(
+        session,
+        envelopeId: alloc.envelopeId,
+        budgetId: budgetId,
+        year: targetYear,
+        month: targetMonth,
+        allocatedCents: alloc.allocatedCents,
+      );
+      results.add(copied);
+    }
+
+    return results;
+  }
+
   /// Moves money between two envelopes in the same budget and month.
   ///
   /// Decreases the source envelope allocation and increases the target.

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -1747,6 +1747,47 @@ class _MonthlyAllocationEndpoint {
     });
   }
 
+  _i3.Future<List<_i7.MonthlyAllocation>> copyMonth(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue budgetId,
+    int sourceYear,
+    int sourceMonth,
+    int targetYear,
+    int targetMonth,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'monthlyAllocation',
+            method: 'copyMonth',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'monthlyAllocation',
+          methodName: 'copyMonth',
+          parameters: _i1.testObjectToJson({
+            'budgetId': budgetId,
+            'sourceYear': sourceYear,
+            'sourceMonth': sourceMonth,
+            'targetYear': targetYear,
+            'targetMonth': targetMonth,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<List<_i7.MonthlyAllocation>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
   _i3.Future<List<_i7.MonthlyAllocation>> moveMoney(
     _i1.TestSessionBuilder sessionBuilder,
     _i2.UuidValue fromEnvelopeId,


### PR DESCRIPTION
## Summary
- Add server-side `copyMonth` method to `MonthlyAllocationService` and `MonthlyAllocationEndpoint` that copies all allocations from a source month to a target month
- Add `copyPreviousMonth` method to `MonthlyAllocationActions` provider on the app side
- Add "Copy Last Month" button to the budget header with a confirmation dialog
- Overwriting existing allocations in the target month when copying

## Test plan
- [ ] Verify the "Copy Last Month" button appears in the budget header
- [ ] Tap the button and confirm the dialog appears with the correct message
- [ ] Cancel the dialog and verify no changes occur
- [ ] Confirm the copy and verify allocations from the previous month appear in the current month
- [ ] Navigate to a different month and verify copy works correctly across month boundaries (e.g., January → previous December)