### PR TITLE
chore: add devenv script aliases and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,32 @@ Cross-platform envelope budgeting app with AI-driven financial intelligence.
 
 - [Devenv](https://devenv.sh/) — manages development environment, services, and scripts
 - [FVM](https://fvm.app/) — Flutter version management
-- Docker — for Serverpod database services (optional, devenv provides postgres/redis natively)
 
-## Setup
+## Getting Started
 
 ```bash
-# 1. Enter the development environment
+# 1. Clone and enter the repo
+git clone https://github.com/openbudget/openbudget.git
+cd openbudget
+
+# 2. Start the devenv shell (installs all tools automatically)
 devenv shell
 
-# 2. Resolve workspace dependencies
+# 3. Install dependencies
 dart pub get
 
-# 3. Start database services
+# 4. Run code generation
+runner:build
+runner:serverpod
+
+# 5. Start everything (Postgres + Redis + server)
 devenv up
 
-# 4. Apply database migrations and start the server
-server:start
+# 6. In a separate terminal, run the app
+flutter:app run -d macos
 ```
+
+That's it. `devenv up` starts Postgres, Redis, and the backend server in one command. The server waits for the databases to be healthy before starting.
 
 ## Project Structure
 
@@ -39,41 +48,124 @@ server:start
 openbudget/
 ├── openbudget_app/           # Flutter application
 ├── openbudget_server/        # Serverpod backend
-├── openbudget_client/        # Generated Serverpod client
+├── openbudget_client/        # Generated client protocol
 ├── openbudget_core/          # Shared Dart models & utilities
 ├── openbudget_ui/            # Shared widgets & theme
+├── openbudget_wired/         # Hand-drawn wired UI components
 ├── openbudget_lints/         # Centralized lint rules
 ├── openbudget_test_utils/    # Shared test helpers
-├── docker-compose.yaml       # Docker services for CI/prod
-├── pubspec.yaml              # Workspace root with melos config
+├── pubspec.yaml              # Workspace root
 └── devenv.nix                # Development environment config
 ```
 
-## Development Commands
+## Commands
+
+All commands run from the repo root. No need to `cd` into subdirectories.
+
+### Running the App
 
 ```bash
-# Analysis & testing
-melos run analyze              # Lint all packages
-melos run test                # Run all tests
-melos run test:flutter        # Run Flutter tests only
+flutter:app run -d macos       # Run on macOS
+flutter:app run -d chrome       # Run on web
+flutter:app run -d ios          # Run on iOS simulator
+flutter:app run -d android      # Run on Android emulator
+flutter:app build web          # Build for web
+```
 
-# Formatting
-melos run format              # Format Dart code
-dprint fmt                    # Format JSON, YAML, Markdown, TOML
+### Services
 
-# Code generation
-melos run generate            # Run build_runner
-melos run serverpod:generate  # Run Serverpod code generation
+```bash
+devenv up                      # Start Postgres + Redis + server (all-in-one)
+server:start                   # Start the server manually (without devenv)
+```
 
-# Utilities
-melos run clean               # Clean all Flutter packages
-melos run upgrade              # Upgrade dependencies
+### Testing
+
+```bash
+test:all                       # Run tests in all packages
+test:flutter                   # Run Flutter tests only
+test:integration               # Run Patrol integration tests
+flutter:app test               # Run app tests only
+```
+
+### Analysis and Formatting
+
+```bash
+analyze                        # Lint all packages
+format                         # Format all code (Dart + JSON/YAML/Markdown)
+format:check                   # Check non-Dart formatting without fixing
+lint:all                       # Run all linting (format check + analyze)
+```
+
+### Code Generation
+
+```bash
+runner:build                   # Generate code (Freezed, Riverpod, etc.)
+runner:serverpod               # Generate server protocol and client
+runner:watch                   # Generate code in watch mode
+```
+
+### Utilities
+
+```bash
+clean                          # Clean all packages
+update:deps                    # Update all dependencies
+```
+
+## Logging
+
+Both the Flutter app and backend server write structured logs to a single shared file during development. This makes it easy to follow what's happening across the entire stack from one place.
+
+### Log File
+
+In development, all logs are written to:
+
+```
+.temp/logs/openbudget-dev.log
+```
+
+This file is gitignored. To follow logs in real time:
+
+```bash
+tail -f .temp/logs/openbudget-dev.log
+```
+
+### Log Format
+
+Each line is structured as:
+
+```
+[2026-02-17T10:30:00.000] [INFO   ] [server] [BudgetService] Created budget id=42
+[2026-02-17T10:30:01.000] [INFO   ] [flutter:macos] [Navigation] Push /home
+```
+
+The fields are: `[timestamp] [level] [source] [logger] message`
+
+- **source** identifies where the log came from:
+  - `server` — backend
+  - `flutter:macos` / `flutter:web` / `flutter:ios-simulator` / `flutter:android-emulator` — app (automatically detected per platform)
+- **logger** is the component name (e.g. `BudgetService`, `Navigation`)
+
+### Auto-Truncation
+
+The log file auto-truncates when it exceeds 10 MB, keeping the most recent 2 MB. No manual cleanup needed.
+
+### Frontend Log Relay
+
+In debug mode, the Flutter app batches log entries and sends them to the server every 2 seconds. The server writes them to the same log file, so you see both frontend and backend activity together. In release mode, log relay is disabled.
+
+### PostHog Analytics (Production Only)
+
+In release builds, [PostHog](https://posthog.com) handles product analytics. It is completely disabled in debug mode. Pass the API key at build time:
+
+```bash
+flutter:app run --dart-define=POSTHOG_API_KEY=phc_xxx
 ```
 
 ## Architecture
 
 - **Envelope budgeting** — zero-sum model where every unit of income is assigned to a category
-- **Cloud-first** — all data stored on Serverpod backend with PostgreSQL
-- **Riverpod + Hooks** — state management following repository → service → provider → UI pattern
+- **Cloud-first** — all data stored on the backend with PostgreSQL
+- **Riverpod + Hooks** — state management following repository > service > provider > UI pattern
 - **Multi-currency native** — first-class support for multiple currencies including crypto
 - **AI-first** — financial intelligence features integrated into the budgeting workflow

--- a/devenv.nix
+++ b/devenv.nix
@@ -52,7 +52,23 @@
     port = 8091;
   };
 
+  processes = {
+    "server:all" = {
+      exec = ''
+        cd "$DEVENV_ROOT/openbudget_server"
+        dart bin/main.dart --apply-migrations
+      '';
+      process-compose = {
+        depends_on = {
+          "devenv-up-postgres".condition = "process_healthy";
+          "devenv-up-redis".condition = "process_healthy";
+        };
+      };
+    };
+  };
+
   scripts = {
+    # ── Core toolchain wrappers ──────────────────────────────────────────
     "flutter" = {
       exec = ''
         set -e
@@ -73,6 +89,14 @@
         fvm flutter $@
       '';
       description = "Run flutter commands.";
+    };
+    "flutter:app" = {
+      exec = ''
+        set -e
+        cd "$DEVENV_ROOT/openbudget_app"
+        flutter $@
+      '';
+      description = "Run flutter commands from the openbudget_app directory.";
     };
     "dart" = {
       exec = ''
@@ -95,33 +119,69 @@
       '';
       description = "Run the serverpod cli.";
     };
-    "update:deps" = {
+
+    # ── Services ─────────────────────────────────────────────────────────
+    "server:start" = {
       exec = ''
         set -e
-        devenv update
-        flutter pub upgrade
+        cd "$DEVENV_ROOT/openbudget_server"
+        dart bin/main.dart --apply-migrations
       '';
-      description = "Update all project dependencies.";
+      description = "Start the Serverpod development server.";
     };
-    "fix:all" = {
+
+    # ── Testing ──────────────────────────────────────────────────────────
+    "test:all" = {
       exec = ''
         set -e
-        fix:format
+        melos run test --no-select
       '';
-      description = "Fix all fixable lint issues.";
+      description = "Run tests in all packages.";
     };
-    "fix:format" = {
+    "test:flutter" = {
       exec = ''
         set -e
+        melos run test:flutter --no-select
+      '';
+      description = "Run Flutter tests only.";
+    };
+    "test:integration" = {
+      exec = ''
+        set -e
+        cd "$DEVENV_ROOT/openbudget_app"
+        flutter test integration_test
+      '';
+      description = "Run Patrol integration tests.";
+    };
+
+    # ── Analysis & formatting ────────────────────────────────────────────
+    "analyze" = {
+      exec = ''
+        set -e
+        melos run analyze --no-select
+      '';
+      description = "Run dart analyze across all packages.";
+    };
+    "format" = {
+      exec = ''
+        set -e
+        melos run format
         dprint fmt --config "$DEVENV_ROOT/dprint.json"
       '';
-      description = "Fix formatting for entire project.";
+      description = "Format all code (Dart and non-Dart).";
+    };
+    "format:check" = {
+      exec = ''
+        set -e
+        dprint check --config "$DEVENV_ROOT/dprint.json"
+      '';
+      description = "Check that all non-Dart formatting is correct.";
     };
     "lint:all" = {
       exec = ''
         set -e
-        lint:format
-        melos analyze
+        format:check
+        analyze
       '';
       description = "Lint all project files.";
     };
@@ -132,6 +192,20 @@
       '';
       description = "Check all formatting is correct.";
     };
+    "fix:all" = {
+      exec = ''
+        set -e
+        format
+      '';
+      description = "Fix all fixable lint issues.";
+    };
+    "fix:format" = {
+      exec = ''
+        set -e
+        dprint fmt --config "$DEVENV_ROOT/dprint.json"
+      '';
+      description = "Fix formatting for entire project.";
+    };
     "dartfmt" = {
       exec = ''
         set -e
@@ -140,6 +214,8 @@
       description = "The `dart format` executable for formatting the workspace.";
       binary = "bash";
     };
+
+    # ── Code generation ──────────────────────────────────────────────────
     "runner:build" = {
       exec = ''
         set -e
@@ -154,13 +230,29 @@
       '';
       description = "Run build_runner in watch mode.";
     };
-    "server:start" = {
+    "runner:serverpod" = {
       exec = ''
         set -e
-        cd "$DEVENV_ROOT/openbudget_server"
-        dart bin/main.dart --apply-migrations
+        melos run serverpod:generate
       '';
-      description = "Start the Serverpod development server.";
+      description = "Run Serverpod code generation.";
+    };
+
+    # ── Utilities ────────────────────────────────────────────────────────
+    "clean" = {
+      exec = ''
+        set -e
+        melos run clean --no-select
+      '';
+      description = "Clean all Flutter packages.";
+    };
+    "update:deps" = {
+      exec = ''
+        set -e
+        devenv update
+        flutter pub upgrade
+      '';
+      description = "Update all project dependencies.";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Add devenv script aliases so users never need to invoke melos or serverpod directly: `analyze`, `format`, `format:check`, `test:all`, `test:flutter`, `test:integration`, `runner:serverpod`, `clean`, and `flutter:app`
- Rewrite the README with a streamlined getting-started guide and full command reference using only devenv aliases
- Document the unified logging infrastructure (shared log file, format, auto-truncation, frontend relay) and PostHog analytics

## Test plan

- [ ] Verify `devenv shell` loads all new scripts (`analyze`, `format`, `test:all`, etc.)
- [ ] Run `flutter:app run -d macos` from repo root to confirm it works
- [ ] Run `analyze` and `test:all` from repo root
- [ ] Verify README renders correctly on GitHub