### PR TITLE
feat: add bulk transaction categorization

### DIFF
--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -1,5 +1,19 @@
 {
   "@@locale": "en",
+  "@bulkAssignSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@bulkSelectedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@comparisonMonths": {
     "placeholders": {
       "count": {
@@ -220,6 +234,14 @@
   "autoAssignNothingToAssign": "All envelopes with goals are fully funded!",
   "autoAssignSuccess": "{count, plural, =1{Auto-assigned to 1 envelope} other{Auto-assigned to {count} envelopes}}",
   "autoAssignTitle": "Auto-Assign",
+  "bulkAssignEnvelope": "Assign Envelope",
+  "bulkAssignError": "Could not assign envelope. Please try again.",
+  "bulkAssignSuccess": "{count, plural, =1{1 transaction updated} other{{count} transactions updated}}",
+  "bulkSelectAll": "Select All",
+  "bulkCancelSelection": "Cancel",
+  "bulkDeselectAll": "Deselect All",
+  "bulkSelectEnvelope": "Select an envelope to assign",
+  "bulkSelectedCount": "{count, plural, =1{1 selected} other{{count} selected}}",
   "budgetAddCategory": "Add Category",
   "budgetAddEnvelope": "Add Envelope",
   "budgetAddExpense": "Add Expense",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -346,6 +346,54 @@ abstract class AppLocalizations {
   /// **'Auto-Assign'**
   String get autoAssignTitle;
 
+  /// No description provided for @bulkAssignEnvelope.
+  ///
+  /// In en, this message translates to:
+  /// **'Assign Envelope'**
+  String get bulkAssignEnvelope;
+
+  /// No description provided for @bulkAssignError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not assign envelope. Please try again.'**
+  String get bulkAssignError;
+
+  /// No description provided for @bulkAssignSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction updated} other{{count} transactions updated}}'**
+  String bulkAssignSuccess(int count);
+
+  /// No description provided for @bulkSelectAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Select All'**
+  String get bulkSelectAll;
+
+  /// No description provided for @bulkCancelSelection.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get bulkCancelSelection;
+
+  /// No description provided for @bulkDeselectAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Deselect All'**
+  String get bulkDeselectAll;
+
+  /// No description provided for @bulkSelectEnvelope.
+  ///
+  /// In en, this message translates to:
+  /// **'Select an envelope to assign'**
+  String get bulkSelectEnvelope;
+
+  /// No description provided for @bulkSelectedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 selected} other{{count} selected}}'**
+  String bulkSelectedCount(int count);
+
   /// No description provided for @budgetAddCategory.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -162,6 +162,46 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoAssignTitle => 'Auto-Assign';
 
   @override
+  String get bulkAssignEnvelope => 'Assign Envelope';
+
+  @override
+  String get bulkAssignError => 'Could not assign envelope. Please try again.';
+
+  @override
+  String bulkAssignSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions updated',
+      one: '1 transaction updated',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bulkSelectAll => 'Select All';
+
+  @override
+  String get bulkCancelSelection => 'Cancel';
+
+  @override
+  String get bulkDeselectAll => 'Deselect All';
+
+  @override
+  String get bulkSelectEnvelope => 'Select an envelope to assign';
+
+  @override
+  String bulkSelectedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count selected',
+      one: '1 selected',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get budgetAddCategory => 'Add Category';
 
   @override

--- a/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
@@ -163,6 +163,37 @@ class TransactionActions extends _$TransactionActions {
     }
   }
 
+  /// Assigns an envelope to multiple transactions at once.
+  Future<int> bulkAssignEnvelope({
+    required List<String> transactionIds,
+    required String envelopeId,
+    required String budgetId,
+  }) async {
+    final client = ref.read(serverpodClientProvider);
+    var count = 0;
+    for (final txId in transactionIds) {
+      try {
+        await client.transaction.update(
+          // Serverpod API requires UuidValue which is experimental in uuid package.
+          // ignore: experimental_member_use
+          UuidValue.fromString(txId),
+          // Serverpod API requires UuidValue which is experimental in uuid package.
+          // ignore: experimental_member_use
+          envelopeId: UuidValue.fromString(envelopeId),
+        );
+        count++;
+      } on Exception catch (_) {
+        // Continue with other transactions on individual failure.
+      }
+    }
+    if (ref.mounted) {
+      ref
+        ..invalidate(transactionListProvider(budgetId))
+        ..invalidate(budgetSummaryProvider(budgetId));
+    }
+    return count;
+  }
+
   Future<Transaction> addExpense({
     required String description,
     required int amountCents,

--- a/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/transaction_actions_provider.dart';
 import 'package:openbudget_app/src/features/transactions/screens/edit_transaction_dialog.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
@@ -30,6 +31,8 @@ class TransactionListScreen extends HookConsumerWidget {
     final searchController = useTextEditingController();
     final searchQuery = useState('');
     final filter = useState(TransactionFilter.all);
+    final selectionMode = useState(false);
+    final selectedIds = useState(<String>{});
 
     useEffect(() {
       void listener() => searchQuery.value = searchController.text;
@@ -47,25 +50,70 @@ class TransactionListScreen extends HookConsumerWidget {
         CurrencyCode.usd;
 
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/budgets/$budgetId'),
-        ),
-        title: Text(l10n.transactionListTitle),
-        actions: [
-          transactionsAsync.whenOrNull(
-                data: (txs) => txs.isNotEmpty
-                    ? IconButton(
-                        icon: const Icon(Icons.copy_rounded),
-                        tooltip: l10n.transactionExportCsv,
-                        onPressed: () => _exportToCsv(context, txs, currency),
-                      )
-                    : null,
-              ) ??
-              const SizedBox.shrink(),
-        ],
-      ),
+      appBar: selectionMode.value
+          ? AppBar(
+              leading: IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () {
+                  selectionMode.value = false;
+                  selectedIds.value = {};
+                },
+              ),
+              title: Text(l10n.bulkSelectedCount(selectedIds.value.length)),
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.select_all_rounded),
+                  tooltip: l10n.bulkSelectAll,
+                  onPressed: () {
+                    final allIds =
+                        transactionsAsync.whenOrNull(
+                          data: (txs) => txs
+                              .where((tx) => tx.parentTransactionId == null)
+                              .map((tx) => tx.id?.toString() ?? '')
+                              .where((id) => id.isNotEmpty)
+                              .toSet(),
+                        ) ??
+                        <String>{};
+                    selectedIds.value = allIds;
+                  },
+                ),
+                IconButton(
+                  icon: const Icon(Icons.deselect_rounded),
+                  tooltip: l10n.bulkDeselectAll,
+                  onPressed: () => selectedIds.value = {},
+                ),
+              ],
+            )
+          : AppBar(
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => context.go('/budgets/$budgetId'),
+              ),
+              title: Text(l10n.transactionListTitle),
+              actions: [
+                transactionsAsync.whenOrNull(
+                      data: (txs) => txs.isNotEmpty
+                          ? Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  icon: const Icon(Icons.checklist_rounded),
+                                  tooltip: l10n.bulkAssignEnvelope,
+                                  onPressed: () => selectionMode.value = true,
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.copy_rounded),
+                                  tooltip: l10n.transactionExportCsv,
+                                  onPressed: () =>
+                                      _exportToCsv(context, txs, currency),
+                                ),
+                              ],
+                            )
+                          : null,
+                    ) ??
+                    const SizedBox.shrink(),
+              ],
+            ),
       body: transactionsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, _) => Center(
@@ -221,6 +269,17 @@ class TransactionListScreen extends HookConsumerWidget {
                       childParentIds: childParentIds,
                       budgetId: budgetId,
                       currencyCode: currency,
+                      selectionMode: selectionMode.value,
+                      selectedIds: selectedIds.value,
+                      onToggleSelection: (id) {
+                        final current = Set<String>.of(selectedIds.value);
+                        if (current.contains(id)) {
+                          current.remove(id);
+                        } else {
+                          current.add(id);
+                        }
+                        selectedIds.value = current;
+                      },
                     ),
                   ),
                 ),
