### PR TITLE
feat: add transfer button to budget detail bottom bar

### DIFF
--- a/.changeset/budget-transfer-button.md
+++ b/.changeset/budget-transfer-button.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Budget transfer button
+
+Added a Transfer button to the budget detail bottom action bar, providing quick access to create account-to-account transfers without navigating away from the budget view.

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -527,6 +527,13 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   ),
                   const SizedBox(width: SpacingTokens.sm),
                   IconButton.filled(
+                    onPressed: () =>
+                        context.go('/budgets/$budgetId/transfers/create'),
+                    icon: const Icon(Icons.sync_alt_rounded),
+                    tooltip: l10n.transferTitle,
+                  ),
+                  const SizedBox(width: SpacingTokens.sm),
+                  IconButton.filled(
                     onPressed: () => _showMoveMoneyDialog(
                       context,
                       summary.categories,


### PR DESCRIPTION
## Summary
- Added a Transfer (sync_alt) icon button to the budget detail bottom action bar
- Navigates to the create transfer screen at `/budgets/{id}/transfers/create`
- Provides quick access to account-to-account transfers directly from the budget view

## Test plan
- [ ] Open a budget detail screen
- [ ] Verify the transfer button appears in the bottom action bar (sync icon)
- [ ] Tap the button and verify it navigates to the create transfer screen
- [ ] Verify the bottom bar doesn't overflow with the additional button