### PR TITLE
feat: show underfunded amount text on envelope rows

### DIFF
--- a/.changeset/underfunded-amount-text.md
+++ b/.changeset/underfunded-amount-text.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Underfunded amount text on envelope rows
+
+Envelope rows with goals now display the underfunded amount as text (e.g., "$150.00 needed") alongside the warning icon on the goal progress bar, giving users immediate visibility into how much more they need to assign without opening the activity sheet.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -377,6 +377,14 @@
   "envelopeNoteHint": "Add a note for this envelope (optional)",
   "envelopeNoteLabel": "Note",
   "envelopeReorderHint": "Long press an envelope to reorder within category",
+  "envelopeUnderfunded": "{amount} needed",
+  "@envelopeUnderfunded": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
   "goalAmountLabel": "Target Amount",
   "goalDateLabel": "Target Date",
   "goalDateSelect": "Select a date",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1120,6 +1120,12 @@ abstract class AppLocalizations {
   /// **'Long press an envelope to reorder within category'**
   String get envelopeReorderHint;
 
+  /// No description provided for @envelopeUnderfunded.
+  ///
+  /// In en, this message translates to:
+  /// **'{amount} needed'**
+  String envelopeUnderfunded(String amount);
+
   /// No description provided for @goalAmountLabel.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -613,6 +613,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'Long press an envelope to reorder within category';
 
   @override
+  String envelopeUnderfunded(String amount) {
+    return '$amount needed';
+  }
+
+  @override
   String get goalAmountLabel => 'Target Amount';
 
   @override

--- a/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/envelope_row.dart
@@ -195,6 +195,7 @@ class EnvelopeRow extends HookConsumerWidget {
                 goal: goal!,
                 budgetedCents: budgeted,
                 availableCents: available,
+                currencyCode: currencyCode,
               )
             else if (budgeted > 0)
               _SpendingProgressBar(budgetedCents: budgeted, spentCents: spent),
@@ -255,14 +256,18 @@ class _GoalProgressBar extends HookWidget {
     required this.goal,
     required this.budgetedCents,
     required this.availableCents,
+    required this.currencyCode,
   });
 
   final EnvelopeGoal goal;
   final int budgetedCents;
   final int availableCents;
+  final CurrencyCode currencyCode;
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
     final progress = computeFundingProgress(
       goal: goal,
       budgetedCents: budgetedCents,
@@ -303,6 +308,14 @@ class _GoalProgressBar extends HookWidget {
           if (underfunded > 0) ...[
             const SizedBox(width: SpacingTokens.xs),
             Icon(Icons.warning_amber_rounded, size: 12, color: barColor),
+            const SizedBox(width: 2),
+            Text(
+              l10n.envelopeUnderfunded(formatCents(underfunded, currencyCode)),
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: barColor,
+                fontSize: 10,
+              ),
+            ),
           ],
         ],
       ),

