### PR TITLE
fix: use localized strings for account type labels

### DIFF
--- a/.changeset/localize-account-types.md
+++ b/.changeset/localize-account-types.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Localize account type labels
+
+Account type labels in the account list screen now use localized strings from `AppLocalizations` instead of hardcoded English text, ensuring consistency with the add account screen and supporting future translations.

--- a/openbudget_app/lib/src/features/accounts/screens/account_list_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/account_list_screen.dart
@@ -267,7 +267,7 @@ class _AccountTile extends HookWidget {
           ],
         ),
         subtitle: Text(
-          _labelForType(account.accountType),
+          _labelForType(account.accountType, AppLocalizations.of(context)),
           style: theme.textTheme.bodySmall?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),
@@ -309,20 +309,13 @@ class _AccountTile extends HookWidget {
     }
   }
 
-  static String _labelForType(String type) {
-    switch (type) {
-      case 'checking':
-        return 'Checking';
-      case 'savings':
-        return 'Savings';
-      case 'creditCard':
-        return 'Credit Card';
-      case 'cash':
-        return 'Cash';
-      case 'investment':
-        return 'Investment';
-      default:
-        return 'Other';
-    }
-  }
+  static String _labelForType(String type, AppLocalizations l10n) =>
+      switch (type) {
+        'checking' => l10n.accountTypeChecking,
+        'savings' => l10n.accountTypeSavings,
+        'creditCard' => l10n.accountTypeCreditCard,
+        'cash' => l10n.accountTypeCash,
+        'investment' => l10n.accountTypeInvestment,
+        _ => l10n.accountTypeOther,
+      };
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded English account type labels ('Checking', 'Savings', etc.) in the account list screen with existing `AppLocalizations` strings
- The add account screen already used these l10n strings; this ensures consistency
- Converts `_labelForType` from switch/case to switch expression pattern matching

## Test plan
- [ ] Verify account list screen still shows correct type labels for all account types
- [ ] Verify labels match those shown in the add account screen