### PR TITLE
feat: add reconciliation with statement balance entry

### DIFF
--- a/.changeset/reconcile-balance-entry.md
+++ b/.changeset/reconcile-balance-entry.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add reconciliation with balance entry. Enter your bank statement balance during reconciliation, see the difference from cleared transactions, and automatically create an adjustment transaction if needed.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -98,6 +98,16 @@
       }
     }
   },
+  "@reconcileSuccessWithAdjustment": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "adjustment": {
+        "type": "String"
+      }
+    }
+  },
   "@recurringDueBanner": {
     "placeholders": {
       "count": {
@@ -337,10 +347,16 @@
   "quickBudgetLastMonth": "Budgeted Last Month",
   "quickBudgetSpentLastMonth": "Spent Last Month",
   "quickBudgetTitle": "Quick Budget",
+  "reconcileAdjustmentNote": "An adjustment transaction will be created for the difference.",
+  "reconcileBalanceHint": "Enter your current bank balance",
+  "reconcileBalanceLabel": "Statement Balance",
   "reconcileButton": "Reconcile",
+  "reconcileClearedBalance": "Cleared Balance",
+  "reconcileDifference": "Difference",
   "reconcileError": "Could not reconcile account. Please try again.",
   "reconcileMessage": "Mark all cleared transactions as reconciled? This locks them from further editing.",
   "reconcileSuccess": "{count, plural, =0{No transactions to reconcile} =1{1 transaction reconciled} other{{count} transactions reconciled}}",
+  "reconcileSuccessWithAdjustment": "{count, plural, =0{Reconciled with {adjustment} adjustment} =1{1 transaction reconciled with {adjustment} adjustment} other{{count} transactions reconciled with {adjustment} adjustment}}",
   "reconcileTitle": "Reconcile Account",
   "recurringAddButton": "Add Recurring",
   "recurringAddTitle": "Add Recurring Transaction",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1276,11 +1276,41 @@ abstract class AppLocalizations {
   /// **'Quick Budget'**
   String get quickBudgetTitle;
 
+  /// No description provided for @reconcileAdjustmentNote.
+  ///
+  /// In en, this message translates to:
+  /// **'An adjustment transaction will be created for the difference.'**
+  String get reconcileAdjustmentNote;
+
+  /// No description provided for @reconcileBalanceHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your current bank balance'**
+  String get reconcileBalanceHint;
+
+  /// No description provided for @reconcileBalanceLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Statement Balance'**
+  String get reconcileBalanceLabel;
+
   /// No description provided for @reconcileButton.
   ///
   /// In en, this message translates to:
   /// **'Reconcile'**
   String get reconcileButton;
+
+  /// No description provided for @reconcileClearedBalance.
+  ///
+  /// In en, this message translates to:
+  /// **'Cleared Balance'**
+  String get reconcileClearedBalance;
+
+  /// No description provided for @reconcileDifference.
+  ///
+  /// In en, this message translates to:
+  /// **'Difference'**
+  String get reconcileDifference;
 
   /// No description provided for @reconcileError.
   ///
@@ -1299,6 +1329,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =0{No transactions to reconcile} =1{1 transaction reconciled} other{{count} transactions reconciled}}'**
   String reconcileSuccess(int count);
+
+  /// No description provided for @reconcileSuccessWithAdjustment.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{Reconciled with {adjustment} adjustment} =1{1 transaction reconciled with {adjustment} adjustment} other{{count} transactions reconciled with {adjustment} adjustment}}'**
+  String reconcileSuccessWithAdjustment(int count, String adjustment);
 
   /// No description provided for @reconcileTitle.
   ///

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -706,7 +706,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get quickBudgetTitle => 'Quick Budget';
 
   @override
+  String get reconcileAdjustmentNote =>
+      'An adjustment transaction will be created for the difference.';
+
+  @override
+  String get reconcileBalanceHint => 'Enter your current bank balance';
+
+  @override
+  String get reconcileBalanceLabel => 'Statement Balance';
+
+  @override
   String get reconcileButton => 'Reconcile';
+
+  @override
+  String get reconcileClearedBalance => 'Cleared Balance';
+
+  @override
+  String get reconcileDifference => 'Difference';
 
   @override
   String get reconcileError => 'Could not reconcile account. Please try again.';
@@ -723,6 +739,18 @@ class AppLocalizationsEn extends AppLocalizations {
       other: '$count transactions reconciled',
       one: '1 transaction reconciled',
       zero: 'No transactions to reconcile',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String reconcileSuccessWithAdjustment(int count, String adjustment) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions reconciled with $adjustment adjustment',
+      one: '1 transaction reconciled with $adjustment adjustment',
+      zero: 'Reconciled with $adjustment adjustment',
     );
     return '$_temp0';
   }

--- a/openbudget_app/lib/src/features/accounts/providers/account_transactions_provider.dart
+++ b/openbudget_app/lib/src/features/accounts/providers/account_transactions_provider.dart
@@ -62,4 +62,27 @@ class AccountTransactionActions extends _$AccountTransactionActions {
       ..invalidate(accountListProvider(budgetId));
     return count;
   }
+
+  Future<List<int>> reconcileWithBalance({
+    required String accountId,
+    required String budgetId,
+    required int statementBalanceCents,
+  }) async {
+    final client = ref.read(serverpodClientProvider);
+    // Serverpod API requires UuidValue which is experimental in uuid package.
+    // ignore: experimental_member_use
+    final accountUuid = UuidValue.fromString(accountId);
+    // UuidValue.fromString is experimental in uuid package.
+    // ignore: experimental_member_use
+    final budgetUuid = UuidValue.fromString(budgetId);
+    final result = await client.transaction.reconcileWithBalance(
+      accountUuid,
+      budgetUuid,
+      statementBalanceCents,
+    );
+    ref
+      ..invalidate(accountTransactionsProvider(budgetId, accountId))
+      ..invalidate(accountListProvider(budgetId));
+    return result;
+  }
 }

--- a/openbudget_app/lib/src/features/accounts/providers/account_transactions_provider.g.dart
+++ b/openbudget_app/lib/src/features/accounts/providers/account_transactions_provider.g.dart
@@ -119,7 +119,7 @@ final class AccountTransactionActionsProvider
 }
 
 String _$accountTransactionActionsHash() =>
