### PR TITLE
feat: add spending progress bar to envelope rows without goals

### DIFF
--- a/.changeset/envelope-spending-progress.md
+++ b/.changeset/envelope-spending-progress.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Envelope spending progress bar
+
+Envelope rows without goals now display a spending progress bar showing how much of the budgeted amount has been spent, with color-coded indicators (green under 80%, yellow 80-100%, red over budget).

--- a/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
@@ -138,9 +138,56 @@ class EnvelopeRow extends HookConsumerWidget {
                 goal: goal!,
                 budgetedCents: budgeted,
                 availableCents: available,
-              ),
+              )
+            else if (budgeted > 0)
+              _SpendingProgressBar(budgetedCents: budgeted, spentCents: spent),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _SpendingProgressBar extends HookWidget {
+  const _SpendingProgressBar({
+    required this.budgetedCents,
+    required this.spentCents,
+  });
+
+  final int budgetedCents;
+  final int spentCents;
+
+  @override
+  Widget build(BuildContext context) {
+    final ratio = budgetedCents > 0 ? spentCents / budgetedCents : 0.0;
+    final clampedRatio = ratio.clamp(0.0, 1.0);
+
+    final Color barColor;
+    if (ratio > 1.0) {
+      barColor = ColorTokens.error;
+    } else if (ratio >= 0.8) {
+      barColor = ColorTokens.tertiary;
+    } else {
+      barColor = ColorTokens.secondary;
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        children: [
+          const SizedBox(width: SpacingTokens.xs),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                value: clampedRatio,
+                minHeight: 3,
+                backgroundColor: barColor.withAlpha(30),
+                valueColor: AlwaysStoppedAnimation<Color>(barColor),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Add a spending progress bar to envelope rows that have a budget allocation but no goal
- Progress bar shows spent vs budgeted ratio with color coding: green (<80%), yellow (80-100%), red (over budget)
- Envelopes with goals continue to show the existing goal progress bar
- Every budgeted envelope now has visual feedback on spending

## Test plan
- [ ] Verify envelopes with goals still show the goal progress bar (no change)
- [ ] Verify envelopes without goals but with budget allocation show the spending progress bar
- [ ] Verify progress bar is green when spending is under 80% of budget
- [ ] Verify progress bar is yellow when spending is 80-100% of budget
- [ ] Verify progress bar is red when spending exceeds budget
- [ ] Verify envelopes with zero budget allocation show no progress bar