### PR TITLE
feat: add carryover indicator to envelope rows

### DIFF
--- a/.changeset/envelope-carryover-indicator.md
+++ b/.changeset/envelope-carryover-indicator.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Envelope carryover indicator
+
+Envelope rows now display a small arrow icon next to the name when there is carryover from the previous month, with a tooltip showing the carried-over amount. A forward arrow indicates positive carryover and a back arrow indicates negative carryover.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -360,6 +360,14 @@
   "editEnvelopeSaved": "Envelope updated",
   "editEnvelopeTitle": "Edit Envelope",
   "envelopeActivityTitle": "Activity",
+  "envelopeCarryover": "Carried over: {amount}",
+  "@envelopeCarryover": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
   "envelopeNoActivity": "No transactions this month",
   "envelopeNoteHint": "Add a note for this envelope (optional)",
   "envelopeNoteLabel": "Note",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1060,6 +1060,12 @@ abstract class AppLocalizations {
   /// **'Activity'**
   String get envelopeActivityTitle;
 
+  /// No description provided for @envelopeCarryover.
+  ///
+  /// In en, this message translates to:
+  /// **'Carried over: {amount}'**
+  String envelopeCarryover(String amount);
+
   /// No description provided for @envelopeNoActivity.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -580,6 +580,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get envelopeActivityTitle => 'Activity';
 
   @override
+  String envelopeCarryover(String amount) {
+    return 'Carried over: $amount';
+  }
+
+  @override
   String get envelopeNoActivity => 'No transactions this month';
 
   @override

--- a/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_goals_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
@@ -30,10 +31,12 @@ class EnvelopeRow extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
     final budgeted =
         monthlyData?.allocatedCents ?? envelope.budgetedAmountCents;
     final spent = monthlyData?.spentCents ?? envelope.spentAmountCents;
     final available = monthlyData?.availableCents ?? (budgeted - spent);
+    final carryover = monthlyData?.carryoverCents ?? 0;
     final availableColor = available > 0
         ? ColorTokens.secondary
         : available < 0
@@ -70,10 +73,36 @@ class EnvelopeRow extends HookConsumerWidget {
                   const SizedBox(width: SpacingTokens.xs),
                 Expanded(
                   flex: 4,
-                  child: Text(
-                    envelope.name,
-                    style: theme.textTheme.bodyMedium,
-                    overflow: TextOverflow.ellipsis,
+                  child: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          envelope.name,
+                          style: theme.textTheme.bodyMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      if (carryover != 0)
+                        Tooltip(
+                          message: l10n.envelopeCarryover(
+                            formatCents(carryover, currencyCode),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              left: SpacingTokens.xs,
+                            ),
+                            child: Icon(
+                              carryover > 0
+                                  ? Icons.arrow_forward_rounded
+                                  : Icons.arrow_back_rounded,
+                              size: 12,
+                              color: carryover > 0
+                                  ? ColorTokens.secondary
+                                  : ColorTokens.error,
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
                 ),
                 Expanded(


### PR DESCRIPTION
## Summary
- Envelope rows now display a small arrow icon next to the name when there is non-zero carryover from the previous month
- Forward arrow (green) for positive carryover, back arrow (red) for negative carryover
- Tooltip shows the exact carried-over amount on hover/long press
- Adds localized `envelopeCarryover` string for the tooltip text

## Test plan
- [ ] Verify envelopes with positive carryover show a green forward arrow icon
- [ ] Verify envelopes with negative carryover show a red back arrow icon
- [ ] Verify envelopes with zero carryover show no arrow
- [ ] Verify tooltip displays the correct carried-over amount
- [ ] Verify envelope name still truncates properly with ellipsis when long