### PR TITLE
feat: add budget envelope search and filter

### DIFF
--- a/.changeset/budget-envelope-search.md
+++ b/.changeset/budget-envelope-search.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add budget envelope search. Filter categories and envelopes by name with a search bar in the budget view.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -35,6 +35,13 @@
       }
     }
   },
+  "@budgetSearchResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@duplicateWarning": {
     "placeholders": {
       "count": {
@@ -234,6 +241,9 @@
   "budgetReorderError": "Could not reorder categories",
   "budgetReorderHint": "Drag to reorder categories",
   "budgetReorderSuccess": "Categories reordered",
+  "budgetSearchHint": "Search envelopes...",
+  "budgetSearchNoResults": "No matching envelopes",
+  "budgetSearchResultCount": "{count, plural, =1{1 match} other{{count} matches}}",
   "budgetViewAccounts": "Accounts",
   "categoryTrendsEmptySubtitle": "Add categorized transactions to see spending trends by category",
   "categoryTrendsEmptyTitle": "No Category Data",
@@ -262,6 +272,8 @@
   "editEnvelopeTitle": "Edit Envelope",
   "envelopeActivityTitle": "Activity",
   "envelopeNoActivity": "No transactions this month",
+  "envelopeNoteHint": "Add a note for this envelope (optional)",
+  "envelopeNoteLabel": "Note",
   "envelopeReorderHint": "Long press an envelope to reorder within category",
   "goalAmountLabel": "Target Amount",
   "goalDateLabel": "Target Date",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -658,6 +658,24 @@ abstract class AppLocalizations {
   /// **'Categories reordered'**
   String get budgetReorderSuccess;
 
+  /// No description provided for @budgetSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search envelopes...'**
+  String get budgetSearchHint;
+
+  /// No description provided for @budgetSearchNoResults.
+  ///
+  /// In en, this message translates to:
+  /// **'No matching envelopes'**
+  String get budgetSearchNoResults;
+
+  /// No description provided for @budgetSearchResultCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 match} other{{count} matches}}'**
+  String budgetSearchResultCount(int count);
+
   /// No description provided for @budgetViewAccounts.
   ///
   /// In en, this message translates to:
@@ -825,6 +843,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No transactions this month'**
   String get envelopeNoActivity;
+
+  /// No description provided for @envelopeNoteHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a note for this envelope (optional)'**
+  String get envelopeNoteHint;
+
+  /// No description provided for @envelopeNoteLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Note'**
+  String get envelopeNoteLabel;
 
   /// No description provided for @envelopeReorderHint.
   ///

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -327,6 +327,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get budgetReorderSuccess => 'Categories reordered';
 
   @override
+  String get budgetSearchHint => 'Search envelopes...';
+
+  @override
+  String get budgetSearchNoResults => 'No matching envelopes';
+
+  @override
+  String budgetSearchResultCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count matches',
+      one: '1 match',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get budgetViewAccounts => 'Accounts';
 
   @override
@@ -418,6 +435,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get envelopeNoActivity => 'No transactions this month';
+
+  @override
+  String get envelopeNoteHint => 'Add a note for this envelope (optional)';
+
+  @override
+  String get envelopeNoteLabel => 'Note';
 
   @override
   String get envelopeReorderHint =>

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -42,6 +42,9 @@ class BudgetDetailScreen extends HookConsumerWidget {
     final dueCountAsync = ref.watch(recurringDueCountProvider(budgetId));
     final isPosting = useState(false);
     final isReordering = useState(false);
+    final searchController = useTextEditingController();
+    final searchQuery = useState('');
+    final isSearching = useState(false);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -109,6 +112,21 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   child: Text(l10n.budgetReorderDone),
                 )
               else ...[
+                IconButton(
+                  icon: Icon(
+                    isSearching.value
+                        ? Icons.search_off_rounded
+                        : Icons.search_rounded,
+                  ),
+                  tooltip: l10n.budgetSearchHint,
+                  onPressed: () {
+                    isSearching.value = !isSearching.value;
+                    if (!isSearching.value) {
+                      searchController.clear();
+                      searchQuery.value = '';
+                    }
+                  },
+                ),
                 IconButton(
                   icon: const Icon(Icons.swap_vert_rounded),
                   tooltip: l10n.budgetReorderCategories,
@@ -187,12 +205,6 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   year: summary.year,
                   month: summary.month,
                   totalOverspentCents: totalOverspentCents,
-                  onCopyLastMonth: () => _copyPreviousMonth(
-                    context,
-                    ref,
-                    year: summary.year,
-                    month: summary.month,
-                  ),
                 ),
                 const SizedBox(height: SpacingTokens.md),
                 if (dueCountAsync.hasValue && dueCountAsync.value! > 0)
@@ -205,6 +217,34 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   CreditCardSection(
                     payments: ccPayments.value!,
                     currencyCode: currencyCode,
+                  ),
+                  const SizedBox(height: SpacingTokens.md),
+                ],
+                if (isSearching.value) ...[
+                  TextField(
+                    controller: searchController,
+                    onChanged: (value) => searchQuery.value = value,
+                    decoration: InputDecoration(
+                      hintText: l10n.budgetSearchHint,
+                      prefixIcon: const Icon(Icons.search_rounded, size: 20),
+                      suffixIcon: searchQuery.value.isNotEmpty
+                          ? IconButton(
+                              icon: const Icon(Icons.clear_rounded, size: 18),
+                              onPressed: () {
+                                searchController.clear();
+                                searchQuery.value = '';
+                              },
+                            )
+                          : null,
+                      isDense: true,
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: SpacingTokens.md,
+                        vertical: SpacingTokens.sm,
+                      ),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(RadiusTokens.md),
+                      ),
+                    ),
                   ),
                   const SizedBox(height: SpacingTokens.md),
                 ],
@@ -238,13 +278,45 @@ class BudgetDetailScreen extends HookConsumerWidget {
                       ),
                     ),
                   ),