-    r'69cc39d03f25ce3e3da3bb931b24bf391bd37b12';
+    r'4cbccddf76ab383b8a5456bf11fda09ee1787ce3';
 
 abstract class _$AccountTransactionActions extends $AsyncNotifier<void> {
   FutureOr<void> build();

--- a/openbudget_app/lib/src/features/accounts/screens/account_detail_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/account_detail_screen.dart
@@ -54,7 +54,9 @@ class AccountDetailScreen extends HookConsumerWidget {
           IconButton(
             icon: const Icon(Icons.check_circle_outline_rounded),
             tooltip: l10n.reconcileButton,
-            onPressed: () => _reconcile(context, ref),
+            onPressed: txnAsync.hasValue
+                ? () => _reconcile(context, ref, txnAsync.value!, currencyCode)
+                : null,
           ),
         ],
       ),
@@ -202,37 +204,60 @@ class AccountDetailScreen extends HookConsumerWidget {
     }
   }
 
-  Future<void> _reconcile(BuildContext context, WidgetRef ref) async {
+  Future<void> _reconcile(
+    BuildContext context,
+    WidgetRef ref,
+    List<Transaction> transactions,
+    CurrencyCode currencyCode,
+  ) async {
     final l10n = AppLocalizations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
-    final confirmed = await showDialog<bool>(
+
+    // Compute cleared balance from transactions.
+    var clearedBalanceCents = 0;
+    for (final txn in transactions) {
+      if (txn.reconciled || txn.cleared) {
+        clearedBalanceCents += txn.amountCents;
+      }
+    }
+
+    final result = await showDialog<int>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l10n.reconcileTitle),
-        content: Text(l10n.reconcileMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(l10n.dialogCancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(l10n.reconcileButton),
-          ),
-        ],
+      builder: (_) => _ReconcileDialog(
+        clearedBalanceCents: clearedBalanceCents,
+        currencyCode: currencyCode,
       ),
     );
 
-    if (confirmed != true || !context.mounted) return;
+    if (result == null || !context.mounted) return;
 
     try {
-      final count = await ref
+      final response = await ref
           .read(accountTransactionActionsProvider.notifier)
-          .reconcileAccount(accountId: accountId, budgetId: budgetId);
+          .reconcileWithBalance(
+            accountId: accountId,
+            budgetId: budgetId,
+            statementBalanceCents: result,
+          );
       if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(l10n.reconcileSuccess(count))));
