### PR TITLE
feat: show envelope note preview in budget rows

### DIFF
--- a/.changeset/envelope-note-preview.md
+++ b/.changeset/envelope-note-preview.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Envelope note preview
+
+Envelope rows now display a small note icon and italic text preview below the envelope name when a note has been set, giving users quick visibility into their envelope notes without opening the detail view.

--- a/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
@@ -73,34 +73,62 @@ class EnvelopeRow extends HookConsumerWidget {
                   const SizedBox(width: SpacingTokens.xs),
                 Expanded(
                   flex: 4,
-                  child: Row(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      Flexible(
-                        child: Text(
-                          envelope.name,
-                          style: theme.textTheme.bodyMedium,
-                          overflow: TextOverflow.ellipsis,
-                        ),
+                      Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              envelope.name,
+                              style: theme.textTheme.bodyMedium,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (carryover != 0)
+                            Tooltip(
+                              message: l10n.envelopeCarryover(
+                                formatCents(carryover, currencyCode),
+                              ),
+                              child: Padding(
+                                padding: const EdgeInsets.only(
+                                  left: SpacingTokens.xs,
+                                ),
+                                child: Icon(
+                                  carryover > 0
+                                      ? Icons.arrow_forward_rounded
+                                      : Icons.arrow_back_rounded,
+                                  size: 12,
+                                  color: carryover > 0
+                                      ? ColorTokens.secondary
+                                      : ColorTokens.error,
+                                ),
+                              ),
+                            ),
+                        ],
                       ),
-                      if (carryover != 0)
-                        Tooltip(
-                          message: l10n.envelopeCarryover(
-                            formatCents(carryover, currencyCode),
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: SpacingTokens.xs,
+                      if (envelope.note != null && envelope.note!.isNotEmpty)
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.sticky_note_2_outlined,
+                              size: 10,
+                              color: theme.colorScheme.onSurfaceVariant,
                             ),
-                            child: Icon(
-                              carryover > 0
-                                  ? Icons.arrow_forward_rounded
-                                  : Icons.arrow_back_rounded,
-                              size: 12,
-                              color: carryover > 0
-                                  ? ColorTokens.secondary
-                                  : ColorTokens.error,
+                            const SizedBox(width: 2),
+                            Flexible(
+                              child: Text(
+                                envelope.note!,
+                                style: theme.textTheme.labelSmall?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                  fontStyle: FontStyle.italic,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
                             ),
-                          ),
+                          ],
                         ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- Envelope rows now display a small note icon and italic text preview below the envelope name when a note has been set
- Gives users quick visibility into their envelope notes without opening the detail view
- Note preview is single-line with ellipsis overflow for long notes

## Test plan
- [ ] Verify envelopes with notes show the sticky note icon and italic preview text
- [ ] Verify envelopes without notes show only the name (no extra row)
- [ ] Verify long notes are truncated with ellipsis
- [ ] Verify the note preview does not affect row layout or alignment