### PR TITLE
feat: add bulk transaction operations (flag, delete, mark cleared)

### DIFF
--- a/.changeset/bulk-transaction-operations.md
+++ b/.changeset/bulk-transaction-operations.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add bulk transaction operations: flag, delete, and mark cleared/uncleared in selection mode with confirmation dialogs and success/error feedback.

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -264,6 +264,46 @@
   "bulkDeselectAll": "Deselect All",
   "bulkSelectEnvelope": "Select an envelope to assign",
   "bulkSelectedCount": "{count, plural, =1{1 selected} other{{count} selected}}",
+  "bulkDeleteConfirm": "Delete {count, plural, =1{1 transaction} other{{count} transactions}}? This cannot be undone.",
+  "@bulkDeleteConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bulkDeleteError": "Could not delete transactions. Please try again.",
+  "bulkDeleteSuccess": "{count, plural, =1{1 transaction deleted} other{{count} transactions deleted}}",
+  "@bulkDeleteSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bulkDeleteTitle": "Delete Transactions",
+  "bulkFlagError": "Could not set flags. Please try again.",
+  "bulkFlagSuccess": "{count, plural, =1{1 transaction flagged} other{{count} transactions flagged}}",
+  "@bulkFlagSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bulkSetFlag": "Set Flag",
+  "bulkClearFlag": "Clear Flag",
+  "bulkClearError": "Could not update transactions. Please try again.",
+  "bulkClearSuccess": "{count, plural, =1{1 transaction cleared} other{{count} transactions cleared}}",
+  "@bulkClearSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bulkMarkCleared": "Mark Cleared",
+  "bulkMarkUncleared": "Mark Uncleared",
   "budgetAddCategory": "Add Category",
   "budgetAddEnvelope": "Add Envelope",
   "budgetAddExpense": "Add Expense",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -484,6 +484,78 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 selected} other{{count} selected}}'**
   String bulkSelectedCount(int count);
 
