### PR TITLE
feat: wire up copy last month allocations with confirmation dialog

### DIFF
--- a/.changeset/copy-last-month-allocations.md
+++ b/.changeset/copy-last-month-allocations.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Wire up "Copy Last Month" button in budget detail screen to copy previous month's allocations with confirmation dialog, success/error feedback, and widget tests.

--- a/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_detail_screen.dart
@@ -268,6 +268,13 @@ class BudgetDetailScreen extends HookConsumerWidget {
                   totalIncomeCents: summary.totalIncomeCents,
                   totalBudgetedCents: summary.totalBudgetedCents,
                   totalActivityCents: totalActivityCents,
+                  onCopyLastMonth: () => _confirmCopyLastMonth(
+                    context,
+                    ref,
+                    budgetId,
+                    summary.year,
+                    summary.month,
+                  ),
                 ),
                 const SizedBox(height: SpacingTokens.md),
                 if (dueCountAsync.hasValue && dueCountAsync.value! > 0)
@@ -896,6 +903,60 @@ class BudgetDetailScreen extends HookConsumerWidget {
       }
     } finally {
       isPosting.value = false;
+    }
+  }
+
+  Future<void> _confirmCopyLastMonth(
+    BuildContext context,
+    WidgetRef ref,
+    String budgetId,
+    int year,
+    int month,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.budgetCopyLastMonth),
+        content: Text(l10n.budgetCopyLastMonthConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancel),
+          ),
+          FilledButton.icon(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            icon: const Icon(Icons.content_copy_rounded, size: 16),
+            label: Text(l10n.budgetCopyLastMonth),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    try {
+      await ref
+          .read(monthlyAllocationActionsProvider.notifier)
+          .copyPreviousMonth(
+            budgetId: budgetId,
+            currentYear: year,
+            currentMonth: month,
+          );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.budgetCopyLastMonthSuccess)),
+        );
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.budgetCopyLastMonthError),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
     }
   }
 

--- a/openbudget_app/test/features/budget/screens/budget_detail_screen_test.dart
+++ b/openbudget_app/test/features/budget/screens/budget_detail_screen_test.dart
@@ -1,9 +1,17 @@
+// Serverpod's UuidValue.fromString is marked experimental.
+// ignore_for_file: experimental_member_use
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_goals_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/credit_card_provider.dart';
 import 'package:openbudget_app/src/features/budget/screens/budget_detail_screen.dart';
+import 'package:openbudget_app/src/features/recurring/providers/recurring_auto_post_provider.dart';
+import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
 void main() {
@@ -11,24 +19,156 @@ void main() {
     GoogleFonts.config.allowRuntimeFetching = false;
   });
 
-  Widget buildSubject({String budgetId = 'test-budget-1'}) {
+  const budgetId = 'test-budget-1';
+
+  Budget makeBudget() => Budget(
+    id: UuidValue.fromString('00000000-0000-0000-0000-000000000001'),
+    name: 'My Budget',
+    currencyCode: 'USD',
+    ownerId: UuidValue.fromString('00000000-0000-0000-0000-000000000099'),
+    createdAt: DateTime(2026),
+  );
+
+  BudgetSummary makeSummary({
+    int readyToAssignCents = 50000,
+    int totalIncomeCents = 100000,
+    int totalBudgetedCents = 50000,
+    List<CategoryWithEnvelopes> categories = const [],
+  }) => BudgetSummary(
+    budget: makeBudget(),
+    categories: categories,
+    totalIncomeCents: totalIncomeCents,
+    totalBudgetedCents: totalBudgetedCents,
+    readyToAssignCents: readyToAssignCents,
+    year: 2026,
+    month: 2,
+  );
+
+  Widget buildSubject({BudgetSummary? summary}) {
     return ProviderScope(
+      overrides: [
+        budgetMonthlySummaryProvider.overrideWith(
+          (ref, id) async => summary ?? makeSummary(),
+        ),
+        creditCardPaymentsProvider.overrideWith(
+          (ref, id) async => <CreditCardPaymentInfo>[],
+        ),
+        budgetGoalsProvider.overrideWith(
+          (ref, id) async => <String, EnvelopeGoal>{},
+        ),
+        recurringDueCountProvider.overrideWith((ref, id) async => 0),
+      ],
       child: MaterialApp(
         theme: OpenBudgetTheme.light,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: BudgetDetailScreen(budgetId: budgetId),
+        home: const BudgetDetailScreen(budgetId: budgetId),
       ),
     );
   }
 
   group('BudgetDetailScreen', () {
     testWidgets('renders loading state initially', (tester) async {
-      await tester.pumpWidget(buildSubject());
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: OpenBudgetTheme.light,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const BudgetDetailScreen(budgetId: budgetId),
+          ),
+        ),
+      );
       await tester.pump();
 
-      // Without provider overrides, it shows loading or the app title
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows budget name in app bar when data loads', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('My Budget'), findsOneWidget);
+    });
+
+    testWidgets('shows Copy Last Month button in header', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Copy Last Month'), findsOneWidget);
+    });
+
+    testWidgets('tapping Copy Last Month shows confirmation dialog', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy Last Month'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'Copy all budget allocations from last month to the current '
+          'month? This will overwrite any existing allocations.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Cancel'), findsOneWidget);
+      // Header button + dialog title + dialog confirm button
+      expect(find.text('Copy Last Month'), findsNWidgets(3));
+    });
+
+    testWidgets('dismissing Copy Last Month dialog via Cancel does nothing', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy Last Month'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // Dialog is dismissed, no snackbar
+      expect(
+        find.text(
+          'Copy all budget allocations from last month to the current '
+          'month? This will overwrite any existing allocations.',
+        ),
+        findsNothing,
+      );
+      expect(find.text('Allocations copied from previous month'), findsNothing);
+    });
+
+    testWidgets('shows empty state when no categories', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.category_rounded), findsOneWidget);
+    });
+
+    testWidgets('shows Add Category button', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('Add Category'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(find.text('Add Category'), findsOneWidget);
+    });
+
+    testWidgets('shows bottom navigation bar with action buttons', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add Income'), findsOneWidget);
+      expect(find.text('Add Expense'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Connects the existing `onCopyLastMonth` callback in `BudgetHeader` to `MonthlyAllocationActions.copyPreviousMonth` provider
- Shows a confirmation dialog before copying allocations from the previous month
- Displays success snackbar on completion and error snackbar on failure
- Expands budget detail screen widget tests (8 tests) covering loading, data display, copy last month dialog flow, empty state, and bottom nav bar

## Test plan
- [x] Widget tests pass for budget detail screen (8 tests)
- [x] `dart analyze` clean
- [x] `dart format` clean
- [ ] CI checks pass