@@ -228,7 +287,111 @@ class TransactionListScreen extends HookConsumerWidget {
           );
         },
       ),
+      bottomNavigationBar: selectionMode.value && selectedIds.value.isNotEmpty
+          ? SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(SpacingTokens.md),
+                child: FilledButton.icon(
+                  onPressed: () => _showEnvelopePicker(
+                    context,
+                    ref,
+                    selectedIds.value,
+                    selectionMode,
+                    selectedIds,
+                  ),
+                  icon: const Icon(Icons.mail_outlined),
+                  label: Text(l10n.bulkAssignEnvelope),
+                ),
+              ),
+            )
+          : null,
     );
+  }
+
+  Future<void> _showEnvelopePicker(
+    BuildContext context,
+    WidgetRef ref,
+    Set<String> ids,
+    ValueNotifier<bool> selectionMode,
+    ValueNotifier<Set<String>> selectedIds,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final summaryAsync = ref.read(budgetSummaryProvider(budgetId));
+    if (!summaryAsync.hasValue) return;
+
+    final summary = summaryAsync.value!;
+    final envelopeItems = <(String, String)>[];
+    for (final catEnv in summary.categories) {
+      for (final envelope in catEnv.envelopes) {
+        final id = envelope.id?.toString() ?? '';
+        if (id.isNotEmpty) {
+          envelopeItems.add((id, '${catEnv.category.name} / ${envelope.name}'));
+        }
+      }
+    }
+
+    final selectedEnvelope = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(SpacingTokens.md),
+              child: Text(
+                l10n.bulkSelectEnvelope,
+                style: Theme.of(ctx).textTheme.titleMedium,
+              ),
+            ),
+            const Divider(height: 1),
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: envelopeItems.length,
+                itemBuilder: (ctx, index) {
+                  final (id, label) = envelopeItems[index];
+                  return ListTile(
+                    leading: const Icon(Icons.mail_outlined),
+                    title: Text(label),
+                    onTap: () => Navigator.of(ctx).pop(id),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (selectedEnvelope == null || !context.mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    try {
+      final count = await ref
+          .read(transactionActionsProvider.notifier)
+          .bulkAssignEnvelope(
+            transactionIds: ids.toList(),
+            envelopeId: selectedEnvelope,
+            budgetId: budgetId,
+          );
+      selectionMode.value = false;
+      selectedIds.value = {};
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.bulkAssignSuccess(count))),
+        );
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.bulkAssignError),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      }
+    }
   }
 
   void _exportToCsv(
@@ -324,12 +487,18 @@ class _TransactionTile extends HookConsumerWidget {
     required this.budgetId,
     required this.currencyCode,
     this.isSplit = false,
+    this.selectionMode = false,
+    this.isSelected = false,
+    this.onToggleSelection,
   });
 
   final Transaction transaction;
   final String budgetId;
   final CurrencyCode currencyCode;
   final bool isSplit;