--- a/openbudget_app/test/features/budget/widgets/envelope_row_test.dart
+++ b/openbudget_app/test/features/budget/widgets/envelope_row_test.dart
@@ -1,0 +1,211 @@
+// UuidValue is needed for constructing test model data.
+// ignore_for_file: experimental_member_use
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/budget/widgets/envelope_row.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  final testCategoryId = UuidValue.fromString(
+    '00000000-0000-0000-0000-000000000001',
+  );
+  final testEnvelopeId = UuidValue.fromString(
+    '00000000-0000-0000-0000-000000000002',
+  );
+
+  Envelope makeEnvelope({
+    String name = 'Groceries',
+    int budgetedAmountCents = 50000,
+    int spentAmountCents = 20000,
+    String? note,
+    bool? isHidden,
+  }) {
+    return Envelope(
+      id: testEnvelopeId,
+      name: name,
+      categoryId: testCategoryId,
+      budgetedAmountCents: budgetedAmountCents,
+      spentAmountCents: spentAmountCents,
+      currencyCode: 'USD',
+      sortOrder: 0,
+      note: note,
+      isHidden: isHidden,
+    );
+  }
+
+  EnvelopeGoal makeGoal({
+    String goalType = 'target_balance',
+    int targetAmountCents = 100000,
+    int? monthlyFundingCents,
+    DateTime? targetDate,
+  }) {
+    return EnvelopeGoal(
+      envelopeId: testEnvelopeId,
+      goalType: goalType,
+      targetAmountCents: targetAmountCents,
+      monthlyFundingCents: monthlyFundingCents,
+      targetDate: targetDate,
+    );
+  }
+
+  Widget buildSubject({
+    required Envelope envelope,
+    CurrencyCode currencyCode = CurrencyCode.usd,
+    MonthlyEnvelopeData? monthlyData,
+    EnvelopeGoal? goal,
+    VoidCallback? onQuickBudget,
+  }) {
+    return ProviderScope(
+      child: MaterialApp(
+        theme: OpenBudgetTheme.light,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: EnvelopeRow(
+            envelope: envelope,
+            currencyCode: currencyCode,
+            onTap: () {},
+            onLongPress: () {},
+            monthlyData: monthlyData,
+            goal: goal,
+            onQuickBudget: onQuickBudget,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('EnvelopeRow', () {
+    testWidgets('renders envelope name and amounts', (tester) async {
+      final envelope = makeEnvelope();
+      await tester.pumpWidget(buildSubject(envelope: envelope));
+      await tester.pump();
+
+      expect(find.text('Groceries'), findsOneWidget);
+    });
+
+    testWidgets('renders note when present', (tester) async {
+      final envelope = makeEnvelope(note: 'Weekly shopping');
+      await tester.pumpWidget(buildSubject(envelope: envelope));
+      await tester.pump();
+
+      expect(find.text('Weekly shopping'), findsOneWidget);
+    });
+
+    testWidgets('does not render note when absent', (tester) async {
+      final envelope = makeEnvelope();
+      await tester.pumpWidget(buildSubject(envelope: envelope));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.sticky_note_2_outlined), findsNothing);
+    });
+
+    testWidgets('renders quick budget button when callback provided', (
+      tester,
+    ) async {
+      final envelope = makeEnvelope();
+      await tester.pumpWidget(
+        buildSubject(envelope: envelope, onQuickBudget: () {}),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.bolt_rounded), findsOneWidget);
+    });
+
+    testWidgets('renders goal progress bar with underfunded text', (
+      tester,
+    ) async {
+      // Envelope with goal target of $1000, but only $300 available
+      final envelope = makeEnvelope(
+        budgetedAmountCents: 30000,
+        spentAmountCents: 0,
+      );
+      final goal = makeGoal();
+
+      await tester.pumpWidget(buildSubject(envelope: envelope, goal: goal));
+      await tester.pump();
+
+      // Should show underfunded text with "needed" label
+      expect(find.textContaining('needed'), findsOneWidget);
+      // Should show warning icon
+      expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+    });
+
+    testWidgets('does not show underfunded text when fully funded', (
+      tester,
+    ) async {
+      // Envelope with goal target of $1000, and $1000 available
+      final envelope = makeEnvelope(
+        budgetedAmountCents: 100000,
+        spentAmountCents: 0,
+      );
+      final goal = makeGoal();
+
+      await tester.pumpWidget(buildSubject(envelope: envelope, goal: goal));
+      await tester.pump();
+
+      // Should not show "needed" text when fully funded
+      expect(find.textContaining('needed'), findsNothing);
+    });
+
+    testWidgets('renders spending progress bar without goal', (tester) async {
+      final envelope = makeEnvelope(spentAmountCents: 25000);
+
+      await tester.pumpWidget(buildSubject(envelope: envelope));
+      await tester.pump();
+
+      // Should render a LinearProgressIndicator (spending bar)
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('renders carryover indicator when present', (tester) async {
+      final envelope = makeEnvelope();
+      final monthlyData = MonthlyEnvelopeData(
+        envelope: envelope,
+        allocatedCents: 50000,
+        spentCents: 20000,
+        availableCents: 30000,
+        carryoverCents: 5000,
+      );
+
+      await tester.pumpWidget(
+        buildSubject(envelope: envelope, monthlyData: monthlyData),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.arrow_forward_rounded), findsOneWidget);
+    });
+
+    testWidgets('renders monthly funding goal underfunded amount', (
+      tester,
+    ) async {
+      // Monthly funding goal: $200/month, but only $50 budgeted
+      final envelope = makeEnvelope(
+        budgetedAmountCents: 5000,
+        spentAmountCents: 0,
+      );
+      final goal = makeGoal(
+        goalType: 'monthly_funding',
+        targetAmountCents: 20000,
+        monthlyFundingCents: 20000,
+      );
+
+      await tester.pumpWidget(buildSubject(envelope: envelope, goal: goal));
+      await tester.pump();
+
+      // Should show underfunded text
+      expect(find.textContaining('needed'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Display underfunded amount text (e.g., "$150.00 needed") next to the warning icon on envelope goal progress bars
- Add `envelopeUnderfunded` l10n string with `{amount}` placeholder
- Add comprehensive widget tests for `EnvelopeRow` (9 test cases)

## Test plan
- [x] Widget tests for envelope name, note, carryover, quick budget button
- [x] Widget tests for underfunded text with target balance goal
- [x] Widget tests for underfunded text with monthly funding goal
- [x] Widget tests for fully funded state (no underfunded text)
- [x] Widget tests for spending progress bar without goals
- [x] `dart analyze` passes with no issues
- [x] `dart format` passes