+  /// No description provided for @bulkDeleteConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete {count, plural, =1{1 transaction} other{{count} transactions}}? This cannot be undone.'**
+  String bulkDeleteConfirm(int count);
+
+  /// No description provided for @bulkDeleteError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not delete transactions. Please try again.'**
+  String get bulkDeleteError;
+
+  /// No description provided for @bulkDeleteSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction deleted} other{{count} transactions deleted}}'**
+  String bulkDeleteSuccess(int count);
+
+  /// No description provided for @bulkDeleteTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Transactions'**
+  String get bulkDeleteTitle;
+
+  /// No description provided for @bulkFlagError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not set flags. Please try again.'**
+  String get bulkFlagError;
+
+  /// No description provided for @bulkFlagSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction flagged} other{{count} transactions flagged}}'**
+  String bulkFlagSuccess(int count);
+
+  /// No description provided for @bulkSetFlag.
+  ///
+  /// In en, this message translates to:
+  /// **'Set Flag'**
+  String get bulkSetFlag;
+
+  /// No description provided for @bulkClearFlag.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear Flag'**
+  String get bulkClearFlag;
+
+  /// No description provided for @bulkClearError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update transactions. Please try again.'**
+  String get bulkClearError;
+
+  /// No description provided for @bulkClearSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 transaction cleared} other{{count} transactions cleared}}'**
+  String bulkClearSuccess(int count);
+
+  /// No description provided for @bulkMarkCleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark Cleared'**
+  String get bulkMarkCleared;
+
+  /// No description provided for @bulkMarkUncleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark Uncleared'**
+  String get bulkMarkUncleared;
+
   /// No description provided for @budgetAddCategory.
   ///
   /// In en, this message translates to:

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -249,6 +249,76 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String bulkDeleteConfirm(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions',
+      one: '1 transaction',
+    );
+    return 'Delete $_temp0? This cannot be undone.';
+  }
+
+  @override
+  String get bulkDeleteError =>
+      'Could not delete transactions. Please try again.';
+
+  @override
+  String bulkDeleteSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions deleted',
+      one: '1 transaction deleted',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bulkDeleteTitle => 'Delete Transactions';
+
+  @override
+  String get bulkFlagError => 'Could not set flags. Please try again.';
+
+  @override
+  String bulkFlagSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions flagged',
+      one: '1 transaction flagged',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bulkSetFlag => 'Set Flag';
+
+  @override
+  String get bulkClearFlag => 'Clear Flag';
+
+  @override
+  String get bulkClearError =>
+      'Could not update transactions. Please try again.';
+
+  @override
+  String bulkClearSuccess(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count transactions cleared',
+      one: '1 transaction cleared',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bulkMarkCleared => 'Mark Cleared';
+
+  @override
+  String get bulkMarkUncleared => 'Mark Uncleared';
+
+  @override
   String get budgetAddCategory => 'Add Category';
 
   @override

--- a/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
+++ b/openbudget_app/lib/src/features/transactions/providers/transaction_actions_provider.dart
@@ -240,6 +240,85 @@ class TransactionActions extends _$TransactionActions {
     return count;
   }
 
+  /// Sets or clears flag on multiple transactions at once.
+  Future<int> bulkSetFlag({
+    required List<String> transactionIds,
+    required String budgetId,
+    String? flagColor,
+  }) async {
+    final client = ref.read(serverpodClientProvider);
+    var count = 0;
+    for (final txId in transactionIds) {
+      try {
+        await client.transaction.setFlag(
+          // Serverpod API requires UuidValue which is experimental in uuid package.
+          // ignore: experimental_member_use
+          UuidValue.fromString(txId),
+          flagColor: flagColor,
+        );
+        count++;
+      } on Exception catch (_) {
+        // Continue with other transactions on individual failure.
+      }
+    }
+    if (ref.mounted) {
+      ref.invalidate(transactionListProvider(budgetId));
+    }
+    return count;
+  }
+
+  /// Deletes multiple transactions at once.
+  Future<int> bulkDelete({
+    required List<String> transactionIds,
+    required String budgetId,
+  }) async {
+    final client = ref.read(serverpodClientProvider);
+    var count = 0;
+    for (final txId in transactionIds) {
+      try {
+        await client.transaction.delete(
+          // Serverpod API requires UuidValue which is experimental in uuid package.
+          // ignore: experimental_member_use
+          UuidValue.fromString(txId),
+        );
+        count++;
+      } on Exception catch (_) {
+        // Continue with other transactions on individual failure.
+      }
+    }
+    if (ref.mounted) {
+      ref
+        ..invalidate(transactionListProvider(budgetId))
+        ..invalidate(budgetSummaryProvider(budgetId));
+    }
+    return count;
+  }
+
+  /// Toggles cleared status on multiple transactions at once.
+  Future<int> bulkToggleCleared({
+    required List<String> transactionIds,
+    required String budgetId,
+  }) async {
+    final client = ref.read(serverpodClientProvider);
+    var count = 0;
+    for (final txId in transactionIds) {
+      try {
+        await client.transaction.toggleCleared(
+          // Serverpod API requires UuidValue which is experimental in uuid package.
+          // ignore: experimental_member_use
+          UuidValue.fromString(txId),
+        );
+        count++;
+      } on Exception catch (_) {
+        // Continue with other transactions on individual failure.
+      }
+    }
+    if (ref.mounted) {
+      ref.invalidate(transactionListProvider(budgetId));
+    }
+    return count;
+  }
+
   Future<Transaction> addExpense({
     required String description,
     required int amountCents,

--- a/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
@@ -442,16 +442,63 @@ class TransactionListScreen extends HookConsumerWidget {
           ? SafeArea(
               child: Padding(
                 padding: const EdgeInsets.all(SpacingTokens.md),
-                child: FilledButton.icon(
-                  onPressed: () => _showEnvelopePicker(
-                    context,
-                    ref,
-                    selectedIds.value,
-                    selectionMode,
-                    selectedIds,
-                  ),
-                  icon: const Icon(Icons.mail_outlined),
-                  label: Text(l10n.bulkAssignEnvelope),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: FilledButton.icon(
+                        onPressed: () => _showEnvelopePicker(
+                          context,
+                          ref,
+                          selectedIds.value,
+                          selectionMode,
+                          selectedIds,
+                        ),
+                        icon: const Icon(Icons.mail_outlined, size: 18),
+                        label: Text(l10n.bulkAssignEnvelope),
+                      ),
+                    ),
+                    const SizedBox(width: SpacingTokens.sm),
+                    IconButton.filled(
+                      onPressed: () => _showBulkFlagMenu(
+                        context,
+                        ref,
+                        selectedIds.value,
+                        selectionMode,
+                        selectedIds,
+                      ),
+                      icon: const Icon(Icons.flag_rounded),
+                      tooltip: l10n.bulkSetFlag,
+                    ),
+                    const SizedBox(width: SpacingTokens.sm),
+                    IconButton.filled(
+                      onPressed: () => _bulkMarkCleared(
+                        context,
+                        ref,
+                        transactionsAsync,
+                        selectedIds.value,
+                        selectionMode,
+                        selectedIds,
+                      ),
+                      icon: const Icon(Icons.check_circle_outline),
+                      tooltip: l10n.bulkMarkCleared,
+                    ),
+                    const SizedBox(width: SpacingTokens.sm),
+                    IconButton.filled(
+                      onPressed: () => _confirmBulkDelete(
+                        context,
+                        ref,
+                        selectedIds.value,
+                        selectionMode,
+                        selectedIds,
+                      ),
+                      icon: const Icon(Icons.delete_outline_rounded),
+                      tooltip: l10n.bulkDeleteTitle,
+                      style: IconButton.styleFrom(
+                        backgroundColor: colorScheme.error,
+                        foregroundColor: colorScheme.onError,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             )
@@ -538,6 +585,251 @@ class TransactionListScreen extends HookConsumerWidget {
         messenger.showSnackBar(
           SnackBar(
             content: Text(l10n.bulkAssignError),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  void _showBulkFlagMenu(
+    BuildContext context,
+    WidgetRef ref,
+    Set<String> ids,
+    ValueNotifier<bool> selectionMode,
+    ValueNotifier<Set<String>> selectedIds,
+  ) {
+    final l10n = AppLocalizations.of(context);
+    final flags = <(String, String, Color)>[
+      ('red', l10n.transactionFlagRed, Colors.red),
+      ('orange', l10n.transactionFlagOrange, Colors.orange),
+      ('yellow', l10n.transactionFlagYellow, Colors.amber),
+      ('green', l10n.transactionFlagGreen, Colors.green),
+      ('blue', l10n.transactionFlagBlue, Colors.blue),
+      ('purple', l10n.transactionFlagPurple, Colors.purple),
+    ];
+
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(SpacingTokens.md),
+              child: Text(
+                l10n.bulkSetFlag,
+                style: Theme.of(ctx).textTheme.titleMedium,
+              ),
+            ),
+            Wrap(
+              spacing: SpacingTokens.md,
+              runSpacing: SpacingTokens.sm,
+              alignment: WrapAlignment.center,
+              children: [
+                for (final (value, label, color) in flags)
+                  ActionChip(
+                    avatar: Icon(Icons.flag_rounded, color: color, size: 18),
+                    label: Text(label),
+                    onPressed: () {
+                      Navigator.of(ctx).pop();
+                      _applyBulkFlag(
+                        context,
+                        ref,
+                        ids,
+                        selectionMode,
+                        selectedIds,
+                        flagColor: value,
+                      );
+                    },
+                  ),
+              ],
+            ),
+            const Divider(),
+            ListTile(
+              leading: const Icon(Icons.flag_outlined),
+              title: Text(l10n.bulkClearFlag),
+              onTap: () {
+                Navigator.of(ctx).pop();
+                _applyBulkFlag(context, ref, ids, selectionMode, selectedIds);
+              },
+            ),
+            const SizedBox(height: SpacingTokens.sm),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _applyBulkFlag(
+    BuildContext context,
+    WidgetRef ref,
+    Set<String> ids,
+    ValueNotifier<bool> selectionMode,
+    ValueNotifier<Set<String>> selectedIds, {
+    String? flagColor,
+  }) async {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final count = await ref
+          .read(transactionActionsProvider.notifier)
+          .bulkSetFlag(
+            transactionIds: ids.toList(),
+            budgetId: budgetId,
+            flagColor: flagColor,
+          );
+      selectionMode.value = false;
+      selectedIds.value = {};
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.bulkFlagSuccess(count))),
+        );
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.bulkFlagError),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _bulkMarkCleared(
+    BuildContext context,
+    WidgetRef ref,
+    AsyncValue<List<Transaction>> transactionsAsync,
+    Set<String> ids,
+    ValueNotifier<bool> selectionMode,
+    ValueNotifier<Set<String>> selectedIds,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+
+    // Only toggle uncleared, non-reconciled transactions to "cleared".
+    final unclearedIds = <String>[];
+    if (transactionsAsync.hasValue) {
+      for (final tx in transactionsAsync.value!) {
+        final txId = tx.id?.toString() ?? '';
+        if (ids.contains(txId) && !tx.cleared && !tx.reconciled) {
+          unclearedIds.add(txId);
+        }
+      }
+    }
+
+    if (unclearedIds.isEmpty) {
+      // All selected are already cleared — toggle them to uncleared instead.
+      final clearedIds = <String>[];
+      if (transactionsAsync.hasValue) {
+        for (final tx in transactionsAsync.value!) {
+          final txId = tx.id?.toString() ?? '';
+          if (ids.contains(txId) && tx.cleared && !tx.reconciled) {
+            clearedIds.add(txId);
+          }
+        }
+      }
+      if (clearedIds.isEmpty) return;
+
+      try {
+        final count = await ref
+            .read(transactionActionsProvider.notifier)
+            .bulkToggleCleared(transactionIds: clearedIds, budgetId: budgetId);
+        selectionMode.value = false;
+        selectedIds.value = {};
+        if (context.mounted) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(l10n.bulkClearSuccess(count))),
+          );
+        }
+      } on Exception catch (_) {
+        if (context.mounted) {
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text(l10n.bulkClearError),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      }
+      return;
+    }
+
+    try {
+      final count = await ref
+          .read(transactionActionsProvider.notifier)
+          .bulkToggleCleared(transactionIds: unclearedIds, budgetId: budgetId);
+      selectionMode.value = false;
+      selectedIds.value = {};
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.bulkClearSuccess(count))),
+        );
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.bulkClearError),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _confirmBulkDelete(
+    BuildContext context,
+    WidgetRef ref,
+    Set<String> ids,
+    ValueNotifier<bool> selectionMode,
+    ValueNotifier<Set<String>> selectedIds,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.bulkDeleteTitle),
+        content: Text(l10n.bulkDeleteConfirm(ids.length)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
+            child: Text(l10n.deleteConfirmButton),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final count = await ref
+          .read(transactionActionsProvider.notifier)
+          .bulkDelete(transactionIds: ids.toList(), budgetId: budgetId);
+      selectionMode.value = false;
+      selectedIds.value = {};
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.bulkDeleteSuccess(count))),
+        );
+      }
+    } on Exception catch (_) {
+      if (context.mounted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(l10n.bulkDeleteError),
             backgroundColor: colorScheme.error,
           ),
         );


### PR DESCRIPTION
## Summary
- Extends the transaction selection mode bottom bar with 3 new bulk actions alongside the existing "Assign Envelope"
- **Bulk Flag**: Opens flag color picker to set/clear flags on all selected transactions
- **Bulk Delete**: Shows confirmation dialog, then deletes all selected transactions
- **Bulk Mark Cleared**: Toggles cleared status — marks uncleared as cleared, or if all selected are already cleared, marks them as uncleared (skips reconciled)
- Adds `bulkSetFlag`, `bulkDelete`, and `bulkToggleCleared` methods to `TransactionActions` provider
- Adds 12 new l10n strings for bulk operation feedback

## Test plan
- [x] All 48 existing tests pass
- [x] `dart analyze` clean
- [x] `dart format` clean
- [ ] CI checks pass