+        final count = response[0];
+        final adjustment = response[1];
+        if (adjustment != 0) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                l10n.reconcileSuccessWithAdjustment(
+                  count,
+                  formatCents(adjustment, currencyCode),
+                ),
+              ),
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(l10n.reconcileSuccess(count))));
+        }
       }
     } on Exception catch (_) {
       if (context.mounted) {
@@ -359,5 +384,111 @@ class _TransactionRow extends HookWidget {
 
   static String _formatDate(DateTime date) {
     return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class _ReconcileDialog extends HookWidget {
+  const _ReconcileDialog({
+    required this.clearedBalanceCents,
+    required this.currencyCode,
+  });
+
+  final int clearedBalanceCents;
+  final CurrencyCode currencyCode;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final controller = useTextEditingController();
+    final enteredCents = useState<int?>(null);
+
+    final differenceCents = enteredCents.value != null
+        ? enteredCents.value! - clearedBalanceCents
+        : null;
+
+    return AlertDialog(
+      title: Text(l10n.reconcileTitle),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                l10n.reconcileClearedBalance,
+                style: theme.textTheme.bodyMedium,
+              ),
+              Text(
+                formatCents(clearedBalanceCents, currencyCode),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: SpacingTokens.md),
+          TextField(
+            controller: controller,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: InputDecoration(
+              labelText: l10n.reconcileBalanceLabel,
+              hintText: l10n.reconcileBalanceHint,
+              border: const OutlineInputBorder(),
+            ),
+            onChanged: (value) {
+              final parsed = double.tryParse(value);
+              enteredCents.value = parsed != null
+                  ? (parsed * 100).round()
+                  : null;
+            },
+          ),
+          if (differenceCents != null) ...[
+            const SizedBox(height: SpacingTokens.md),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  l10n.reconcileDifference,
+                  style: theme.textTheme.bodyMedium,
+                ),
+                Text(
+                  formatCents(differenceCents, currencyCode),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: differenceCents != 0
+                        ? colorScheme.error
+                        : ColorTokens.secondary,
+                  ),
+                ),
+              ],
+            ),
+            if (differenceCents != 0) ...[
+              const SizedBox(height: SpacingTokens.sm),
+              Text(
+                l10n.reconcileAdjustmentNote,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.dialogCancel),
+        ),
+        FilledButton(
+          onPressed: enteredCents.value != null
+              ? () => Navigator.of(context).pop(enteredCents.value)
+              : null,
+          child: Text(l10n.reconcileButton),
+        ),
+      ],
+    );
   }
 }

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -992,6 +992,21 @@ class EndpointTransaction extends _i1.EndpointRef {
     'budgetId': budgetId,
   });
 
