### PR TITLE
feat: show ready-to-assign and overspent count on home budget cards

### DIFF
--- a/.changeset/home-budget-insights.md
+++ b/.changeset/home-budget-insights.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Home budget insights
+
+Budget cards on the home screen now display the "Ready to Assign" amount and an overspent envelope count, giving users a quick overview of each budget's health without navigating into the budget detail.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -379,6 +379,22 @@
   "goalTypeMonthly": "Monthly",
   "homeBudgetAccounts": "{count, plural, =1{1 account} other{{count} accounts}}",
   "homeBudgetCount": "{count, plural, =1{1 budget} other{{count} budgets}}",
+  "homeBudgetOverspent": "{count, plural, =1{1 overspent} other{{count} overspent}}",
+  "@homeBudgetOverspent": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homeBudgetReadyToAssign": "{amount} to assign",
+  "@homeBudgetReadyToAssign": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
   "homeBudgetTotalBalance": "Total Balance",
   "homeCreateBudget": "Create Your First Budget",
   "homeLoadError": "Could not load budgets",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1174,6 +1174,18 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 budget} other{{count} budgets}}'**
   String homeBudgetCount(int count);
 
+  /// No description provided for @homeBudgetOverspent.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 overspent} other{{count} overspent}}'**
+  String homeBudgetOverspent(int count);
+
+  /// No description provided for @homeBudgetReadyToAssign.
+  ///
+  /// In en, this message translates to:
+  /// **'{amount} to assign'**
+  String homeBudgetReadyToAssign(String amount);
+
   /// No description provided for @homeBudgetTotalBalance.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -654,6 +654,22 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String homeBudgetOverspent(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count overspent',
+      one: '1 overspent',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String homeBudgetReadyToAssign(String amount) {
+    return '$amount to assign';
+  }
+
+  @override
   String get homeBudgetTotalBalance => 'Total Balance';
 
   @override

--- a/openbudget_app/lib/src/features/home/screens/home_screen.dart
+++ b/openbudget_app/lib/src/features/home/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
 import 'package:openbudget_app/src/features/auth/providers/auth_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/features/home/providers/budget_actions_provider.dart';
 import 'package:openbudget_app/src/features/home/providers/budget_list_provider.dart';
 import 'package:openbudget_app/src/routing/route_names.dart';
@@ -208,6 +209,7 @@ class _BudgetCard extends HookConsumerWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final accountsAsync = ref.watch(accountListProvider(budgetId));
+    final summaryAsync = ref.watch(budgetSummaryProvider(budgetId));
 
     final currency = CurrencyCode.values.firstWhere(
       (c) => c.code == currencyCode,
@@ -290,6 +292,79 @@ class _BudgetCard extends HookConsumerWidget {
                                     : ColorTokens.error,
                               ),
                             ),
+                          ],
+                        ),
+                      );
+                    },
+                  ) ??
+                  const SizedBox.shrink(),
+              summaryAsync.whenOrNull(
+                    data: (summary) {
+                      final readyToAssign = summary.readyToAssignCents;
+                      var overspentCount = 0;
+                      for (final cat in summary.categories) {
+                        for (final env in cat.envelopes) {
+                          final idx = cat.envelopes.indexOf(env);
+                          final available = idx < cat.monthlyEnvelopes.length
+                              ? cat.monthlyEnvelopes[idx].availableCents
+                              : (env.budgetedAmountCents -
+                                    env.spentAmountCents);
+                          if (available < 0) overspentCount++;
+                        }
+                      }
+
+                      return Padding(
+                        padding: const EdgeInsets.only(top: SpacingTokens.sm),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    Icons.assignment_rounded,
+                                    size: 14,
+                                    color: readyToAssign > 0
+                                        ? ColorTokens.secondary
+                                        : readyToAssign < 0
+                                        ? ColorTokens.error
+                                        : colorScheme.onSurfaceVariant,
+                                  ),
+                                  const SizedBox(width: SpacingTokens.xs),
+                                  Text(
+                                    l10n.homeBudgetReadyToAssign(
+                                      formatCents(readyToAssign, currency),
+                                    ),
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: readyToAssign > 0
+                                          ? ColorTokens.secondary
+                                          : readyToAssign < 0
+                                          ? ColorTokens.error
+                                          : colorScheme.onSurfaceVariant,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            if (overspentCount > 0)
+                              Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(
+                                    Icons.warning_amber_rounded,
+                                    size: 14,
+                                    color: ColorTokens.error,
+                                  ),
+                                  const SizedBox(width: 2),
+                                  Text(
+                                    l10n.homeBudgetOverspent(overspentCount),
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: ColorTokens.error,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                ],
+                              ),
                           ],
                         ),
                       );


### PR DESCRIPTION
## Summary
- Budget cards on the home screen now display the "Ready to Assign" amount with color coding (green positive, red negative)
- Shows an overspent envelope count warning indicator when any envelopes have negative available balance
- Uses the existing `budgetSummaryProvider` to fetch summary data without additional server calls
- Adds l10n strings for ready-to-assign display and overspent count

## Test plan
- [ ] Verify budget cards show "Ready to Assign" amount below the account summary
- [ ] Verify amount is green when positive, red when negative, neutral when zero
- [ ] Verify overspent count shows when there are overspent envelopes
- [ ] Verify no overspent indicator when all envelopes are at or above zero
- [ ] Verify the card still loads correctly when budget summary is loading