### PR TITLE
feat: enhance edit transaction dialog with memo, payee, and envelope

### DIFF
--- a/.changeset/enhanced-edit-transaction.md
+++ b/.changeset/enhanced-edit-transaction.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Enhanced transaction editing
+
+The Edit Transaction dialog now supports editing memo, payee, and envelope fields in addition to description, amount, and date. The update provider also supports changing a transaction's payee.

--- a/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
@@ -56,6 +56,7 @@ class TransactionActions extends _$TransactionActions {
     String? description,
     int? amountCents,
     String? envelopeId,
+    String? payeeId,
     DateTime? transactionDate,
     String? memo,
   }) async {
@@ -72,6 +73,11 @@ class TransactionActions extends _$TransactionActions {
             // Serverpod API requires UuidValue which is experimental in uuid package.
             // ignore: experimental_member_use
             ? UuidValue.fromString(envelopeId)
+            : null,
+        payeeId: payeeId != null
+            // Serverpod API requires UuidValue which is experimental in uuid package.
+            // ignore: experimental_member_use
+            ? UuidValue.fromString(payeeId)
             : null,
         transactionDate: transactionDate,
         memo: memo,

--- a/openbudget_app/lib/src/features/transactions/screens/edit_transaction_dialog.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/edit_transaction_dialog.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/transaction_actions_provider.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
@@ -31,9 +33,54 @@ class EditTransactionDialog extends HookConsumerWidget {
       text: (transaction.amountCents.abs() / _pow10(currencyCode.decimals))
           .toStringAsFixed(currencyCode.decimals),
     );
+    final memoController = useTextEditingController(
+      text: transaction.memo ?? '',
+    );
     final selectedDate = useState(transaction.transactionDate);
+    final selectedPayeeId = useState<String?>(transaction.payeeId?.toString());
+    final selectedEnvelopeId = useState<String?>(
+      transaction.envelopeId?.toString(),
+    );
     final isSubmitting = useState(false);
     final isIncome = transaction.amountCents > 0;
+
+    final payeesAsync = ref.watch(payeeListProvider(budgetId));
+    final summaryAsync = ref.watch(budgetSummaryProvider(budgetId));
+
+    // Build payee dropdown items.
+    final payeeItems = <DropdownMenuItem<String>>[
+      DropdownMenuItem<String>(value: '', child: Text(l10n.payeeNone)),
+    ];
+    if (payeesAsync.hasValue) {
+      for (final payee in payeesAsync.value!) {
+        payeeItems.add(
+          DropdownMenuItem<String>(
+            value: payee.id?.toString() ?? '',
+            child: Text(payee.name),
+          ),
+        );
+      }
+    }
+
+    // Build envelope dropdown items.
+    final envelopeItems = <DropdownMenuItem<String>>[
+      DropdownMenuItem<String>(
+        value: '',
+        child: Text(l10n.transactionUnassigned),
+      ),
+    ];
+    if (summaryAsync.hasValue) {
+      for (final catEnv in summaryAsync.value!.categories) {
+        for (final envelope in catEnv.envelopes) {
+          envelopeItems.add(
+            DropdownMenuItem<String>(
+              value: envelope.id?.toString() ?? '',
+              child: Text('${catEnv.category.name} / ${envelope.name}'),
+            ),
+          );
+        }
+      }
+    }
 
     return AlertDialog(
       title: Text(l10n.transactionEditTitle),
@@ -59,7 +106,7 @@ class EditTransactionDialog extends HookConsumerWidget {
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
               ),
-              textInputAction: TextInputAction.done,
+              textInputAction: TextInputAction.next,
             ),
             const SizedBox(height: SpacingTokens.md),
             ListTile(
@@ -82,6 +129,47 @@ class EditTransactionDialog extends HookConsumerWidget {
                 }
               },
             ),
+            const SizedBox(height: SpacingTokens.md),
+            DropdownButtonFormField<String>(
+              initialValue: selectedPayeeId.value ?? '',
+              items: payeeItems,
+              onChanged: (value) {
+                selectedPayeeId.value = (value != null && value.isNotEmpty)
+                    ? value
+                    : null;
+              },
+              decoration: InputDecoration(
+                labelText: l10n.payeeLabel,
+                prefixIcon: const Icon(Icons.person_outlined),
+              ),
+            ),
+            if (!isIncome) ...[
+              const SizedBox(height: SpacingTokens.md),
+              DropdownButtonFormField<String>(
+                initialValue: selectedEnvelopeId.value ?? '',
+                items: envelopeItems,
+                onChanged: (value) {
+                  selectedEnvelopeId.value = (value != null && value.isNotEmpty)
+                      ? value
+                      : null;
+                },
+                decoration: InputDecoration(
+                  labelText: l10n.splitEnvelopeLabel,
+                  prefixIcon: const Icon(Icons.mail_outlined),
+                ),
+              ),
+            ],
+            const SizedBox(height: SpacingTokens.md),
+            TextField(
+              controller: memoController,
+              decoration: InputDecoration(
+                labelText: l10n.transactionMemoLabel,
+                hintText: l10n.transactionMemoHint,
+                prefixIcon: const Icon(Icons.notes_rounded),
+              ),
+              maxLines: 2,
+              textInputAction: TextInputAction.done,
+            ),
           ],
         ),
       ),
@@ -102,6 +190,7 @@ class EditTransactionDialog extends HookConsumerWidget {
                   final amountCents = (amount * _pow10(currencyCode.decimals))
                       .round();
                   final signedAmount = isIncome ? amountCents : -amountCents;
+                  final memo = memoController.text.trim();
 
                   isSubmitting.value = true;
                   final navigator = Navigator.of(context);
@@ -115,6 +204,9 @@ class EditTransactionDialog extends HookConsumerWidget {
                           description: description,
                           amountCents: signedAmount,
                           transactionDate: selectedDate.value,
+                          payeeId: selectedPayeeId.value,
+                          envelopeId: selectedEnvelopeId.value,
+                          memo: memo.isNotEmpty ? memo : null,
                         );
                     messenger.showSnackBar(
                       SnackBar(content: Text(l10n.transactionEditSuccess)),


### PR DESCRIPTION
## Summary
- Added memo text field to edit transaction dialog (was previously missing)
- Added payee dropdown to edit transaction dialog
- Added envelope dropdown for expense transactions in edit dialog
- Added `payeeId` parameter to `updateTransaction` provider method
- Envelope dropdown only shown for expense transactions (not income)

## Test plan
- [ ] Edit a transaction and verify memo field is pre-populated
- [ ] Change the memo and save, verify it persists
- [ ] Change the payee via dropdown and save, verify it persists
- [ ] Change the envelope via dropdown (expense only) and save, verify it persists
- [ ] Edit an income transaction and verify envelope dropdown is hidden
- [ ] Clear memo field and save, verify it is cleared