+  /// Reconciles an account with a statement balance.
+  ///
+  /// If the cleared balance differs from the statement balance, creates an
+  /// adjustment transaction. Returns [reconciledCount, adjustmentCents].
+  _i2.Future<List<int>> reconcileWithBalance(
+    _i1.UuidValue accountId,
+    _i1.UuidValue budgetId,
+    int statementBalanceCents,
+  ) => caller
+      .callServerEndpoint<List<int>>('transaction', 'reconcileWithBalance', {
+        'accountId': accountId,
+        'budgetId': budgetId,
+        'statementBalanceCents': statementBalanceCents,
+      });
+
   /// Calculates the "Age of Money" for a budget.
   ///
   /// Returns the average days between income and spending, or null if

--- a/openbudget_client/lib/src/protocol/protocol.dart
+++ b/openbudget_client/lib/src/protocol/protocol.dart
@@ -222,6 +222,9 @@ class Protocol extends _i1.SerializationManager {
               .toList()
           as T;
     }
+    if (t == List<int>) {
+      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
+    }
     if (t == List<_i24.SplitItem>) {
       return (data as List).map((e) => deserialize<_i24.SplitItem>(e)).toList()
           as T;

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -1781,6 +1781,34 @@ class Endpoints extends _i1.EndpointDispatch {
                     params['budgetId'],
                   ),
         ),
+        'reconcileWithBalance': _i1.MethodConnector(
+          name: 'reconcileWithBalance',
+          params: {
+            'accountId': _i1.ParameterDescription(
+              name: 'accountId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'budgetId': _i1.ParameterDescription(
+              name: 'budgetId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'statementBalanceCents': _i1.ParameterDescription(
+              name: 'statementBalanceCents',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+          },
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['transaction'] as _i14.TransactionEndpoint)
+                  .reconcileWithBalance(
+                    session,
+                    params['accountId'],
+                    params['budgetId'],
+                    params['statementBalanceCents'],
+                  ),
+        ),
         'ageOfMoney': _i1.MethodConnector(
           name: 'ageOfMoney',
           params: {

--- a/openbudget_server/lib/src/generated/protocol.dart
+++ b/openbudget_server/lib/src/generated/protocol.dart
@@ -1461,6 +1461,9 @@ class Protocol extends _i1.SerializationManagerServer {
               .toList()
           as T;
     }
+    if (t == List<int>) {
+      return (data as List).map((e) => deserialize<int>(e)).toList() as T;
+    }
     if (t == List<_i27.SplitItem>) {
       return (data as List).map((e) => deserialize<_i27.SplitItem>(e)).toList()
           as T;

--- a/openbudget_server/lib/src/generated/protocol.yaml
+++ b/openbudget_server/lib/src/generated/protocol.yaml
@@ -80,6 +80,7 @@ transaction:
   - listByAccount:
   - toggleCleared:
   - reconcileAccount:
+  - reconcileWithBalance:
   - ageOfMoney:
   - createSplit:
   - listSplits:

--- a/openbudget_server/lib/src/transactions/transaction_endpoint.dart
+++ b/openbudget_server/lib/src/transactions/transaction_endpoint.dart
@@ -142,6 +142,24 @@ class TransactionEndpoint extends Endpoint {
     );
   }
 
+  /// Reconciles an account with a statement balance.
+  ///
+  /// If the cleared balance differs from the statement balance, creates an
+  /// adjustment transaction. Returns [reconciledCount, adjustmentCents].
+  Future<List<int>> reconcileWithBalance(
+    Session session,
+    UuidValue accountId,
+    UuidValue budgetId,
+    int statementBalanceCents,
+  ) async {
+    return TransactionService.reconcileWithBalance(
+      session,
+      accountId: accountId,
+      budgetId: budgetId,
+      statementBalanceCents: statementBalanceCents,
+    );
+  }
+
   /// Calculates the "Age of Money" for a budget.
   ///
   /// Returns the average days between income and spending, or null if

--- a/openbudget_server/lib/src/transactions/transaction_service.dart
+++ b/openbudget_server/lib/src/transactions/transaction_service.dart
@@ -212,6 +212,64 @@ class TransactionService {
     return cleared.length;
   }
 
+  /// Reconciles an account with a statement balance.
+  ///
+  /// Computes the cleared balance (sum of all cleared & unreconciled
+  /// transactions plus previously reconciled transactions). If it differs
+  /// from [statementBalanceCents], an adjustment transaction is created.
+  /// All cleared transactions are then marked reconciled.
+  ///
+  /// Returns a list containing: [reconciledCount, adjustmentCents].
+  static Future<List<int>> reconcileWithBalance(
+    Session session, {
+    required UuidValue accountId,
+    required UuidValue budgetId,
+    required int statementBalanceCents,
+  }) async {
+    final budget = await BudgetService.getById(session, budgetId: budgetId);
+
+    // Sum all transactions for this account to get the current balance.
+    final allTransactions = await Transaction.db.find(
+      session,
+      where: (t) => t.budgetId.equals(budgetId) & t.accountId.equals(accountId),
+    );
+
+    // Cleared balance = sum of all reconciled + cleared transactions.
+    var clearedBalanceCents = 0;
+    for (final txn in allTransactions) {
+      if (txn.reconciled || txn.cleared) {
+        clearedBalanceCents += txn.amountCents;
+      }
+    }
+
+    final adjustmentCents = statementBalanceCents - clearedBalanceCents;
+
+    // Create adjustment transaction if needed.
+    if (adjustmentCents != 0) {
+      final adjustment = Transaction(
+        budgetId: budgetId,
+        accountId: accountId,
+        amountCents: adjustmentCents,
+        currencyCode: budget.currencyCode,
+        description: 'Reconciliation adjustment',
+        transactionDate: DateTime.now(),
+        cleared: true,
+        reconciled: true,
+        createdAt: DateTime.now(),
+      );
+      await Transaction.db.insertRow(session, adjustment);
+    }
+
+    // Mark all cleared transactions as reconciled.
+    final count = await reconcileAccount(
+      session,
+      accountId: accountId,
+      budgetId: budgetId,
+    );
+
+    return [count, adjustmentCents];
+  }
+
   /// Calculates the "Age of Money" for a budget using FIFO matching.
   ///
   /// Returns the average number of days between income receipt and spending

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -2719,6 +2719,43 @@ class _TransactionEndpoint {
     });
   }
 
