### PR TITLE
feat: auto-post due recurring transactions on budget open

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -115,6 +115,13 @@
       }
     }
   },
+  "@recurringAutoPosted": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@recurringDueBanner": {
     "placeholders": {
       "count": {
@@ -372,6 +379,7 @@
   "reconcileTitle": "Reconcile Account",
   "recurringAddButton": "Add Recurring",
   "recurringAddTitle": "Add Recurring Transaction",
+  "recurringAutoPosted": "{count, plural, =1{1 scheduled transaction auto-posted} other{{count} scheduled transactions auto-posted}}",
   "recurringCreateError": "Could not create recurring transaction. Please try again.",
   "recurringCreateSuccess": "Recurring transaction created",
   "recurringDueBanner": "{count, plural, =1{1 scheduled transaction is due} other{{count} scheduled transactions are due}}",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1384,6 +1384,12 @@ abstract class AppLocalizations {
   /// **'Add Recurring Transaction'**
   String get recurringAddTitle;
 
+  /// No description provided for @recurringAutoPosted.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 scheduled transaction auto-posted} other{{count} scheduled transactions auto-posted}}'**
+  String recurringAutoPosted(int count);
+
   /// No description provided for @recurringCreateError.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -788,6 +788,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get recurringAddTitle => 'Add Recurring Transaction';
 
   @override
+  String recurringAutoPosted(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count scheduled transactions auto-posted',
+      one: '1 scheduled transaction auto-posted',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get recurringCreateError =>
       'Could not create recurring transaction. Please try again.';
 

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -41,12 +41,42 @@ class BudgetDetailScreen extends HookConsumerWidget {
     final goalsAsync = ref.watch(budgetGoalsProvider(budgetId));
     final dueCountAsync = ref.watch(recurringDueCountProvider(budgetId));
     final isPosting = useState(false);
+    final hasAutoPosted = useState(false);
     final isReordering = useState(false);
     final searchController = useTextEditingController();
     final searchQuery = useState('');
     final isSearching = useState(false);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+
+    // Auto-post due recurring transactions when the budget opens.
+    useEffect(() {
+      if (hasAutoPosted.value) return null;
+      if (!dueCountAsync.hasValue || dueCountAsync.value! <= 0) return null;
+      if (!summaryAsync.hasValue) return null;
+
+      hasAutoPosted.value = true;
+
+      Future.microtask(() async {
+        isPosting.value = true;
+        try {
+          final count = await ref
+              .read(recurringAutoPostActionsProvider.notifier)
+              .postDue(budgetId: budgetId);
+          if (context.mounted && count > 0) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(l10n.recurringAutoPosted(count))),
+            );
+          }
+        } on Exception catch (_) {
+          hasAutoPosted.value = false;
+        } finally {
+          isPosting.value = false;
+        }
+      });
+
+      return null;
+    }, [dueCountAsync, summaryAsync]);
 
     return summaryAsync.when(
       loading: () => Scaffold(


### PR DESCRIPTION
## Summary
- Automatically posts due recurring transactions when the budget detail screen opens, instead of requiring a manual "Post Now" tap
- Shows a SnackBar notification with the count of auto-posted transactions
- The manual due banner remains as a fallback if auto-post fails or for transactions that become due during the session
- Adds `recurringAutoPosted` l10n string with plural support

## Test plan
- [ ] Open a budget with due recurring transactions — verify they are auto-posted and a SnackBar appears
- [ ] Verify the due banner disappears after auto-post completes
- [ ] If auto-post fails, verify the manual "Post Now" banner remains functional
- [ ] Navigate away and back to the budget — verify auto-post fires again for any newly due transactions
- [ ] Run `dart analyze --fatal-infos` — no issues
- [ ] Run `flutter test` — all tests pass