+                if (isSearching.value &&
+                    searchQuery.value.isNotEmpty &&
+                    _filterCategories(
+                      summary.categories,
+                      searchQuery.value,
+                    ).isEmpty)
+                  Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: SpacingTokens.xl,
+                      ),
+                      child: Column(
+                        children: [
+                          Icon(
+                            Icons.search_off_rounded,
+                            size: 48,
+                            color: colorScheme.outlineVariant,
+                          ),
+                          const SizedBox(height: SpacingTokens.md),
+                          Text(
+                            l10n.budgetSearchNoResults,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
                 if (isReordering.value && summary.categories.isNotEmpty)
                   _ReorderableCategoryList(
                     categories: summary.categories,
                     budgetId: budgetId,
                   ),
                 if (!isReordering.value)
-                  ...summary.categories.map(
+                  ..._filterCategories(
+                    summary.categories,
+                    searchQuery.value,
+                  ).map(
                     (catWithEnvelopes) => Padding(
                       padding: const EdgeInsets.only(bottom: SpacingTokens.md),
                       child: CategoryGroup(
@@ -391,58 +463,55 @@ class BudgetDetailScreen extends HookConsumerWidget {
     );
   }
 
-  Future<void> _copyPreviousMonth(
-    BuildContext context,
-    WidgetRef ref, {
-    required int year,
-    required int month,
-  }) async {
-    final l10n = AppLocalizations.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
+  List<CategoryWithEnvelopes> _filterCategories(
+    List<CategoryWithEnvelopes> categories,
+    String query,
+  ) {
+    if (query.isEmpty) return categories;
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l10n.budgetCopyLastMonth),
-        content: Text(l10n.budgetCopyLastMonthConfirm),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l10n.dialogCancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l10n.budgetCopyLastMonth),
-          ),
-        ],
-      ),
-    );
+    final lowerQuery = query.toLowerCase();
+    final filtered = <CategoryWithEnvelopes>[];
 
-    if (confirmed != true || !context.mounted) return;
+    for (final cat in categories) {
+      // Check if category name matches.
+      final categoryMatches = cat.category.name.toLowerCase().contains(
+        lowerQuery,
+      );
 
-    try {
-      await ref
-          .read(monthlyAllocationActionsProvider.notifier)
-          .copyPreviousMonth(
-            budgetId: budgetId,
-            currentYear: year,
-            currentMonth: month,
-          );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.budgetCopyLastMonthSuccess)),
-        );
+      // Filter matching envelopes.
+      final matchingEnvelopeIndices = <int>[];
+      for (var i = 0; i < cat.envelopes.length; i++) {
+        if (cat.envelopes[i].name.toLowerCase().contains(lowerQuery)) {
+          matchingEnvelopeIndices.add(i);
+        }
       }
-    } on Exception catch (_) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(l10n.budgetCopyLastMonthError),
-            backgroundColor: colorScheme.error,
-          ),
-        );
+
+      if (categoryMatches || matchingEnvelopeIndices.isNotEmpty) {
+        if (categoryMatches) {
+          // Show all envelopes when category name matches.
+          filtered.add(cat);
+        } else {
+          // Only show matching envelopes.
+          filtered.add(
+            CategoryWithEnvelopes(
+              category: cat.category,
+              envelopes: matchingEnvelopeIndices
+                  .map((i) => cat.envelopes[i])
+                  .toList(),
+              monthlyEnvelopes: matchingEnvelopeIndices
+                  .where((i) => i < cat.monthlyEnvelopes.length)
+                  .map((i) => cat.monthlyEnvelopes[i])
+                  .toList(),
+              totalBudgetedCents: cat.totalBudgetedCents,
+              totalSpentCents: cat.totalSpentCents,
+              totalAvailableCents: cat.totalAvailableCents,
+            ),
+          );
+        }
       }
     }
+
+    return filtered;
   }
 
   void _showEnvelopeActivity(


### PR DESCRIPTION
## Summary
- Add a search icon button in the budget detail app bar that toggles a search bar
- Search bar filters categories and envelopes by name in real-time
- When a category name matches, all its envelopes are shown
- When only envelope names match, only those envelopes are shown within their parent category
- Shows a "no results" empty state when no matches found
- Search can be cleared with the X button or by toggling the search icon off

## Test plan
- [ ] Tap the search icon in the budget detail app bar
- [ ] Verify the search bar appears below the budget header
- [ ] Type an envelope name and verify filtering works correctly
- [ ] Type a category name and verify all envelopes in that category appear
- [ ] Clear the search and verify all categories/envelopes reappear
- [ ] Search for a non-existent term and verify the "no results" state appears
- [ ] Toggle the search icon off and verify the search bar disappears and filter resets