+  _i3.Future<List<int>> reconcileWithBalance(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue accountId,
+    _i2.UuidValue budgetId,
+    int statementBalanceCents,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'transaction',
+            method: 'reconcileWithBalance',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'transaction',
+          methodName: 'reconcileWithBalance',
+          parameters: _i1.testObjectToJson({
+            'accountId': accountId,
+            'budgetId': budgetId,
+            'statementBalanceCents': statementBalanceCents,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<List<int>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
   _i3.Future<int?> ageOfMoney(
     _i1.TestSessionBuilder sessionBuilder,
     _i2.UuidValue budgetId,


### PR DESCRIPTION
## Summary
- Replace the simple reconcile confirmation with a balance entry dialog
- Users enter their bank statement balance during reconciliation
- Dialog shows the current cleared balance and the difference
- If there's a discrepancy, an adjustment transaction is automatically created
- Server-side `reconcileWithBalance` method computes cleared balance, creates adjustment, and marks all cleared transactions as reconciled
- Shows success message with adjustment amount when applicable

## Test plan
- [ ] Navigate to an account detail screen
- [ ] Mark some transactions as cleared
- [ ] Tap the reconcile button in the app bar
- [ ] Verify the dialog shows the cleared balance
- [ ] Enter a statement balance matching the cleared balance and reconcile - verify no adjustment is created
- [ ] Enter a different statement balance and reconcile - verify an adjustment transaction is created
- [ ] Verify reconciled transactions show the lock icon and cannot be toggled