+  final bool selectionMode;
+  final bool isSelected;
+  final VoidCallback? onToggleSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -360,29 +529,25 @@ class _TransactionTile extends HookConsumerWidget {
 
     final flagColor = _flagColorFromString(transaction.flagColor);
 
-    return Dismissible(
-      key: ValueKey(transaction.id),
-      direction: DismissDirection.endToStart,
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: SpacingTokens.lg),
-        margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
-        decoration: BoxDecoration(
-          color: colorScheme.error,
-          borderRadius: BorderRadius.circular(RadiusTokens.md),
-        ),
-        child: Icon(Icons.delete_rounded, color: colorScheme.onError),
-      ),
-      confirmDismiss: (_) => _confirmDelete(context, l10n, colorScheme),
-      onDismissed: (_) => _deleteTransaction(context, ref, l10n, colorScheme),
-      child: Card(
-        margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
-        child: ListTile(
-          onTap: () => _showEditDialog(context),
-          onLongPress: () => _showFlagMenu(context, ref, l10n),
-          leading: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
+    final card = Card(
+      margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
+      color: isSelected ? colorScheme.primaryContainer.withAlpha(80) : null,
+      child: ListTile(
+        onTap: selectionMode
+            ? onToggleSelection
+            : () => _showEditDialog(context),
+        onLongPress: selectionMode
+            ? null
+            : () => _showFlagMenu(context, ref, l10n),
+        leading: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (selectionMode)
+              Checkbox(
+                value: isSelected,
+                onChanged: (_) => onToggleSelection?.call(),
+              )
+            else ...[
               if (flagColor != null)
                 Container(
                   width: 4,
@@ -406,64 +571,81 @@ class _TransactionTile extends HookConsumerWidget {
                   ),
                 ),
               ),
-              const SizedBox(width: SpacingTokens.xs),
-              CircleAvatar(
-                backgroundColor: color.withAlpha(25),
-                child: Icon(icon, color: color, size: 20),
-              ),
             ],
-          ),
-          title: Row(
-            children: [
-              Flexible(
-                child: Text(
-                  transaction.description,
-                  style: theme.textTheme.bodyMedium,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              if (isSplit) ...[
-                const SizedBox(width: SpacingTokens.xs),
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 6,
-                    vertical: 2,
-                  ),
-                  decoration: BoxDecoration(
-                    color: colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  child: Text(
-                    l10n.splitLabel,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: colorScheme.onPrimaryContainer,
-                      fontSize: 10,
-                    ),
-                  ),
-                ),
-              ],
-            ],
-          ),
-          subtitle: transaction.memo != null && transaction.memo!.isNotEmpty
-              ? Text(
-                  transaction.memo!,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                    fontStyle: FontStyle.italic,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                )
-              : null,
-          trailing: Text(
-            formatCents(transaction.amountCents, currencyCode),
-            style: theme.textTheme.titleSmall?.copyWith(
-              color: color,
-              fontWeight: FontWeight.bold,
+            const SizedBox(width: SpacingTokens.xs),
+            CircleAvatar(
+              backgroundColor: color.withAlpha(25),
+              child: Icon(icon, color: color, size: 20),
             ),
+          ],
+        ),
+        title: Row(
+          children: [
+            Flexible(
+              child: Text(
+                transaction.description,
+                style: theme.textTheme.bodyMedium,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (isSplit) ...[
+              const SizedBox(width: SpacingTokens.xs),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  l10n.splitLabel,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onPrimaryContainer,
+                    fontSize: 10,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+        subtitle: transaction.memo != null && transaction.memo!.isNotEmpty
+            ? Text(
+                transaction.memo!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontStyle: FontStyle.italic,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              )
+            : null,
+        trailing: Text(
+          formatCents(transaction.amountCents, currencyCode),
+          style: theme.textTheme.titleSmall?.copyWith(
+            color: color,
+            fontWeight: FontWeight.bold,
           ),
         ),
       ),
+    );
+
+    if (selectionMode) return card;
+
+    return Dismissible(
+      key: ValueKey(transaction.id),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: SpacingTokens.lg),
+        margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
+        decoration: BoxDecoration(
+          color: colorScheme.error,
+          borderRadius: BorderRadius.circular(RadiusTokens.md),
+        ),
+        child: Icon(Icons.delete_rounded, color: colorScheme.onError),
+      ),
+      confirmDismiss: (_) => _confirmDelete(context, l10n, colorScheme),
+      onDismissed: (_) => _deleteTransaction(context, ref, l10n, colorScheme),
+      child: card,
     );
   }
 
@@ -679,12 +861,18 @@ class _GroupedTransactionList extends HookWidget {
     required this.childParentIds,
     required this.budgetId,
     required this.currencyCode,
+    this.selectionMode = false,
+    this.selectedIds = const {},
+    this.onToggleSelection,
   });
 
   final List<Transaction> transactions;
   final Set<String> childParentIds;
   final String budgetId;
   final CurrencyCode currencyCode;
+  final bool selectionMode;
+  final Set<String> selectedIds;
+  final ValueChanged<String>? onToggleSelection;
 
   @override
   Widget build(BuildContext context) {
@@ -717,12 +905,18 @@ class _GroupedTransactionList extends HookWidget {
           return _DateHeader(date: item.date!);
         }
         final tx = item.transaction!;
-        final isSplit = childParentIds.contains(tx.id?.toString());
+        final txId = tx.id?.toString() ?? '';
+        final isSplit = childParentIds.contains(txId);
         return _TransactionTile(
           transaction: tx,
           budgetId: budgetId,
           currencyCode: currencyCode,
           isSplit: isSplit,
+          selectionMode: selectionMode,
+          isSelected: selectedIds.contains(txId),
+          onToggleSelection: txId.isNotEmpty
+              ? () => onToggleSelection?.call(txId)
+              : null,
         );
       },
     );


### PR DESCRIPTION
## Summary
- Adds `bulkAssignEnvelope` method to `TransactionActions` provider for batch envelope assignment
- Adds multi-select mode to transaction list screen with checkbox selection UI
- Selection mode app bar shows count with select all / deselect all actions
- Bottom action bar with "Assign Envelope" button opens envelope picker bottom sheet
- Transactions highlight with primary container color when selected
- Swipe-to-delete is disabled during selection mode to prevent accidental deletions

## Test plan
- [x] Analyze passes with `--fatal-infos`
- [x] All existing tests pass
- [ ] Manually test multi-select mode toggle via checklist icon in app bar
- [ ] Verify select all / deselect all behavior
- [ ] Verify envelope picker bottom sheet shows categories/envelopes
- [ ] Verify bulk assignment updates transactions and shows success snackbar
- [ ] Verify selection mode exits after successful bulk assignment