### PR TITLE
feat: add multi-month budget comparison

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -1,5 +1,12 @@
 {
   "@@locale": "en",
+  "@comparisonMonths": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@ageOfMoneyLabel": {
     "placeholders": {
       "days": {
@@ -280,6 +287,14 @@
   "categoryTrendsEmptyTitle": "No Category Data",
   "categoryTrendsLoadError": "Could not load category trends",
   "categoryTrendsTitle": "Category Trends",
+  "comparisonTitle": "Budget Comparison",
+  "comparisonMonthRange": "Month Range",
+  "comparisonMonths": "{count, plural, =1{Last 1 month} other{Last {count} months}}",
+  "comparisonLoadError": "Could not load comparison data",
+  "comparisonEmptyTitle": "No Budget Data",
+  "comparisonEmptySubtitle": "Add categories and envelopes to compare months",
+  "comparisonCategoryLabel": "Category",
+  "comparisonTotalLabel": "Total Spending",
   "createBudgetButton": "Create",
   "createBudgetCreating": "Creating...",
   "createBudgetCurrencyLabel": "Primary Currency",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -748,6 +748,54 @@ abstract class AppLocalizations {
   /// **'Category Trends'**
   String get categoryTrendsTitle;
 
+  /// No description provided for @comparisonTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Budget Comparison'**
+  String get comparisonTitle;
+
+  /// No description provided for @comparisonMonthRange.
+  ///
+  /// In en, this message translates to:
+  /// **'Month Range'**
+  String get comparisonMonthRange;
+
+  /// No description provided for @comparisonMonths.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Last 1 month} other{Last {count} months}}'**
+  String comparisonMonths(int count);
+
+  /// No description provided for @comparisonLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load comparison data'**
+  String get comparisonLoadError;
+
+  /// No description provided for @comparisonEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Budget Data'**
+  String get comparisonEmptyTitle;
+
+  /// No description provided for @comparisonEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add categories and envelopes to compare months'**
+  String get comparisonEmptySubtitle;
+
+  /// No description provided for @comparisonCategoryLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Category'**
+  String get comparisonCategoryLabel;
+
+  /// No description provided for @comparisonTotalLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Total Spending'**
+  String get comparisonTotalLabel;
+
   /// No description provided for @createBudgetButton.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -389,6 +389,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String get categoryTrendsTitle => 'Category Trends';
 
   @override
+  String get comparisonTitle => 'Budget Comparison';
+
+  @override
+  String get comparisonMonthRange => 'Month Range';
+
+  @override
+  String comparisonMonths(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Last $count months',
+      one: 'Last 1 month',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get comparisonLoadError => 'Could not load comparison data';
+
+  @override
+  String get comparisonEmptyTitle => 'No Budget Data';
+
+  @override
+  String get comparisonEmptySubtitle =>
+      'Add categories and envelopes to compare months';
+
+  @override
+  String get comparisonCategoryLabel => 'Category';
+
+  @override
+  String get comparisonTotalLabel => 'Total Spending';
+
+  @override
   String get createBudgetButton => 'Create';
 
   @override

--- a/openbudget_app/lib/src/features/reports/providers/multi_month_comparison_provider.dart
+++ b/openbudget_app/lib/src/features/reports/providers/multi_month_comparison_provider.dart
@@ -1,0 +1,206 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/monthly_allocation_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'multi_month_comparison_provider.freezed.dart';
+part 'multi_month_comparison_provider.g.dart';
+
+@freezed
+sealed class MonthColumn with _$MonthColumn {
+  const factory MonthColumn({
+    required int year,
+    required int month,
+    required int totalBudgetedCents,
+    required int totalSpentCents,
+    required int totalAvailableCents,
+    required int totalIncomeCents,
+  }) = _MonthColumn;
+}
+
+@freezed
+sealed class EnvelopeComparison with _$EnvelopeComparison {
+  const factory EnvelopeComparison({
+    required Envelope envelope,
+
+    /// Keyed by "year-month" string, each entry holds
+    /// [budgeted, spent, available].
+    required Map<String, List<int>> monthData,
+  }) = _EnvelopeComparison;
+}
+
+@freezed
+sealed class CategoryComparison with _$CategoryComparison {
+  const factory CategoryComparison({
+    required Category category,
+    required List<EnvelopeComparison> envelopes,
+
+    /// Keyed by "year-month" string, each entry holds
+    /// [budgeted, spent, available].
+    required Map<String, List<int>> monthTotals,
+  }) = _CategoryComparison;
+}
+
+@freezed
+sealed class MultiMonthComparison with _$MultiMonthComparison {
+  const factory MultiMonthComparison({
+    required Budget budget,
+    required List<MonthColumn> months,
+    required List<CategoryComparison> categories,
+  }) = _MultiMonthComparison;
+}
+
+/// Fetches budget data for [monthCount] consecutive months ending at the
+/// current month and returns a comparison structure.
+@riverpod
+Future<MultiMonthComparison> multiMonthComparison(
+  Ref ref,
+  String budgetId, {
+  int monthCount = 3,
+}) async {
+  final budget = await ref.watch(budgetDetailProvider(budgetId).future);
+  final categories = await ref.watch(categoryListProvider(budgetId).future);
+
+  final now = DateTime.now();
+  final monthKeys = <String>[];
+  final monthColumns = <MonthColumn>[];
+
+  // Generate month ranges (most recent N months).
+  final monthRanges = <(int, int)>[];
+  for (var i = monthCount - 1; i >= 0; i--) {
+    var y = now.year;
+    var m = now.month - i;
+    while (m <= 0) {
+      m += 12;
+      y--;
+    }
+    monthRanges.add((y, m));
+  }
+
+  // Fetch allocations and transactions for each month.
+  final allAllocations = <String, List<MonthlyAllocation>>{};
+  final allTransactions = <String, List<Transaction>>{};
+
+  for (final (year, month) in monthRanges) {
+    final key = '$year-$month';
+    monthKeys.add(key);
+
+    final allocations = await ref.watch(
+      monthlyAllocationsProvider(budgetId, year, month).future,
+    );
+    final transactions = await ref.watch(
+      monthlyTransactionsProvider(budgetId, year, month).future,
+    );
+
+    allAllocations[key] = allocations;
+    allTransactions[key] = transactions;
+  }
+
+  // Build per-month allocation and spending maps.
+  final monthAllocationMaps = <String, Map<String, MonthlyAllocation>>{};
+  final monthSpentMaps = <String, Map<String, int>>{};
+  final monthIncomeMaps = <String, int>{};
+
+  for (final key in monthKeys) {
+    final aMap = <String, MonthlyAllocation>{};
+    for (final a in allAllocations[key]!) {
+      aMap[a.envelopeId.toString()] = a;
+    }
+    monthAllocationMaps[key] = aMap;
+
+    final sMap = <String, int>{};
+    var income = 0;
+    for (final t in allTransactions[key]!) {
+      if (t.amountCents > 0) {
+        income += t.amountCents;
+      } else if (t.envelopeId != null) {
+        final ek = t.envelopeId.toString();
+        sMap[ek] = (sMap[ek] ?? 0) + t.amountCents.abs();
+      }
+    }
+    monthSpentMaps[key] = sMap;
+    monthIncomeMaps[key] = income;
+  }
+
+  // Build category comparison data.
+  final categoryComparisons = <CategoryComparison>[];
+
+  for (final category in categories) {
+    final categoryId = category.id?.toString() ?? '';
+    final envelopes = await ref.watch(envelopeListProvider(categoryId).future);
+
+    final envelopeComparisons = <EnvelopeComparison>[];
+    final catMonthTotals = <String, List<int>>{};
+
+    for (final key in monthKeys) {
+      catMonthTotals[key] = [0, 0, 0]; // [budgeted, spent, available]
+    }
+
+    for (final envelope in envelopes) {
+      final ek = envelope.id?.toString() ?? '';
+      final envMonthData = <String, List<int>>{};
+
+      for (final key in monthKeys) {
+        final allocation = monthAllocationMaps[key]![ek];
+        final allocated = allocation?.allocatedCents ?? 0;
+        final carryover = allocation?.carryoverCents ?? 0;
+        final spent = monthSpentMaps[key]![ek] ?? 0;
+        final available = allocated + carryover - spent;
+
+        envMonthData[key] = [allocated, spent, available];
+        catMonthTotals[key] = [
+          catMonthTotals[key]![0] + allocated,
+          catMonthTotals[key]![1] + spent,
+          catMonthTotals[key]![2] + available,
+        ];
+      }
+
+      envelopeComparisons.add(
+        EnvelopeComparison(envelope: envelope, monthData: envMonthData),
+      );
+    }
+
+    categoryComparisons.add(
+      CategoryComparison(
+        category: category,
+        envelopes: envelopeComparisons,
+        monthTotals: catMonthTotals,
+      ),
+    );
+  }
+
+  // Build month column summaries.
+  for (final (year, month) in monthRanges) {
+    final key = '$year-$month';
+    var totalBudgeted = 0;
+    var totalSpent = 0;
+    var totalAvailable = 0;
+
+    for (final cat in categoryComparisons) {
+      final totals = cat.monthTotals[key];
+      if (totals != null) {
+        totalBudgeted += totals[0];
+        totalSpent += totals[1];
+        totalAvailable += totals[2];
+      }
+    }
+
+    monthColumns.add(
+      MonthColumn(
+        year: year,
+        month: month,
+        totalBudgetedCents: totalBudgeted,
+        totalSpentCents: totalSpent,
+        totalAvailableCents: totalAvailable,
+        totalIncomeCents: monthIncomeMaps[key] ?? 0,
+      ),
+    );
+  }
+
+  return MultiMonthComparison(
+    budget: budget,
+    months: monthColumns,
+    categories: categoryComparisons,
+  );
+}

--- a/openbudget_app/lib/src/features/reports/providers/multi_month_comparison_provider.freezed.dart
+++ b/openbudget_app/lib/src/features/reports/providers/multi_month_comparison_provider.freezed.dart
@@ -1,0 +1,1090 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'multi_month_comparison_provider.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$MonthColumn {
+
+ int get year; int get month; int get totalBudgetedCents; int get totalSpentCents; int get totalAvailableCents; int get totalIncomeCents;
+/// Create a copy of MonthColumn
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MonthColumnCopyWith<MonthColumn> get copyWith => _$MonthColumnCopyWithImpl<MonthColumn>(this as MonthColumn, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MonthColumn&&(identical(other.year, year) || other.year == year)&&(identical(other.month, month) || other.month == month)&&(identical(other.totalBudgetedCents, totalBudgetedCents) || other.totalBudgetedCents == totalBudgetedCents)&&(identical(other.totalSpentCents, totalSpentCents) || other.totalSpentCents == totalSpentCents)&&(identical(other.totalAvailableCents, totalAvailableCents) || other.totalAvailableCents == totalAvailableCents)&&(identical(other.totalIncomeCents, totalIncomeCents) || other.totalIncomeCents == totalIncomeCents));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,year,month,totalBudgetedCents,totalSpentCents,totalAvailableCents,totalIncomeCents);
+
+@override
+String toString() {
+  return 'MonthColumn(year: $year, month: $month, totalBudgetedCents: $totalBudgetedCents, totalSpentCents: $totalSpentCents, totalAvailableCents: $totalAvailableCents, totalIncomeCents: $totalIncomeCents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MonthColumnCopyWith<$Res>  {
+  factory $MonthColumnCopyWith(MonthColumn value, $Res Function(MonthColumn) _then) = _$MonthColumnCopyWithImpl;
+@useResult
+$Res call({
+ int year, int month, int totalBudgetedCents, int totalSpentCents, int totalAvailableCents, int totalIncomeCents
+});
+
+
+
+
+}
+/// @nodoc
+class _$MonthColumnCopyWithImpl<$Res>
+    implements $MonthColumnCopyWith<$Res> {
+  _$MonthColumnCopyWithImpl(this._self, this._then);
+
+  final MonthColumn _self;
+  final $Res Function(MonthColumn) _then;
+
+/// Create a copy of MonthColumn
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? year = null,Object? month = null,Object? totalBudgetedCents = null,Object? totalSpentCents = null,Object? totalAvailableCents = null,Object? totalIncomeCents = null,}) {
+  return _then(_self.copyWith(
+year: null == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
+as int,month: null == month ? _self.month : month // ignore: cast_nullable_to_non_nullable
+as int,totalBudgetedCents: null == totalBudgetedCents ? _self.totalBudgetedCents : totalBudgetedCents // ignore: cast_nullable_to_non_nullable
+as int,totalSpentCents: null == totalSpentCents ? _self.totalSpentCents : totalSpentCents // ignore: cast_nullable_to_non_nullable
+as int,totalAvailableCents: null == totalAvailableCents ? _self.totalAvailableCents : totalAvailableCents // ignore: cast_nullable_to_non_nullable
+as int,totalIncomeCents: null == totalIncomeCents ? _self.totalIncomeCents : totalIncomeCents // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MonthColumn].
+extension MonthColumnPatterns on MonthColumn {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MonthColumn value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MonthColumn() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MonthColumn value)  $default,){
+final _that = this;
+switch (_that) {
+case _MonthColumn():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MonthColumn value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MonthColumn() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int year,  int month,  int totalBudgetedCents,  int totalSpentCents,  int totalAvailableCents,  int totalIncomeCents)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MonthColumn() when $default != null:
+return $default(_that.year,_that.month,_that.totalBudgetedCents,_that.totalSpentCents,_that.totalAvailableCents,_that.totalIncomeCents);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int year,  int month,  int totalBudgetedCents,  int totalSpentCents,  int totalAvailableCents,  int totalIncomeCents)  $default,) {final _that = this;
+switch (_that) {
+case _MonthColumn():
+return $default(_that.year,_that.month,_that.totalBudgetedCents,_that.totalSpentCents,_that.totalAvailableCents,_that.totalIncomeCents);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int year,  int month,  int totalBudgetedCents,  int totalSpentCents,  int totalAvailableCents,  int totalIncomeCents)?  $default,) {final _that = this;
+switch (_that) {
+case _MonthColumn() when $default != null:
+return $default(_that.year,_that.month,_that.totalBudgetedCents,_that.totalSpentCents,_that.totalAvailableCents,_that.totalIncomeCents);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _MonthColumn implements MonthColumn {
+  const _MonthColumn({required this.year, required this.month, required this.totalBudgetedCents, required this.totalSpentCents, required this.totalAvailableCents, required this.totalIncomeCents});
+  
+
+@override final  int year;
+@override final  int month;
+@override final  int totalBudgetedCents;
+@override final  int totalSpentCents;
+@override final  int totalAvailableCents;
+@override final  int totalIncomeCents;
+
+/// Create a copy of MonthColumn
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MonthColumnCopyWith<_MonthColumn> get copyWith => __$MonthColumnCopyWithImpl<_MonthColumn>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MonthColumn&&(identical(other.year, year) || other.year == year)&&(identical(other.month, month) || other.month == month)&&(identical(other.totalBudgetedCents, totalBudgetedCents) || other.totalBudgetedCents == totalBudgetedCents)&&(identical(other.totalSpentCents, totalSpentCents) || other.totalSpentCents == totalSpentCents)&&(identical(other.totalAvailableCents, totalAvailableCents) || other.totalAvailableCents == totalAvailableCents)&&(identical(other.totalIncomeCents, totalIncomeCents) || other.totalIncomeCents == totalIncomeCents));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,year,month,totalBudgetedCents,totalSpentCents,totalAvailableCents,totalIncomeCents);
+
+@override
+String toString() {
+  return 'MonthColumn(year: $year, month: $month, totalBudgetedCents: $totalBudgetedCents, totalSpentCents: $totalSpentCents, totalAvailableCents: $totalAvailableCents, totalIncomeCents: $totalIncomeCents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$MonthColumnCopyWith<$Res> implements $MonthColumnCopyWith<$Res> {
+  factory _$MonthColumnCopyWith(_MonthColumn value, $Res Function(_MonthColumn) _then) = __$MonthColumnCopyWithImpl;
+@override @useResult
+$Res call({
+ int year, int month, int totalBudgetedCents, int totalSpentCents, int totalAvailableCents, int totalIncomeCents
+});
+
+
+
+
+}
+/// @nodoc
+class __$MonthColumnCopyWithImpl<$Res>
+    implements _$MonthColumnCopyWith<$Res> {
+  __$MonthColumnCopyWithImpl(this._self, this._then);
+
+  final _MonthColumn _self;
+  final $Res Function(_MonthColumn) _then;
+
+/// Create a copy of MonthColumn
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? year = null,Object? month = null,Object? totalBudgetedCents = null,Object? totalSpentCents = null,Object? totalAvailableCents = null,Object? totalIncomeCents = null,}) {
+  return _then(_MonthColumn(
+year: null == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
+as int,month: null == month ? _self.month : month // ignore: cast_nullable_to_non_nullable
+as int,totalBudgetedCents: null == totalBudgetedCents ? _self.totalBudgetedCents : totalBudgetedCents // ignore: cast_nullable_to_non_nullable
+as int,totalSpentCents: null == totalSpentCents ? _self.totalSpentCents : totalSpentCents // ignore: cast_nullable_to_non_nullable
+as int,totalAvailableCents: null == totalAvailableCents ? _self.totalAvailableCents : totalAvailableCents // ignore: cast_nullable_to_non_nullable
+as int,totalIncomeCents: null == totalIncomeCents ? _self.totalIncomeCents : totalIncomeCents // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$EnvelopeComparison {
+
+ Envelope get envelope;/// Keyed by "year-month" string, each entry holds
+/// [budgeted, spent, available].
+ Map<String, List<int>> get monthData;
+/// Create a copy of EnvelopeComparison
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EnvelopeComparisonCopyWith<EnvelopeComparison> get copyWith => _$EnvelopeComparisonCopyWithImpl<EnvelopeComparison>(this as EnvelopeComparison, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EnvelopeComparison&&(identical(other.envelope, envelope) || other.envelope == envelope)&&const DeepCollectionEquality().equals(other.monthData, monthData));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,envelope,const DeepCollectionEquality().hash(monthData));
+
+@override
+String toString() {
+  return 'EnvelopeComparison(envelope: $envelope, monthData: $monthData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EnvelopeComparisonCopyWith<$Res>  {
+  factory $EnvelopeComparisonCopyWith(EnvelopeComparison value, $Res Function(EnvelopeComparison) _then) = _$EnvelopeComparisonCopyWithImpl;
+@useResult
+$Res call({
+ Envelope envelope, Map<String, List<int>> monthData
+});
+
+
+
+
+}
+/// @nodoc
+class _$EnvelopeComparisonCopyWithImpl<$Res>
+    implements $EnvelopeComparisonCopyWith<$Res> {
+  _$EnvelopeComparisonCopyWithImpl(this._self, this._then);
+
+  final EnvelopeComparison _self;
+  final $Res Function(EnvelopeComparison) _then;
+
+/// Create a copy of EnvelopeComparison
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? envelope = null,Object? monthData = null,}) {
+  return _then(_self.copyWith(
+envelope: null == envelope ? _self.envelope : envelope // ignore: cast_nullable_to_non_nullable
+as Envelope,monthData: null == monthData ? _self.monthData : monthData // ignore: cast_nullable_to_non_nullable
+as Map<String, List<int>>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EnvelopeComparison].
+extension EnvelopeComparisonPatterns on EnvelopeComparison {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EnvelopeComparison value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EnvelopeComparison() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EnvelopeComparison value)  $default,){
+final _that = this;
+switch (_that) {
+case _EnvelopeComparison():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EnvelopeComparison value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EnvelopeComparison() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Envelope envelope,  Map<String, List<int>> monthData)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EnvelopeComparison() when $default != null:
+return $default(_that.envelope,_that.monthData);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Envelope envelope,  Map<String, List<int>> monthData)  $default,) {final _that = this;
+switch (_that) {
+case _EnvelopeComparison():
+return $default(_that.envelope,_that.monthData);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Envelope envelope,  Map<String, List<int>> monthData)?  $default,) {final _that = this;
+switch (_that) {
+case _EnvelopeComparison() when $default != null:
+return $default(_that.envelope,_that.monthData);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EnvelopeComparison implements EnvelopeComparison {
+  const _EnvelopeComparison({required this.envelope, required final  Map<String, List<int>> monthData}): _monthData = monthData;
+  
+
+@override final  Envelope envelope;
+/// Keyed by "year-month" string, each entry holds
+/// [budgeted, spent, available].
+ final  Map<String, List<int>> _monthData;
+/// Keyed by "year-month" string, each entry holds
+/// [budgeted, spent, available].
+@override Map<String, List<int>> get monthData {
+  if (_monthData is EqualUnmodifiableMapView) return _monthData;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_monthData);
+}
+
+
+/// Create a copy of EnvelopeComparison
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EnvelopeComparisonCopyWith<_EnvelopeComparison> get copyWith => __$EnvelopeComparisonCopyWithImpl<_EnvelopeComparison>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EnvelopeComparison&&(identical(other.envelope, envelope) || other.envelope == envelope)&&const DeepCollectionEquality().equals(other._monthData, _monthData));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,envelope,const DeepCollectionEquality().hash(_monthData));
+
+@override
+String toString() {
+  return 'EnvelopeComparison(envelope: $envelope, monthData: $monthData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EnvelopeComparisonCopyWith<$Res> implements $EnvelopeComparisonCopyWith<$Res> {
+  factory _$EnvelopeComparisonCopyWith(_EnvelopeComparison value, $Res Function(_EnvelopeComparison) _then) = __$EnvelopeComparisonCopyWithImpl;
+@override @useResult
+$Res call({
+ Envelope envelope, Map<String, List<int>> monthData
+});
+
+
+
+
+}
+/// @nodoc
+class __$EnvelopeComparisonCopyWithImpl<$Res>
+    implements _$EnvelopeComparisonCopyWith<$Res> {
+  __$EnvelopeComparisonCopyWithImpl(this._self, this._then);
+
+  final _EnvelopeComparison _self;
+  final $Res Function(_EnvelopeComparison) _then;
+
+/// Create a copy of EnvelopeComparison
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? envelope = null,Object? monthData = null,}) {
+  return _then(_EnvelopeComparison(
+envelope: null == envelope ? _self.envelope : envelope // ignore: cast_nullable_to_non_nullable
+as Envelope,monthData: null == monthData ? _self._monthData : monthData // ignore: cast_nullable_to_non_nullable
+as Map<String, List<int>>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$CategoryComparison {
+
+ Category get category; List<EnvelopeComparison> get envelopes;/// Keyed by "year-month" string, each entry holds
+/// [budgeted, spent, available].
+ Map<String, List<int>> get monthTotals;
+/// Create a copy of CategoryComparison
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CategoryComparisonCopyWith<CategoryComparison> get copyWith => _$CategoryComparisonCopyWithImpl<CategoryComparison>(this as CategoryComparison, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CategoryComparison&&(identical(other.category, category) || other.category == category)&&const DeepCollectionEquality().equals(other.envelopes, envelopes)&&const DeepCollectionEquality().equals(other.monthTotals, monthTotals));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,category,const DeepCollectionEquality().hash(envelopes),const DeepCollectionEquality().hash(monthTotals));
+
+@override
+String toString() {
+  return 'CategoryComparison(category: $category, envelopes: $envelopes, monthTotals: $monthTotals)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CategoryComparisonCopyWith<$Res>  {
+  factory $CategoryComparisonCopyWith(CategoryComparison value, $Res Function(CategoryComparison) _then) = _$CategoryComparisonCopyWithImpl;
+@useResult
+$Res call({
+ Category category, List<EnvelopeComparison> envelopes, Map<String, List<int>> monthTotals
+});
+
+
+
+
+}
+/// @nodoc
+class _$CategoryComparisonCopyWithImpl<$Res>
+    implements $CategoryComparisonCopyWith<$Res> {
+  _$CategoryComparisonCopyWithImpl(this._self, this._then);
+
+  final CategoryComparison _self;
+  final $Res Function(CategoryComparison) _then;
+
+/// Create a copy of CategoryComparison
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? category = null,Object? envelopes = null,Object? monthTotals = null,}) {
+  return _then(_self.copyWith(
+category: null == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as Category,envelopes: null == envelopes ? _self.envelopes : envelopes // ignore: cast_nullable_to_non_nullable
+as List<EnvelopeComparison>,monthTotals: null == monthTotals ? _self.monthTotals : monthTotals // ignore: cast_nullable_to_non_nullable
+as Map<String, List<int>>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [CategoryComparison].
+extension CategoryComparisonPatterns on CategoryComparison {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CategoryComparison value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CategoryComparison() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CategoryComparison value)  $default,){
+final _that = this;
+switch (_that) {
+case _CategoryComparison():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CategoryComparison value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CategoryComparison() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Category category,  List<EnvelopeComparison> envelopes,  Map<String, List<int>> monthTotals)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CategoryComparison() when $default != null:
+return $default(_that.category,_that.envelopes,_that.monthTotals);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Category category,  List<EnvelopeComparison> envelopes,  Map<String, List<int>> monthTotals)  $default,) {final _that = this;
+switch (_that) {
+case _CategoryComparison():
+return $default(_that.category,_that.envelopes,_that.monthTotals);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Category category,  List<EnvelopeComparison> envelopes,  Map<String, List<int>> monthTotals)?  $default,) {final _that = this;
+switch (_that) {
+case _CategoryComparison() when $default != null:
+return $default(_that.category,_that.envelopes,_that.monthTotals);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _CategoryComparison implements CategoryComparison {
+  const _CategoryComparison({required this.category, required final  List<EnvelopeComparison> envelopes, required final  Map<String, List<int>> monthTotals}): _envelopes = envelopes,_monthTotals = monthTotals;
+  
+
+@override final  Category category;
+ final  List<EnvelopeComparison> _envelopes;
+@override List<EnvelopeComparison> get envelopes {
+  if (_envelopes is EqualUnmodifiableListView) return _envelopes;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_envelopes);
+}
+
+/// Keyed by "year-month" string, each entry holds
+/// [budgeted, spent, available].
+ final  Map<String, List<int>> _monthTotals;
+/// Keyed by "year-month" string, each entry holds
+/// [budgeted, spent, available].
+@override Map<String, List<int>> get monthTotals {
+  if (_monthTotals is EqualUnmodifiableMapView) return _monthTotals;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_monthTotals);
+}
+
+
+/// Create a copy of CategoryComparison
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CategoryComparisonCopyWith<_CategoryComparison> get copyWith => __$CategoryComparisonCopyWithImpl<_CategoryComparison>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CategoryComparison&&(identical(other.category, category) || other.category == category)&&const DeepCollectionEquality().equals(other._envelopes, _envelopes)&&const DeepCollectionEquality().equals(other._monthTotals, _monthTotals));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,category,const DeepCollectionEquality().hash(_envelopes),const DeepCollectionEquality().hash(_monthTotals));
+
+@override
+String toString() {
+  return 'CategoryComparison(category: $category, envelopes: $envelopes, monthTotals: $monthTotals)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CategoryComparisonCopyWith<$Res> implements $CategoryComparisonCopyWith<$Res> {
+  factory _$CategoryComparisonCopyWith(_CategoryComparison value, $Res Function(_CategoryComparison) _then) = __$CategoryComparisonCopyWithImpl;
+@override @useResult
+$Res call({
+ Category category, List<EnvelopeComparison> envelopes, Map<String, List<int>> monthTotals
+});
+
+
+
+
+}
+/// @nodoc
+class __$CategoryComparisonCopyWithImpl<$Res>
+    implements _$CategoryComparisonCopyWith<$Res> {
+  __$CategoryComparisonCopyWithImpl(this._self, this._then);
+
+  final _CategoryComparison _self;
+  final $Res Function(_CategoryComparison) _then;
+
+/// Create a copy of CategoryComparison
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? category = null,Object? envelopes = null,Object? monthTotals = null,}) {
+  return _then(_CategoryComparison(
+category: null == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as Category,envelopes: null == envelopes ? _self._envelopes : envelopes // ignore: cast_nullable_to_non_nullable
+as List<EnvelopeComparison>,monthTotals: null == monthTotals ? _self._monthTotals : monthTotals // ignore: cast_nullable_to_non_nullable
+as Map<String, List<int>>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$MultiMonthComparison {
+
+ Budget get budget; List<MonthColumn> get months; List<CategoryComparison> get categories;
+/// Create a copy of MultiMonthComparison
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MultiMonthComparisonCopyWith<MultiMonthComparison> get copyWith => _$MultiMonthComparisonCopyWithImpl<MultiMonthComparison>(this as MultiMonthComparison, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultiMonthComparison&&(identical(other.budget, budget) || other.budget == budget)&&const DeepCollectionEquality().equals(other.months, months)&&const DeepCollectionEquality().equals(other.categories, categories));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,budget,const DeepCollectionEquality().hash(months),const DeepCollectionEquality().hash(categories));
+
+@override
+String toString() {
+  return 'MultiMonthComparison(budget: $budget, months: $months, categories: $categories)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MultiMonthComparisonCopyWith<$Res>  {
+  factory $MultiMonthComparisonCopyWith(MultiMonthComparison value, $Res Function(MultiMonthComparison) _then) = _$MultiMonthComparisonCopyWithImpl;
+@useResult
+$Res call({
+ Budget budget, List<MonthColumn> months, List<CategoryComparison> categories
+});
+
+
+
+
+}
+/// @nodoc
+class _$MultiMonthComparisonCopyWithImpl<$Res>
+    implements $MultiMonthComparisonCopyWith<$Res> {
+  _$MultiMonthComparisonCopyWithImpl(this._self, this._then);
+
+  final MultiMonthComparison _self;
+  final $Res Function(MultiMonthComparison) _then;
+
+/// Create a copy of MultiMonthComparison
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? budget = null,Object? months = null,Object? categories = null,}) {
+  return _then(_self.copyWith(
+budget: null == budget ? _self.budget : budget // ignore: cast_nullable_to_non_nullable
+as Budget,months: null == months ? _self.months : months // ignore: cast_nullable_to_non_nullable
+as List<MonthColumn>,categories: null == categories ? _self.categories : categories // ignore: cast_nullable_to_non_nullable
+as List<CategoryComparison>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MultiMonthComparison].
+extension MultiMonthComparisonPatterns on MultiMonthComparison {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MultiMonthComparison value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MultiMonthComparison() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MultiMonthComparison value)  $default,){
+final _that = this;
+switch (_that) {
+case _MultiMonthComparison():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MultiMonthComparison value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MultiMonthComparison() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Budget budget,  List<MonthColumn> months,  List<CategoryComparison> categories)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MultiMonthComparison() when $default != null:
+return $default(_that.budget,_that.months,_that.categories);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Budget budget,  List<MonthColumn> months,  List<CategoryComparison> categories)  $default,) {final _that = this;
+switch (_that) {
+case _MultiMonthComparison():
+return $default(_that.budget,_that.months,_that.categories);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Budget budget,  List<MonthColumn> months,  List<CategoryComparison> categories)?  $default,) {final _that = this;
+switch (_that) {
+case _MultiMonthComparison() when $default != null:
+return $default(_that.budget,_that.months,_that.categories);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _MultiMonthComparison implements MultiMonthComparison {
+  const _MultiMonthComparison({required this.budget, required final  List<MonthColumn> months, required final  List<CategoryComparison> categories}): _months = months,_categories = categories;
+  
+
+@override final  Budget budget;
+ final  List<MonthColumn> _months;
+@override List<MonthColumn> get months {
+  if (_months is EqualUnmodifiableListView) return _months;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_months);
+}
+
+ final  List<CategoryComparison> _categories;
+@override List<CategoryComparison> get categories {
+  if (_categories is EqualUnmodifiableListView) return _categories;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_categories);
+}
+
+
+/// Create a copy of MultiMonthComparison
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MultiMonthComparisonCopyWith<_MultiMonthComparison> get copyWith => __$MultiMonthComparisonCopyWithImpl<_MultiMonthComparison>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MultiMonthComparison&&(identical(other.budget, budget) || other.budget == budget)&&const DeepCollectionEquality().equals(other._months, _months)&&const DeepCollectionEquality().equals(other._categories, _categories));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,budget,const DeepCollectionEquality().hash(_months),const DeepCollectionEquality().hash(_categories));
+
+@override
+String toString() {
+  return 'MultiMonthComparison(budget: $budget, months: $months, categories: $categories)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$MultiMonthComparisonCopyWith<$Res> implements $MultiMonthComparisonCopyWith<$Res> {
+  factory _$MultiMonthComparisonCopyWith(_MultiMonthComparison value, $Res Function(_MultiMonthComparison) _then) = __$MultiMonthComparisonCopyWithImpl;
+@override @useResult
+$Res call({
+ Budget budget, List<MonthColumn> months, List<CategoryComparison> categories
+});
+
+
+
+
+}
+/// @nodoc
+class __$MultiMonthComparisonCopyWithImpl<$Res>
+    implements _$MultiMonthComparisonCopyWith<$Res> {
+  __$MultiMonthComparisonCopyWithImpl(this._self, this._then);
+
+  final _MultiMonthComparison _self;
+  final $Res Function(_MultiMonthComparison) _then;
+
+/// Create a copy of MultiMonthComparison
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? budget = null,Object? months = null,Object? categories = null,}) {
+  return _then(_MultiMonthComparison(
+budget: null == budget ? _self.budget : budget // ignore: cast_nullable_to_non_nullable
+as Budget,months: null == months ? _self._months : months // ignore: cast_nullable_to_non_nullable
+as List<MonthColumn>,categories: null == categories ? _self._categories : categories // ignore: cast_nullable_to_non_nullable
+as List<CategoryComparison>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/openbudget_app/lib/src/features/reports/providers/multi_month_comparison_provider.g.dart
+++ b/openbudget_app/lib/src/features/reports/providers/multi_month_comparison_provider.g.dart
@@ -1,0 +1,112 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'multi_month_comparison_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches budget data for [monthCount] consecutive months ending at the
+/// current month and returns a comparison structure.
+
+@ProviderFor(multiMonthComparison)
+final multiMonthComparisonProvider = MultiMonthComparisonFamily._();
+
+/// Fetches budget data for [monthCount] consecutive months ending at the
+/// current month and returns a comparison structure.
+
+final class MultiMonthComparisonProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<MultiMonthComparison>,
+          MultiMonthComparison,
+          FutureOr<MultiMonthComparison>
+        >
+    with
+        $FutureModifier<MultiMonthComparison>,
+        $FutureProvider<MultiMonthComparison> {
+  /// Fetches budget data for [monthCount] consecutive months ending at the
+  /// current month and returns a comparison structure.
+  MultiMonthComparisonProvider._({
+    required MultiMonthComparisonFamily super.from,
+    required (String, {int monthCount}) super.argument,
+  }) : super(
+         retry: null,
+         name: r'multiMonthComparisonProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$multiMonthComparisonHash();
+
+  @override
+  String toString() {
+    return r'multiMonthComparisonProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<MultiMonthComparison> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<MultiMonthComparison> create(Ref ref) {
+    final argument = this.argument as (String, {int monthCount});
+    return multiMonthComparison(
+      ref,
+      argument.$1,
+      monthCount: argument.monthCount,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MultiMonthComparisonProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$multiMonthComparisonHash() =>
+    r'179d987ca68a2ed999aafdf16a218c9284c53d90';
+
+/// Fetches budget data for [monthCount] consecutive months ending at the
+/// current month and returns a comparison structure.
+
+final class MultiMonthComparisonFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<MultiMonthComparison>,
+          (String, {int monthCount})
+        > {
+  MultiMonthComparisonFamily._()
+    : super(
+        retry: null,
+        name: r'multiMonthComparisonProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches budget data for [monthCount] consecutive months ending at the
+  /// current month and returns a comparison structure.
+
+  MultiMonthComparisonProvider call(String budgetId, {int monthCount = 3}) =>
+      MultiMonthComparisonProvider._(
+        argument: (budgetId, monthCount: monthCount),
+        from: this,
+      );
+
+  @override
+  String toString() => r'multiMonthComparisonProvider';
+}

--- a/openbudget_app/lib/src/features/reports/screens/multi_month_comparison_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/multi_month_comparison_screen.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/reports/providers/multi_month_comparison_provider.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+class MultiMonthComparisonScreen extends HookConsumerWidget {
+  const MultiMonthComparisonScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final monthCount = useState(3);
+
+    final comparisonAsync = ref.watch(
+      multiMonthComparisonProvider(budgetId, monthCount: monthCount.value),
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.comparisonTitle),
+        actions: [
+          PopupMenuButton<int>(
+            icon: const Icon(Icons.tune_rounded),
+            tooltip: l10n.comparisonMonthRange,
+            onSelected: (value) => monthCount.value = value,
+            itemBuilder: (_) => [
+              for (final count in [3, 6, 12])
+                PopupMenuItem(
+                  value: count,
+                  child: Text(l10n.comparisonMonths(count)),
+                ),
+            ],
+          ),
+        ],
+      ),
+      body: comparisonAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline_rounded,
+                size: 48,
+                color: colorScheme.error,
+              ),
+              const SizedBox(height: SpacingTokens.md),
+              Text(
+                l10n.comparisonLoadError,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.error,
+                ),
+              ),
+            ],
+          ),
+        ),
+        data: (comparison) {
+          final currency = CurrencyCode.values.firstWhere(
+            (c) => c.code == comparison.budget.currencyCode,
+            orElse: () => CurrencyCode.usd,
+          );
+
+          if (comparison.categories.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.compare_arrows_rounded,
+                    size: 48,
+                    color: colorScheme.outlineVariant,
+                  ),
+                  const SizedBox(height: SpacingTokens.md),
+                  Text(
+                    l10n.comparisonEmptyTitle,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: SpacingTokens.sm),
+                  Text(
+                    l10n.comparisonEmptySubtitle,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return _ComparisonTable(comparison: comparison, currency: currency);
+        },
+      ),
+    );
+  }
+}
+
+class _ComparisonTable extends HookWidget {
+  const _ComparisonTable({required this.comparison, required this.currency});
+
+  final MultiMonthComparison comparison;
+  final CurrencyCode currency;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final scrollController = useScrollController();
+
+    final months = comparison.months;
+    final monthKeys = months.map((m) => '${m.year}-${m.month}').toList();
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(SpacingTokens.sm),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        controller: scrollController,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header row with month names.
+            _buildHeaderRow(l10n, theme, months),
+            const SizedBox(height: SpacingTokens.xs),
+            // Totals row.
+            _buildTotalRow(l10n, theme, colorScheme, months, monthKeys),
+            const Divider(),
+            // Category/envelope rows.
+            for (final cat in comparison.categories) ...[
+              _buildCategoryRow(theme, colorScheme, cat, monthKeys),
+              for (final env in cat.envelopes)
+                _buildEnvelopeRow(theme, colorScheme, env, monthKeys),
+              const SizedBox(height: SpacingTokens.sm),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeaderRow(
+    AppLocalizations l10n,
+    ThemeData theme,
+    List<MonthColumn> months,
+  ) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 160,
+          child: Text(
+            l10n.comparisonCategoryLabel,
+            style: theme.textTheme.labelLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        for (final m in months)
+          SizedBox(
+            width: 120,
+            child: Text(
+              _shortMonthName(l10n, m.month, m.year),
+              style: theme.textTheme.labelLarge?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.right,
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildTotalRow(
+    AppLocalizations l10n,
+    ThemeData theme,
+    ColorScheme colorScheme,
+    List<MonthColumn> months,
+    List<String> monthKeys,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: SpacingTokens.xs),
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer.withAlpha(40),
+        borderRadius: BorderRadius.circular(RadiusTokens.sm),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 160,
+            child: Padding(
+              padding: const EdgeInsets.only(left: SpacingTokens.xs),
+              child: Text(
+                l10n.comparisonTotalLabel,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+          for (final m in months)
+            SizedBox(
+              width: 120,
+              child: Text(
+                formatCents(m.totalSpentCents, currency),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: ColorTokens.error,
+                ),
+                textAlign: TextAlign.right,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryRow(
+    ThemeData theme,
+    ColorScheme colorScheme,
+    CategoryComparison cat,
+    List<String> monthKeys,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: SpacingTokens.xs),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withAlpha(60),
+        borderRadius: BorderRadius.circular(RadiusTokens.sm),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 160,
+            child: Padding(
+              padding: const EdgeInsets.only(left: SpacingTokens.xs),
+              child: Text(
+                cat.category.name,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+          for (final key in monthKeys)
+            SizedBox(
+              width: 120,
+              child: Text(
+                formatCents(cat.monthTotals[key]?[1] ?? 0, currency),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.right,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEnvelopeRow(
+    ThemeData theme,
+    ColorScheme colorScheme,
+    EnvelopeComparison env,
+    List<String> monthKeys,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 160,
+            child: Padding(
+              padding: const EdgeInsets.only(left: SpacingTokens.lg),
+              child: Text(
+                env.envelope.name,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+          for (final key in monthKeys)
+            SizedBox(
+              width: 120,
+              child: Text(
+                formatCents(env.monthData[key]?[1] ?? 0, currency),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.right,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _shortMonthName(AppLocalizations l10n, int month, int year) {
+    final name = switch (month) {
+      1 => l10n.budgetMonthJanuary,
+      2 => l10n.budgetMonthFebruary,
+      3 => l10n.budgetMonthMarch,
+      4 => l10n.budgetMonthApril,
+      5 => l10n.budgetMonthMay,
+      6 => l10n.budgetMonthJune,
+      7 => l10n.budgetMonthJuly,
+      8 => l10n.budgetMonthAugust,
+      9 => l10n.budgetMonthSeptember,
+      10 => l10n.budgetMonthOctober,
+      11 => l10n.budgetMonthNovember,
+      12 => l10n.budgetMonthDecember,
+      _ => '',
+    };
+    // Abbreviate to first 3 chars.
+    final short = name.length > 3 ? name.substring(0, 3) : name;
+    return "$short '${(year % 100).toString().padLeft(2, '0')}";
+  }
+}

--- a/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
+++ b/openbudget_app/lib/src/features/reports/screens/reports_screen.dart
@@ -62,6 +62,14 @@ class ReportsScreen extends HookConsumerWidget {
               pathParameters: {'id': budgetId},
             ),
           ),
+          IconButton(
+            icon: const Icon(Icons.compare_arrows_rounded),
+            tooltip: l10n.comparisonTitle,
+            onPressed: () => context.pushNamed(
+              multiMonthComparisonRoute,
+              pathParameters: {'id': budgetId},
+            ),
+          ),
         ],
       ),
       body: Column(

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -13,6 +13,7 @@ import 'package:openbudget_app/src/features/home/screens/home_screen.dart';
 import 'package:openbudget_app/src/features/payees/screens/payee_list_screen.dart';
 import 'package:openbudget_app/src/features/recurring/screens/recurring_list_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/category_trends_screen.dart';
+import 'package:openbudget_app/src/features/reports/screens/multi_month_comparison_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/net_worth_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/reports_screen.dart';
 import 'package:openbudget_app/src/features/reports/screens/spending_by_payee_screen.dart';
@@ -204,6 +205,14 @@ GoRouter appRouter(Ref ref) {
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return CategoryTrendsScreen(budgetId: id);
+        },
+      ),
+      GoRoute(
+        name: multiMonthComparisonRoute,
+        path: multiMonthComparisonPath,
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return MultiMonthComparisonScreen(budgetId: id);
         },
       ),
       GoRoute(

--- a/openbudget_app/lib/src/routing/app_router.g.dart
+++ b/openbudget_app/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'70ac1ab69b64803be3419f9d333db471d7f1854c';
+String _$appRouterHash() => r'759cf971dd7c7423b0456d5b127a71818182203f';

--- a/openbudget_app/lib/src/routing/route_names.dart
+++ b/openbudget_app/lib/src/routing/route_names.dart
@@ -40,5 +40,7 @@ const spendingByPayeeRoute = 'spendingByPayee';
 const spendingByPayeePath = '/budgets/:id/reports/payees';
 const categoryTrendsRoute = 'categoryTrends';
 const categoryTrendsPath = '/budgets/:id/reports/category-trends';
+const multiMonthComparisonRoute = 'multiMonthComparison';
+const multiMonthComparisonPath = '/budgets/:id/reports/comparison';
 const settingsRoute = 'settings';
 const settingsPath = '/budgets/:id/settings';


### PR DESCRIPTION
## Summary
- Add `MultiMonthComparisonScreen` with horizontally scrollable table comparing spending across months
- New `multiMonthComparisonProvider` that fetches allocations and transactions for N consecutive months
- Freezed data models: `MonthColumn`, `EnvelopeComparison`, `CategoryComparison`, `MultiMonthComparison`
- Configurable month range (3, 6, or 12 months) via popup menu
- Navigate from Reports screen via compare icon button
- Category rows with envelope breakdown, showing spent amounts per month

## Test plan
- [ ] Open Reports screen and tap the compare arrows icon
- [ ] Verify comparison table loads with last 3 months
- [ ] Scroll horizontally to see all month columns
- [ ] Change month range to 6 or 12 months
- [ ] Verify category totals and envelope breakdowns are correct
- [ ] Verify empty state when no categories exist