### PR TITLE
feat: add net worth summary card to home screen

### DIFF
--- a/.changeset/home-net-worth-summary.md
+++ b/.changeset/home-net-worth-summary.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Home net worth summary
+
+The home screen now displays a net worth summary card at the top showing the combined balance across all active accounts from all budgets, with account count and color-coded positive/negative amounts.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -84,6 +84,13 @@
       }
     }
   },
+  "@homeNetWorthAccounts": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@homeBudgetCount": {
     "placeholders": {
       "count": {
@@ -376,6 +383,8 @@
   "homeCreateBudget": "Create Your First Budget",
   "homeLoadError": "Could not load budgets",
   "homeLogout": "Sign Out",
+  "homeNetWorthLabel": "Net Worth",
+  "homeNetWorthAccounts": "{count, plural, =1{1 account} other{{count} accounts}}",
   "homeNoBudgets": "No Budgets Yet",
   "homeRetry": "Retry",
   "importButton": "{count, plural, =1{Import 1 Transaction} other{Import {count} Transactions}}",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1198,6 +1198,18 @@ abstract class AppLocalizations {
   /// **'Sign Out'**
   String get homeLogout;
 
+  /// No description provided for @homeNetWorthLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Net Worth'**
+  String get homeNetWorthLabel;
+
+  /// No description provided for @homeNetWorthAccounts.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 account} other{{count} accounts}}'**
+  String homeNetWorthAccounts(int count);
+
   /// No description provided for @homeNoBudgets.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -666,6 +666,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeLogout => 'Sign Out';
 
   @override
+  String get homeNetWorthLabel => 'Net Worth';
+
+  @override
+  String homeNetWorthAccounts(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count accounts',
+      one: '1 account',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get homeNoBudgets => 'No Budgets Yet';
 
   @override

--- a/openbudget_app/lib/src/features/home/screens/home_screen.dart
+++ b/openbudget_app/lib/src/features/home/screens/home_screen.dart
@@ -93,24 +93,30 @@ class HomeScreen extends HookConsumerWidget {
 
           return RefreshIndicator(
             onRefresh: () async => ref.invalidate(budgetListProvider),
-            child: ListView.builder(
+            child: ListView(
               padding: const EdgeInsets.all(SpacingTokens.md),
-              itemCount: budgetList.length,
-              itemBuilder: (context, index) {
-                final budget = budgetList[index];
-                return _BudgetCard(
-                  budgetId: budget.id?.toString() ?? '',
-                  budgetName: budget.name,
-                  currencyCode: budget.currencyCode,
-                  onTap: () => context.go('/budgets/${budget.id}'),
-                  onLongPress: () => _confirmDeleteBudget(
-                    context,
-                    ref,
-                    budget.id?.toString() ?? '',
-                    budget.name,
+              children: [
+                _NetWorthSummary(
+                  budgetIds: budgetList
+                      .map((b) => b.id?.toString() ?? '')
+                      .where((id) => id.isNotEmpty)
+                      .toList(),
+                ),
+                const SizedBox(height: SpacingTokens.md),
+                for (final budget in budgetList)
+                  _BudgetCard(
+                    budgetId: budget.id?.toString() ?? '',
+                    budgetName: budget.name,
+                    currencyCode: budget.currencyCode,
+                    onTap: () => context.go('/budgets/${budget.id}'),
+                    onLongPress: () => _confirmDeleteBudget(
+                      context,
+                      ref,
+                      budget.id?.toString() ?? '',
+                      budget.name,
+                    ),
                   ),
-                );
-              },
+              ],
             ),
           );
         },
@@ -293,6 +299,98 @@ class _BudgetCard extends HookConsumerWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _NetWorthSummary extends HookConsumerWidget {
+  const _NetWorthSummary({required this.budgetIds});
+
+  final List<String> budgetIds;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    var totalBalanceCents = 0;
+    var totalAccounts = 0;
+    var loaded = false;
+
+    for (final budgetId in budgetIds) {
+      final accountsAsync = ref.watch(accountListProvider(budgetId));
+      if (accountsAsync.hasValue) {
+        loaded = true;
+        final active = accountsAsync.value!.where((a) => !a.isClosed);
+        for (final account in active) {
+          totalBalanceCents += account.balanceCents;
+          totalAccounts++;
+        }
+      }
+    }
+
+    if (!loaded) return const SizedBox.shrink();
+
+    final isPositive = totalBalanceCents >= 0;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(SpacingTokens.md),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: isPositive
+              ? [
+                  ColorTokens.primary.withAlpha(15),
+                  ColorTokens.secondary.withAlpha(15),
+                ]
+              : [
+                  ColorTokens.error.withAlpha(15),
+                  ColorTokens.error.withAlpha(8),
+                ],
+        ),
+        borderRadius: BorderRadius.circular(RadiusTokens.md),
+        border: Border.all(
+          color: isPositive
+              ? ColorTokens.primary.withAlpha(40)
+              : ColorTokens.error.withAlpha(40),
+        ),
+      ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.account_balance_wallet_rounded,
+                size: 18,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: SpacingTokens.xs),
+              Text(
+                l10n.homeNetWorthLabel,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                l10n.homeNetWorthAccounts(totalAccounts),
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: SpacingTokens.xs),
+          Text(
+            formatCents(totalBalanceCents, CurrencyCode.usd),
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: isPositive ? ColorTokens.secondary : ColorTokens.error,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Added a net worth summary card at the top of the home screen budget list
- Shows combined balance across all active accounts from all budgets
- Displays total account count
- Color-coded: green gradient for positive net worth, red for negative
- Only appears once account data has loaded

## Test plan
- [ ] Open the home screen with one or more budgets containing accounts
- [ ] Verify the net worth card appears at the top showing total balance
- [ ] Verify the account count is correct
- [ ] Verify positive balances show green, negative show red
- [ ] Verify the card doesn't appear when accounts haven't loaded yet