### PR TITLE
feat(app): integrate ynab flows with multi-currency support

### DIFF
--- a/openbudget_app/integration_test/account_flow_test.dart
+++ b/openbudget_app/integration_test/account_flow_test.dart
@@ -8,9 +8,14 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
+import 'package:openbudget_app/src/features/accounts/providers/account_transactions_provider.dart';
+import 'package:openbudget_app/src/features/accounts/screens/account_detail_screen.dart';
 import 'package:openbudget_app/src/features/accounts/screens/account_list_screen.dart';
 import 'package:openbudget_app/src/features/accounts/screens/add_account_screen.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -23,9 +28,11 @@ Account _makeAccount({
   required String name,
   required int balanceCents,
   required String currencyCode,
+  UuidValue? id,
   bool onBudget = true,
 }) {
   return Account(
+    id: id,
     name: name,
     accountType: 'checking',
     balanceCents: balanceCents,
@@ -47,22 +54,45 @@ Budget _makeBudget({String currencyCode = 'USD'}) {
   );
 }
 
+BudgetSummary _makeSummary({String currencyCode = 'USD'}) {
+  return BudgetSummary(
+    budget: _makeBudget(currencyCode: currencyCode),
+    categories: const [],
+    totalIncomeCents: 0,
+    totalBudgetedCents: 0,
+    readyToAssignCents: 0,
+    year: 2026,
+    month: 9,
+  );
+}
+
 Widget _buildApp({
   required List<Account> accounts,
+  List<Transaction> accountTransactions = const [],
   String budgetCurrencyCode = 'USD',
 }) {
   final router = GoRouter(
     initialLocation: '/budgets/$_budgetId/accounts',
     routes: [
       GoRoute(
+        name: accountListRoute,
         path: '/budgets/:id/accounts',
         builder: (context, state) =>
             AccountListScreen(budgetId: state.pathParameters['id']!),
       ),
       GoRoute(
+        name: addAccountRoute,
         path: '/budgets/:id/accounts/add',
         builder: (context, state) =>
             AddAccountScreen(budgetId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        name: accountDetailRoute,
+        path: '/budgets/:id/accounts/:accountId',
+        builder: (context, state) => AccountDetailScreen(
+          budgetId: state.pathParameters['id']!,
+          accountId: state.pathParameters['accountId']!,
+        ),
       ),
     ],
   );
@@ -70,6 +100,13 @@ Widget _buildApp({
   return ProviderScope(
     overrides: [
       accountListProvider.overrideWith((ref, budgetId) async => accounts),
+      accountTransactionsProvider.overrideWith(
+        (ref, args) async => accountTransactions,
+      ),
+      payeeListProvider.overrideWith((ref, budgetId) async => const []),
+      budgetSummaryProvider.overrideWith(
+        (ref, budgetId) async => _makeSummary(currencyCode: budgetCurrencyCode),
+      ),
       budgetDetailProvider.overrideWith(
         (ref, budgetId) async => _makeBudget(currencyCode: budgetCurrencyCode),
       ),
@@ -131,5 +168,45 @@ void main() {
 
     expect(find.text('EUR (€)'), findsOneWidget);
     expect(find.text('GBP (£)'), findsOneWidget);
+  });
+
+  testWidgets('account detail flow navigates to detail and back to list', (
+    tester,
+  ) async {
+    final accountId = UuidValue.fromString(
+      '00000000-0000-0000-0000-000000000111',
+    );
+    await tester.pumpWidget(
+      _buildApp(
+        accounts: [
+          _makeAccount(
+            id: accountId,
+            name: 'Daily USD',
+            balanceCents: 250000,
+            currencyCode: 'USD',
+          ),
+        ],
+        accountTransactions: [
+          Transaction(
+            id: UuidValue.fromString('00000000-0000-0000-0000-000000000211'),
+            description: 'Rent',
+            amountCents: -280000,
+            currencyCode: 'USD',
+            budgetId: _budgetUuid,
+            accountId: accountId,
+            transactionDate: DateTime(2026, 9, 3),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Daily USD'));
+    await tester.pumpAndSettle();
+    expect(find.text('Rent'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.arrow_back));
+    await tester.pumpAndSettle();
+    expect(find.text('Daily USD'), findsOneWidget);
   });
 }

--- a/openbudget_app/integration_test/app_test.dart
+++ b/openbudget_app/integration_test/app_test.dart
@@ -1,36 +1,44 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:openbudget_app/main.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_provider.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_state.dart';
+import 'package:openbudget_app/src/features/home/providers/budget_list_provider.dart';
 
-import 'common/patrol_helpers.dart';
-import 'common/test_data.dart';
+Future<void> _pumpApp(
+  WidgetTester tester, {
+  required AuthState authState,
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      authProvider.overrideWithValue(authState),
+      budgetListProvider.overrideWith((ref) async => const []),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const OpenBudgetApp(),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('full app flow: login → create budget → view budget', (
+  testWidgets('unauthenticated app launch shows login screen', (tester) async {
+    await _pumpApp(tester, authState: const Unauthenticated());
+    expect(find.text('Welcome to OpenBudget'), findsOneWidget);
+  });
+
+  testWidgets('authenticated app launch shows home empty state', (
     tester,
   ) async {
-    await initApp(tester);
-
-    final loginPage = LoginPage(tester);
-    final createBudgetPage = CreateBudgetPage(tester);
-    final budgetDetailPage = BudgetDetailPage(tester);
-
-    // Login screen is shown on launch
-    expect(loginPage.emailField, findsOneWidget);
-
-    // Sign in
-    await loginPage.signIn(TestData.validEmail, TestData.validPassword);
-
-    // Verify navigation to create budget screen
-    expect(createBudgetPage.nameField, findsOneWidget);
-
-    // Create a budget
-    await createBudgetPage.createBudget(TestData.budgetName);
-
-    // Verify navigation to budget detail screen
-    expect(budgetDetailPage.emptyStateTitle, findsOneWidget);
-    expect(budgetDetailPage.emptyStateSubtitle, findsOneWidget);
-    expect(budgetDetailPage.addCategoryButton, findsOneWidget);
+    await _pumpApp(tester, authState: const Authenticated(userId: 'user-1'));
+    expect(find.text('No Budgets Yet'), findsOneWidget);
   });
 }

--- a/openbudget_app/integration_test/auth_flow_test.dart
+++ b/openbudget_app/integration_test/auth_flow_test.dart
@@ -1,44 +1,69 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_provider.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_state.dart';
+import 'package:openbudget_app/src/features/auth/screens/login_screen.dart';
+import 'package:openbudget_app/src/features/auth/screens/register_screen.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
 
-import 'common/patrol_helpers.dart';
-import 'common/test_data.dart';
+Widget _buildAuthApp() {
+  final router = GoRouter(
+    initialLocation: loginPath,
+    routes: [
+      GoRoute(path: loginPath, builder: (_, __) => const LoginScreen()),
+      GoRoute(path: registerPath, builder: (_, __) => const RegisterScreen()),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [authProvider.overrideWithValue(const Unauthenticated())],
+    child: MaterialApp.router(
+      theme: OpenBudgetTheme.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('shows login screen on launch', (tester) async {
-    await initApp(tester);
+  testWidgets('login screen renders on auth flow launch', (tester) async {
+    await tester.pumpWidget(_buildAuthApp());
+    await tester.pumpAndSettle();
 
-    final loginPage = LoginPage(tester);
-
-    expect(loginPage.emailField, findsOneWidget);
-    expect(loginPage.passwordField, findsOneWidget);
-    expect(loginPage.signInButton, findsOneWidget);
     expect(find.text('Welcome to OpenBudget'), findsOneWidget);
+    expect(find.byType(TextField), findsNWidgets(2));
   });
 
-  testWidgets('login navigates to create budget screen', (tester) async {
-    await initApp(tester);
+  testWidgets('login flow can navigate to register screen', (tester) async {
+    await tester.pumpWidget(_buildAuthApp());
+    await tester.pumpAndSettle();
 
-    final loginPage = LoginPage(tester);
+    await tester.tap(find.byType(TextButton));
+    await tester.pumpAndSettle();
 
-    await loginPage.signIn(TestData.validEmail, TestData.validPassword);
-
-    expect(find.text('Create Budget'), findsOneWidget);
-    expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
-    expect(find.byType(FilledButton), findsOneWidget);
+    expect(find.text('Create Account'), findsOneWidget);
+    expect(find.text('Send Verification Code'), findsOneWidget);
   });
 
-  testWidgets('redirects unauthenticated user to login', (tester) async {
-    await initApp(tester);
+  testWidgets('register flow can navigate back to login screen', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildAuthApp());
+    await tester.pumpAndSettle();
 
-    // Verify login is shown (auth guard redirects unauthenticated users)
+    await tester.tap(find.byType(TextButton));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Already have an account? Sign In'));
+    await tester.pumpAndSettle();
+
     expect(find.text('Welcome to OpenBudget'), findsOneWidget);
-
-    // Verify budget creation form is NOT accessible
-    expect(find.byType(DropdownButtonFormField<String>), findsNothing);
-    expect(find.text('Create Budget'), findsNothing);
   });
 }

--- a/openbudget_app/integration_test/budget_flow_test.dart
+++ b/openbudget_app/integration_test/budget_flow_test.dart
@@ -1,61 +1,74 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:integration_test/integration_test.dart';
-
-import 'common/patrol_helpers.dart';
-import 'common/test_data.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/main.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_provider.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_state.dart';
+import 'package:openbudget_app/src/features/budget/screens/create_budget_screen.dart';
+import 'package:openbudget_app/src/features/home/providers/budget_list_provider.dart';
+import 'package:openbudget_app/src/routing/app_router.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('create budget screen renders form', (tester) async {
-    await initApp(tester);
+  testWidgets('create budget screen renders form fields', (tester) async {
+    final router = GoRouter(
+      initialLocation: createBudgetPath,
+      routes: [
+        GoRoute(
+          path: createBudgetPath,
+          builder: (_, __) => const CreateBudgetScreen(),
+        ),
+      ],
+    );
 
-    final loginPage = LoginPage(tester);
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          theme: OpenBudgetTheme.light,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-    // Navigate past login
-    await loginPage.signIn(TestData.validEmail, TestData.validPassword);
-
-    // Verify form elements
+    expect(find.text('Create Budget'), findsAtLeast(1));
     expect(find.byType(TextField), findsOneWidget);
     expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     expect(find.byType(FilledButton), findsOneWidget);
-    expect(find.text('Create Budget'), findsOneWidget);
   });
 
-  testWidgets('creating a budget navigates to budget detail', (tester) async {
-    await initApp(tester);
+  testWidgets(
+    'unauthenticated user is redirected to login from create budget',
+    (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          authProvider.overrideWithValue(const Unauthenticated()),
+          budgetListProvider.overrideWith((ref) async => const []),
+        ],
+      );
+      addTearDown(container.dispose);
+      final router = container.read(appRouterProvider);
 
-    final loginPage = LoginPage(tester);
-    final createBudgetPage = CreateBudgetPage(tester);
-    final budgetDetailPage = BudgetDetailPage(tester);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const OpenBudgetApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    // Navigate past login
-    await loginPage.signIn(TestData.validEmail, TestData.validPassword);
+      router.go(createBudgetPath);
+      await tester.pumpAndSettle();
 
-    // Create budget
-    await createBudgetPage.createBudget(TestData.budgetName);
-
-    // Verify navigation to budget detail
-    expect(budgetDetailPage.budgetHeader, findsOneWidget);
-    expect(find.text('Budget: mock-budget-1'), findsOneWidget);
-  });
-
-  testWidgets('budget detail shows empty state', (tester) async {
-    await initApp(tester);
-
-    final loginPage = LoginPage(tester);
-    final createBudgetPage = CreateBudgetPage(tester);
-    final budgetDetailPage = BudgetDetailPage(tester);
-
-    // Navigate to budget detail via login → create budget
-    await loginPage.signIn(TestData.validEmail, TestData.validPassword);
-    await createBudgetPage.createBudget(TestData.budgetName);
-
-    // Verify empty state
-    expect(budgetDetailPage.emptyStateTitle, findsOneWidget);
-    expect(budgetDetailPage.emptyStateSubtitle, findsOneWidget);
-    expect(budgetDetailPage.addCategoryButton, findsOneWidget);
-    expect(find.text('Add Category'), findsOneWidget);
-  });
+      expect(find.text('Welcome to OpenBudget'), findsOneWidget);
+    },
+  );
 }

--- a/openbudget_app/integration_test/tab_navigation_test.dart
+++ b/openbudget_app/integration_test/tab_navigation_test.dart
@@ -1,140 +1,138 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/screens/budget_shell_screen.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
 
-import 'common/patrol_helpers.dart';
-import 'common/test_data.dart';
+const _budgetId = 'test-budget-id';
+
+Widget _buildApp() {
+  final router = GoRouter(
+    initialLocation: '/plan',
+    routes: [
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) => BudgetShellScreen(
+          navigationShell: navigationShell,
+          budgetId: _budgetId,
+        ),
+        branches: [
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/plan',
+                builder: (_, __) =>
+                    const Scaffold(body: Center(child: Text('Plan Tab'))),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/accounts',
+                builder: (_, __) =>
+                    const Scaffold(body: Center(child: Text('Accounts Tab'))),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/reflect',
+                builder: (_, __) =>
+                    const Scaffold(body: Center(child: Text('Reflect Tab'))),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/more',
+                builder: (_, __) =>
+                    const Scaffold(body: Center(child: Text('More Tab'))),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+
+  return MaterialApp.router(
+    theme: OpenBudgetTheme.light,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    routerConfig: router,
+  );
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  /// Helper that logs in and creates a budget so the shell is visible.
-  Future<void> navigateToBudgetShell(WidgetTester tester) async {
-    await initApp(tester);
-
-    final loginPage = LoginPage(tester);
-    final createBudgetPage = CreateBudgetPage(tester);
-
-    await loginPage.signIn(TestData.validEmail, TestData.validPassword);
-    await createBudgetPage.createBudget(TestData.budgetName);
-  }
-
   testWidgets('bottom navigation bar renders all five tabs', (tester) async {
-    await navigateToBudgetShell(tester);
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final shell = BudgetShellPage(tester);
-
-    expect(shell.navigationBar, findsOneWidget);
-    expect(shell.planTab, findsOneWidget);
-    expect(shell.accountsTab, findsAtLeast(1));
-    expect(shell.addTab, findsOneWidget);
-    expect(shell.reflectTab, findsOneWidget);
-    expect(shell.moreTab, findsAtLeast(1));
+    expect(find.byType(NavigationBar), findsOneWidget);
+    expect(find.text('Plan'), findsOneWidget);
+    expect(find.text('Accounts'), findsOneWidget);
+    expect(find.text('Add'), findsOneWidget);
+    expect(find.text('Reflect'), findsOneWidget);
+    expect(find.text('More'), findsOneWidget);
   });
 
-  testWidgets('tapping Accounts tab shows accounts screen', (tester) async {
-    await navigateToBudgetShell(tester);
+  testWidgets('tapping Accounts tab shows accounts content', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final shell = BudgetShellPage(tester);
-    final accountsPage = AccountsTabPage(tester);
+    await tester.tap(find.text('Accounts'));
+    await tester.pumpAndSettle();
 
-    await shell.tapAccountsTab();
-
-    // Accounts tab content should be visible (empty state or account list)
-    expect(
-      accountsPage.emptyStateTitle,
-      findsOneWidget,
-      reason: 'No accounts exist yet, so empty state should show',
-    );
+    expect(find.text('Accounts Tab'), findsOneWidget);
   });
 
-  testWidgets('tapping "+" tab shows add transaction sheet', (tester) async {
-    await navigateToBudgetShell(tester);
+  testWidgets('tapping Add tab shows add transaction sheet', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final shell = BudgetShellPage(tester);
-    final addSheet = AddTransactionSheetPage(tester);
+    await tester.tap(find.text('Add'));
+    await tester.pumpAndSettle();
 
-    await shell.tapAddTab();
-
-    expect(addSheet.sheetTitle, findsOneWidget);
-    expect(addSheet.incomeOption, findsOneWidget);
-    expect(addSheet.expenseOption, findsOneWidget);
-    expect(addSheet.transferOption, findsAtLeast(1));
-  });
-
-  testWidgets('dismissing add sheet keeps current tab', (tester) async {
-    await navigateToBudgetShell(tester);
-
-    final shell = BudgetShellPage(tester);
-    final planPage = PlanTabPage(tester);
-
-    // Open then dismiss the add sheet
-    await shell.tapAddTab();
     expect(find.text('Add Transaction'), findsOneWidget);
+    expect(find.text('Add Income'), findsOneWidget);
+    expect(find.text('Add Expense'), findsOneWidget);
+    expect(find.text('Transfer'), findsOneWidget);
+  });
 
-    // Dismiss by tapping scrim
+  testWidgets('dismissing add sheet keeps plan tab visible', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Add'));
+    await tester.pumpAndSettle();
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
 
-    // Should still be on Plan tab
-    expect(planPage.emptyStateTitle, findsOneWidget);
+    expect(find.text('Plan Tab'), findsOneWidget);
   });
 
-  testWidgets('tapping Reflect tab shows reports screen', (tester) async {
-    await navigateToBudgetShell(tester);
+  testWidgets('tab switching works across reflect and more tabs', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final shell = BudgetShellPage(tester);
+    await tester.tap(find.text('Reflect'));
+    await tester.pumpAndSettle();
+    expect(find.text('Reflect Tab'), findsOneWidget);
 
-    await shell.tapReflectTab();
+    await tester.tap(find.text('More'));
+    await tester.pumpAndSettle();
+    expect(find.text('More Tab'), findsOneWidget);
 
-    // The Reflect tab should show the reports screen
-    expect(shell.reflectTab, findsOneWidget);
-  });
-
-  testWidgets('tapping More tab shows more screen options', (tester) async {
-    await navigateToBudgetShell(tester);
-
-    final shell = BudgetShellPage(tester);
-    final morePage = MoreTabPage(tester);
-
-    await shell.tapMoreTab();
-
-    expect(morePage.recurringTile, findsOneWidget);
-    expect(morePage.payeesTile, findsOneWidget);
-    expect(morePage.rulesTile, findsOneWidget);
-    expect(morePage.importTile, findsOneWidget);
-    expect(morePage.settingsTile, findsOneWidget);
-  });
-
-  testWidgets('can navigate back to Plan tab from More tab', (tester) async {
-    await navigateToBudgetShell(tester);
-
-    final shell = BudgetShellPage(tester);
-    final planPage = PlanTabPage(tester);
-
-    // Navigate to More
-    await shell.tapMoreTab();
-    expect(find.text('Recurring Transactions'), findsOneWidget);
-
-    // Navigate back to Plan
-    await shell.tapPlanTab();
-    expect(planPage.emptyStateTitle, findsOneWidget);
-  });
-
-  testWidgets('tab state is preserved across switches', (tester) async {
-    await navigateToBudgetShell(tester);
-
-    final shell = BudgetShellPage(tester);
-
-    // Navigate to Accounts (empty state)
-    await shell.tapAccountsTab();
-    expect(find.text('No Accounts Yet'), findsOneWidget);
-
-    // Switch to More
-    await shell.tapMoreTab();
-    expect(find.text('Recurring Transactions'), findsOneWidget);
-
-    // Switch back to Accounts — state should be preserved
-    await shell.tapAccountsTab();
-    expect(find.text('No Accounts Yet'), findsOneWidget);
+    await tester.tap(find.text('Plan'));
+    await tester.pumpAndSettle();
+    expect(find.text('Plan Tab'), findsOneWidget);
   });
 }

--- a/openbudget_app/integration_test/transaction_flow_test.dart
+++ b/openbudget_app/integration_test/transaction_flow_test.dart
@@ -1,90 +1,168 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
+// Serverpod's UuidValue.fromString is marked experimental.
+// ignore_for_file: experimental_member_use
 
-import 'common/patrol_helpers.dart';
-import 'common/test_data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/budget/widgets/add_transaction_sheet.dart';
+import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
+import 'package:openbudget_app/src/features/transactions/screens/add_expense_screen.dart';
+import 'package:openbudget_app/src/features/transactions/screens/add_income_screen.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+const _budgetId = 'test-budget-id';
+final _budgetUuid = UuidValue.fromString(
+  '00000000-0000-0000-0000-000000000010',
+);
+final _ownerUuid = UuidValue.fromString('00000000-0000-0000-0000-000000000099');
+
+Budget _makeBudget() => Budget(
+  id: _budgetUuid,
+  name: 'OpenBudget',
+  currencyCode: 'USD',
+  ownerId: _ownerUuid,
+  createdAt: DateTime(2026),
+);
+
+BudgetSummary _makeSummary() => BudgetSummary(
+  budget: _makeBudget(),
+  categories: const [],
+  totalIncomeCents: 0,
+  totalBudgetedCents: 0,
+  readyToAssignCents: 0,
+  year: 2026,
+  month: 9,
+);
+
+Widget _buildApp() {
+  final router = GoRouter(
+    initialLocation: '/budgets/$_budgetId/plan',
+    routes: [
+      GoRoute(
+        name: planRoute,
+        path: planPath,
+        builder: (context, state) => Scaffold(
+          appBar: AppBar(title: const Text('Plan Route')),
+          body: Center(
+            child: FilledButton(
+              onPressed: () => showModalBottomSheet<void>(
+                context: context,
+                isScrollControlled: true,
+                builder: (_) =>
+                    AddTransactionSheet(budgetId: state.pathParameters['id']!),
+              ),
+              child: const Text('Open Add Sheet'),
+            ),
+          ),
+        ),
+      ),
+      GoRoute(
+        name: addIncomeRoute,
+        path: addIncomePath,
+        builder: (context, state) =>
+            AddIncomeScreen(budgetId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        name: addExpenseRoute,
+        path: addExpensePath,
+        builder: (context, state) =>
+            AddExpenseScreen(budgetId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        name: createTransferRoute,
+        path: createTransferPath,
+        builder: (_, _) =>
+            const Scaffold(body: Center(child: Text('Transfer Route'))),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
+      budgetSummaryProvider.overrideWith((ref, id) async => _makeSummary()),
+      payeeListProvider.overrideWith((ref, id) async => const []),
+    ],
+    child: MaterialApp.router(
+      theme: OpenBudgetTheme.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  /// Helper that logs in and creates a budget so the shell is visible.
-  Future<void> navigateToBudgetShell(WidgetTester tester) async {
-    await initApp(tester);
+  testWidgets('add transaction sheet routes to add expense', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final loginPage = LoginPage(tester);
-    final createBudgetPage = CreateBudgetPage(tester);
+    await tester.tap(find.text('Open Add Sheet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Expense'));
+    await tester.pumpAndSettle();
 
-    await loginPage.signIn(TestData.validEmail, TestData.validPassword);
-    await createBudgetPage.createBudget(TestData.budgetName);
-  }
-
-  testWidgets('tapping Add Expense navigates to add expense screen', (
-    tester,
-  ) async {
-    await navigateToBudgetShell(tester);
-
-    final shell = BudgetShellPage(tester);
-    final addSheet = AddTransactionSheetPage(tester);
-
-    // Open add transaction sheet
-    await shell.tapAddTab();
-    expect(addSheet.sheetTitle, findsOneWidget);
-
-    // Tap Add Expense
-    await addSheet.tapExpense();
-
-    // Should navigate to the Add Expense screen
-    expect(find.text('Add Expense'), findsOneWidget);
+    expect(find.text('Add Expense'), findsNWidgets(2));
   });
 
-  testWidgets('tapping Add Income navigates to add income screen', (
-    tester,
-  ) async {
-    await navigateToBudgetShell(tester);
+  testWidgets('add transaction sheet routes to add income', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final shell = BudgetShellPage(tester);
-    final addSheet = AddTransactionSheetPage(tester);
+    await tester.tap(find.text('Open Add Sheet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Income'));
+    await tester.pumpAndSettle();
 
-    // Open add transaction sheet
-    await shell.tapAddTab();
-    expect(addSheet.sheetTitle, findsOneWidget);
-
-    // Tap Add Income
-    await addSheet.tapIncome();
-
-    // Should navigate to the Add Income screen
-    expect(find.text('Add Income'), findsOneWidget);
+    expect(find.text('Add Income'), findsNWidgets(2));
   });
 
-  testWidgets('add transaction sheet shows all three action tiles', (
-    tester,
-  ) async {
-    await navigateToBudgetShell(tester);
+  testWidgets('add transaction sheet routes to transfer', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final shell = BudgetShellPage(tester);
-    final addSheet = AddTransactionSheetPage(tester);
+    await tester.tap(find.text('Open Add Sheet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Transfer'));
+    await tester.pumpAndSettle();
 
-    await shell.tapAddTab();
-
-    expect(addSheet.incomeIcon, findsOneWidget);
-    expect(addSheet.expenseIcon, findsOneWidget);
-    // Transfer icon may appear in multiple places (accounts tab bar action)
-    expect(addSheet.transferIcon, findsAtLeast(1));
+    expect(find.text('Transfer Route'), findsOneWidget);
   });
 
-  testWidgets('tapping Transfer navigates to transfer screen', (tester) async {
-    await navigateToBudgetShell(tester);
+  testWidgets('cancel from add expense returns to plan route', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    final shell = BudgetShellPage(tester);
-    final addSheet = AddTransactionSheetPage(tester);
+    await tester.tap(find.text('Open Add Sheet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Expense'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
 
-    await shell.tapAddTab();
+    expect(find.text('Plan Route'), findsOneWidget);
+  });
 
-    // Tap Transfer — the text "Transfer" may appear in multiple places,
-    // so we tap the one inside the sheet.
-    await addSheet.tapTransfer();
+  testWidgets('cancel from add income returns to plan route', (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
 
-    // Should navigate to the Transfer screen
-    expect(find.text('Transfer'), findsAtLeast(1));
+    await tester.tap(find.text('Open Add Sheet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Income'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Plan Route'), findsOneWidget);
   });
 }

--- a/openbudget_app/lib/src/features/accounts/screens/account_detail_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/account_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:openbudget_app/src/features/accounts/providers/account_list_prov
 import 'package:openbudget_app/src/features/accounts/providers/account_transactions_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_app/src/theme/ynab_palette.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
@@ -61,7 +62,10 @@ class AccountDetailScreen extends HookConsumerWidget {
         scrolledUnderElevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/budgets/$budgetId/accounts'),
+          onPressed: () => context.goNamed(
+            accountListRoute,
+            pathParameters: {'id': budgetId},
+          ),
         ),
         title: isSearching.value
             ? TextField(
@@ -720,7 +724,7 @@ class _ReconcileDialog extends HookWidget {
             onChanged: (value) {
               final parsed = double.tryParse(value);
               enteredCents.value = parsed != null
-                  ? (parsed * 100).round()
+                  ? (parsed * _pow10(currencyCode.decimals)).round()
                   : null;
             },
           ),
@@ -769,5 +773,13 @@ class _ReconcileDialog extends HookWidget {
         ),
       ],
     );
+  }
+
+  double _pow10(int exponent) {
+    var result = 1.0;
+    for (var i = 0; i < exponent; i++) {
+      result *= 10;
+    }
+    return result;
   }
 }

--- a/openbudget_app/lib/src/features/accounts/screens/account_list_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/account_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
 import 'package:openbudget_app/src/features/accounts/screens/edit_account_dialog.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_app/src/utils/currency_code_utils.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
@@ -31,7 +32,10 @@ class AccountListScreen extends HookConsumerWidget {
           IconButton(
             icon: const Icon(Icons.swap_horiz_rounded),
             tooltip: l10n.transferTitle,
-            onPressed: () => context.go('/budgets/$budgetId/transfer'),
+            onPressed: () => context.goNamed(
+              createTransferRoute,
+              pathParameters: {'id': budgetId},
+            ),
           ),
         ],
       ),
@@ -91,8 +95,10 @@ class AccountListScreen extends HookConsumerWidget {
                     ),
                     const SizedBox(height: SpacingTokens.lg),
                     FilledButton.icon(
-                      onPressed: () =>
-                          context.go('/budgets/$budgetId/accounts/add'),
+                      onPressed: () => context.goNamed(
+                        addAccountRoute,
+                        pathParameters: {'id': budgetId},
+                      ),
                       icon: const Icon(Icons.add),
                       label: Text(l10n.accountAddButton),
                     ),
@@ -162,7 +168,8 @@ class AccountListScreen extends HookConsumerWidget {
         },
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => context.go('/budgets/$budgetId/accounts/add'),
+        onPressed: () =>
+            context.goNamed(addAccountRoute, pathParameters: {'id': budgetId}),
         child: const Icon(Icons.add),
       ),
     );
@@ -240,11 +247,17 @@ class _AccountTile extends HookWidget {
     final colorScheme = theme.colorScheme;
     final icon = _iconForType(account.accountType);
     final currency = parseCurrencyCode(account.currencyCode);
+    final accountId = account.id?.toString();
 
     return Card(
       margin: const EdgeInsets.only(bottom: SpacingTokens.xs),
       child: ListTile(
-        onTap: () => context.go('/budgets/$budgetId/accounts/${account.id}'),
+        onTap: accountId == null
+            ? null
+            : () => context.goNamed(
+                accountDetailRoute,
+                pathParameters: {'id': budgetId, 'accountId': accountId},
+              ),
         onLongPress: () => showDialog<void>(
           context: context,
           builder: (_) =>

--- a/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_actions_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_app/src/utils/currency_code_utils.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
@@ -52,7 +53,10 @@ class AddAccountScreen extends HookConsumerWidget {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/budgets/$budgetId/accounts'),
+          onPressed: () => context.goNamed(
+            accountListRoute,
+            pathParameters: {'id': budgetId},
+          ),
         ),
         title: Text(l10n.accountAddTitle),
       ),
@@ -199,7 +203,10 @@ class AddAccountScreen extends HookConsumerWidget {
                                     content: Text(l10n.accountCreateSuccess),
                                   ),
                                 );
-                                router.go('/budgets/$budgetId/accounts');
+                                router.goNamed(
+                                  accountListRoute,
+                                  pathParameters: {'id': budgetId},
+                                );
                               } on Exception catch (_) {
                                 isSubmitting.value = false;
                                 messenger.showSnackBar(

--- a/openbudget_app/lib/src/features/budget/screens/create_budget_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/create_budget_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -112,7 +113,10 @@ class CreateBudgetScreen extends HookConsumerWidget {
                                           ),
                                         ),
                                       );
-                                      context.go('/budgets/$budgetId');
+                                      context.goNamed(
+                                        planRoute,
+                                        pathParameters: {'id': budgetId},
+                                      );
                                     }
                                   } on Exception catch (_) {
                                     isSubmitting.value = false;

--- a/openbudget_app/lib/src/features/budget/screens/move_money_dialog.dart
+++ b/openbudget_app/lib/src/features/budget/screens/move_money_dialog.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/monthly_allocation_provider.dart';
+import 'package:openbudget_app/src/utils/currency_code_utils.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
+import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
 class MoveMoneyDialog extends HookConsumerWidget {
@@ -27,6 +31,12 @@ class MoveMoneyDialog extends HookConsumerWidget {
     final fromEnvelopeId = useState<String?>(null);
     final toEnvelopeId = useState<String?>(null);
     final isSubmitting = useState(false);
+    final budgetAsync = ref.watch(budgetDetailProvider(budgetId));
+    final currency =
+        budgetAsync.whenOrNull(
+          data: (budget) => parseCurrencyCode(budget.currencyCode),
+        ) ??
+        CurrencyCode.usd;
 
     // Build a flat list of envelopes with category labels.
     final envelopeItems = <DropdownMenuItem<String>>[];
@@ -71,8 +81,9 @@ class MoveMoneyDialog extends HookConsumerWidget {
             TextField(
               controller: amountController,
               decoration: InputDecoration(
-                labelText: l10n.transactionAmountLabel,
-                prefixIcon: const Icon(Icons.attach_money),
+                labelText: '${l10n.transactionAmountLabel} (${currency.code})',
+                prefixText: '${currency.symbol} ',
+                hintText: formatCents(0, currency),
               ),
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
@@ -95,6 +106,7 @@ class MoveMoneyDialog extends HookConsumerWidget {
                   amountController,
                   fromEnvelopeId,
                   toEnvelopeId,
+                  currency,
                   isSubmitting,
                 ),
           child: isSubmitting.value
@@ -115,6 +127,7 @@ class MoveMoneyDialog extends HookConsumerWidget {
     TextEditingController amountController,
     ValueNotifier<String?> fromEnvelopeId,
     ValueNotifier<String?> toEnvelopeId,
+    CurrencyCode currency,
     ValueNotifier<bool> isSubmitting,
   ) async {
     final l10n = AppLocalizations.of(context);
@@ -135,7 +148,7 @@ class MoveMoneyDialog extends HookConsumerWidget {
     final amount = double.tryParse(amountController.text.trim()) ?? 0;
     if (amount <= 0) return;
 
-    final amountCents = (amount * 100).round();
+    final amountCents = (amount * _pow10(currency.decimals)).round();
     isSubmitting.value = true;
 
     try {
@@ -160,5 +173,13 @@ class MoveMoneyDialog extends HookConsumerWidget {
         ),
       );
     }
+  }
+
+  double _pow10(int exponent) {
+    var result = 1.0;
+    for (var i = 0; i < exponent; i++) {
+      result *= 10;
+    }
+    return result;
   }
 }

--- a/openbudget_app/lib/src/features/budget/widgets/add_transaction_sheet.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/add_transaction_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_app/src/theme/ynab_palette.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -46,7 +47,10 @@ class AddTransactionSheet extends HookWidget {
               color: YnabPalette.progressGreen,
               onTap: () {
                 Navigator.of(context).pop();
-                context.go('/budgets/$budgetId/income/add');
+                context.goNamed(
+                  addIncomeRoute,
+                  pathParameters: {'id': budgetId},
+                );
               },
             ),
             const SizedBox(height: SpacingTokens.sm),
@@ -56,7 +60,10 @@ class AddTransactionSheet extends HookWidget {
               color: YnabPalette.negative,
               onTap: () {
                 Navigator.of(context).pop();
-                context.go('/budgets/$budgetId/expenses/add');
+                context.goNamed(
+                  addExpenseRoute,
+                  pathParameters: {'id': budgetId},
+                );
               },
             ),
             const SizedBox(height: SpacingTokens.sm),
@@ -66,7 +73,10 @@ class AddTransactionSheet extends HookWidget {
               color: YnabPalette.accentBlue,
               onTap: () {
                 Navigator.of(context).pop();
-                context.go('/budgets/$budgetId/transfer');
+                context.goNamed(
+                  createTransferRoute,
+                  pathParameters: {'id': budgetId},
+                );
               },
             ),
             const SizedBox(height: SpacingTokens.md),

--- a/openbudget_app/lib/src/features/home/screens/home_screen.dart
+++ b/openbudget_app/lib/src/features/home/screens/home_screen.dart
@@ -83,7 +83,7 @@ class HomeScreen extends HookConsumerWidget {
                     ),
                     const SizedBox(height: SpacingTokens.lg),
                     FilledButton.icon(
-                      onPressed: () => context.go(createBudgetPath),
+                      onPressed: () => context.goNamed(createBudgetRoute),
                       icon: const Icon(Icons.add),
                       label: Text(l10n.homeCreateBudget),
                     ),
@@ -110,7 +110,11 @@ class HomeScreen extends HookConsumerWidget {
                     budgetId: budget.id?.toString() ?? '',
                     budgetName: budget.name,
                     currencyCode: budget.currencyCode,
-                    onTap: () => context.go('/budgets/${budget.id}'),
+                    onTap: () {
+                      final id = budget.id?.toString();
+                      if (id == null || id.isEmpty) return;
+                      context.goNamed(planRoute, pathParameters: {'id': id});
+                    },
                     onLongPress: () => _confirmDeleteBudget(
                       context,
                       ref,
@@ -126,7 +130,7 @@ class HomeScreen extends HookConsumerWidget {
       floatingActionButton: budgets.maybeWhen(
         data: (list) => list.isNotEmpty
             ? FloatingActionButton(
-                onPressed: () => context.go(createBudgetPath),
+                onPressed: () => context.goNamed(createBudgetRoute),
                 child: const Icon(Icons.add),
               )
             : null,

--- a/openbudget_app/lib/src/features/more/screens/more_screen.dart
+++ b/openbudget_app/lib/src/features/more/screens/more_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
 class MoreScreen extends HookWidget {
@@ -24,31 +25,46 @@ class MoreScreen extends HookWidget {
                 _MoreTile(
                   icon: Icons.repeat_rounded,
                   label: l10n.moreRecurring,
-                  onTap: () => context.go('/budgets/$budgetId/more/recurring'),
+                  onTap: () => context.goNamed(
+                    recurringListRoute,
+                    pathParameters: {'id': budgetId},
+                  ),
                 ),
                 const Divider(height: 1),
                 _MoreTile(
                   icon: Icons.people_outline_rounded,
                   label: l10n.morePayees,
-                  onTap: () => context.go('/budgets/$budgetId/more/payees'),
+                  onTap: () => context.goNamed(
+                    payeeListRoute,
+                    pathParameters: {'id': budgetId},
+                  ),
                 ),
                 const Divider(height: 1),
                 _MoreTile(
                   icon: Icons.rule_rounded,
                   label: l10n.moreRules,
-                  onTap: () => context.go('/budgets/$budgetId/more/rules'),
+                  onTap: () => context.goNamed(
+                    transactionRulesRoute,
+                    pathParameters: {'id': budgetId},
+                  ),
                 ),
                 const Divider(height: 1),
                 _MoreTile(
                   icon: Icons.file_upload_outlined,
                   label: l10n.moreImport,
-                  onTap: () => context.go('/budgets/$budgetId/more/import'),
+                  onTap: () => context.goNamed(
+                    importTransactionsRoute,
+                    pathParameters: {'id': budgetId},
+                  ),
                 ),
                 const Divider(height: 1),
                 _MoreTile(
                   icon: Icons.settings_outlined,
                   label: l10n.moreSettings,
-                  onTap: () => context.go('/budgets/$budgetId/more/settings'),
+                  onTap: () => context.goNamed(
+                    settingsRoute,
+                    pathParameters: {'id': budgetId},
+                  ),
                 ),
               ],
             ),

--- a/openbudget_app/lib/src/features/payees/screens/payee_list_screen.dart
+++ b/openbudget_app/lib/src/features/payees/screens/payee_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/payees/providers/payee_actions_provider.dart';
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -32,7 +33,8 @@ class PayeeListScreen extends HookConsumerWidget {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/budgets/$budgetId/more'),
+          onPressed: () =>
+              context.goNamed(moreRoute, pathParameters: {'id': budgetId}),
         ),
         title: Text(l10n.payeeListTitle),
         actions: [

--- a/openbudget_app/lib/src/features/recurring/screens/recurring_list_screen.dart
+++ b/openbudget_app/lib/src/features/recurring/screens/recurring_list_screen.dart
@@ -3,9 +3,11 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/recurring/providers/recurring_actions_provider.dart';
 import 'package:openbudget_app/src/features/recurring/providers/recurring_list_provider.dart';
 import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_app/src/utils/currency_code_utils.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
@@ -19,8 +21,14 @@ class RecurringListScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final recurringAsync = ref.watch(recurringListProvider(budgetId));
+    final budgetAsync = ref.watch(budgetDetailProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final budgetCurrency =
+        budgetAsync.whenOrNull(
+          data: (budget) => parseCurrencyCode(budget.currencyCode),
+        ) ??
+        CurrencyCode.usd;
 
     return Scaffold(
       appBar: AppBar(
@@ -37,7 +45,7 @@ class RecurringListScreen extends HookConsumerWidget {
           IconButton(
             icon: const Icon(Icons.add),
             tooltip: l10n.recurringAddButton,
-            onPressed: () => _showAddDialog(context),
+            onPressed: () => _showAddDialog(context, budgetCurrency),
           ),
         ],
       ),
@@ -88,7 +96,7 @@ class RecurringListScreen extends HookConsumerWidget {
                   ),
                   const SizedBox(height: SpacingTokens.lg),
                   FilledButton.icon(
-                    onPressed: () => _showAddDialog(context),
+                    onPressed: () => _showAddDialog(context, budgetCurrency),
                     icon: const Icon(Icons.add),
                     label: Text(l10n.recurringAddButton),
                   ),
@@ -122,10 +130,11 @@ class RecurringListScreen extends HookConsumerWidget {
     );
   }
 
-  void _showAddDialog(BuildContext context) {
+  void _showAddDialog(BuildContext context, CurrencyCode currencyCode) {
     showDialog<void>(
       context: context,
-      builder: (_) => _AddRecurringDialog(budgetId: budgetId),
+      builder: (_) =>
+          _AddRecurringDialog(budgetId: budgetId, currencyCode: currencyCode),
     );
   }
 
@@ -385,9 +394,13 @@ class _RecurringTile extends HookWidget {
 }
 
 class _AddRecurringDialog extends HookConsumerWidget {
-  const _AddRecurringDialog({required this.budgetId});
+  const _AddRecurringDialog({
+    required this.budgetId,
+    required this.currencyCode,
+  });
 
   final String budgetId;
+  final CurrencyCode currencyCode;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -419,7 +432,9 @@ class _AddRecurringDialog extends HookConsumerWidget {
             TextField(
               controller: amountController,
               decoration: InputDecoration(
-                labelText: l10n.transactionAmountLabel,
+                labelText:
+                    '${l10n.transactionAmountLabel} (${currencyCode.code})',
+                prefixText: '${currencyCode.symbol} ',
               ),
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
@@ -510,6 +525,7 @@ class _AddRecurringDialog extends HookConsumerWidget {
                   frequency,
                   nextDate,
                   isExpense,
+                  currencyCode,
                   isSubmitting,
                 ),
           child: isSubmitting.value
@@ -532,6 +548,7 @@ class _AddRecurringDialog extends HookConsumerWidget {
     ValueNotifier<String> frequency,
     ValueNotifier<DateTime> nextDate,
     ValueNotifier<bool> isExpense,
+    CurrencyCode currencyCode,
     ValueNotifier<bool> isSubmitting,
   ) async {
     final l10n = AppLocalizations.of(context);
@@ -541,7 +558,7 @@ class _AddRecurringDialog extends HookConsumerWidget {
     final amount = double.tryParse(amountController.text.trim()) ?? 0;
     if (amount <= 0) return;
 
-    final amountCents = (amount * 100).round();
+    final amountCents = (amount * _pow10(currencyCode.decimals)).round();
     final signedCents = isExpense.value ? -amountCents : amountCents;
 
     isSubmitting.value = true;
@@ -554,7 +571,7 @@ class _AddRecurringDialog extends HookConsumerWidget {
           .createRecurring(
             description: description,
             amountCents: signedCents,
-            currencyCode: 'USD',
+            currencyCode: currencyCode.code,
             budgetId: budgetId,
             frequency: frequency.value,
             nextOccurrence: nextDate.value,
@@ -587,9 +604,12 @@ class _EditRecurringDialog extends HookConsumerWidget {
     final descController = useTextEditingController(
       text: recurring.description,
     );
+    final currency = parseCurrencyCode(recurring.currencyCode);
     final amountCents = recurring.amountCents.abs();
     final amountController = useTextEditingController(
-      text: (amountCents / 100).toStringAsFixed(2),
+      text: (amountCents / _pow10(currency.decimals)).toStringAsFixed(
+        currency.decimals,
+      ),
     );
     final frequency = useState(recurring.frequency);
     final nextDate = useState(recurring.nextOccurrence);
@@ -614,7 +634,8 @@ class _EditRecurringDialog extends HookConsumerWidget {
             TextField(
               controller: amountController,
               decoration: InputDecoration(
-                labelText: l10n.transactionAmountLabel,
+                labelText: '${l10n.transactionAmountLabel} (${currency.code})',
+                prefixText: '${currency.symbol} ',
               ),
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
@@ -688,6 +709,7 @@ class _EditRecurringDialog extends HookConsumerWidget {
                   amountController,
                   frequency,
                   nextDate,
+                  currency,
                   isSubmitting,
                 ),
           child: isSubmitting.value
@@ -709,6 +731,7 @@ class _EditRecurringDialog extends HookConsumerWidget {
     TextEditingController amountController,
     ValueNotifier<String> frequency,
     ValueNotifier<DateTime> nextDate,
+    CurrencyCode currency,
     ValueNotifier<bool> isSubmitting,
   ) async {
     final l10n = AppLocalizations.of(context);
@@ -718,7 +741,7 @@ class _EditRecurringDialog extends HookConsumerWidget {
     final amount = double.tryParse(amountController.text.trim()) ?? 0;
     if (amount <= 0) return;
 
-    final amountCents = (amount * 100).round();
+    final amountCents = (amount * _pow10(currency.decimals)).round();
     final isExpense = recurring.amountCents < 0;
     final signedCents = isExpense ? -amountCents : amountCents;
 

--- a/openbudget_app/lib/src/features/reports/providers/net_worth_provider.dart
+++ b/openbudget_app/lib/src/features/reports/providers/net_worth_provider.dart
@@ -45,19 +45,15 @@ Future<NetWorthData> netWorth(Ref ref, String budgetId) async {
           .toList()
         ..sort((a, b) => a.currency.code.compareTo(b.currency.code));
 
-  final totalAssets = breakdown.fold<int>(
-    0,
-    (sum, data) => sum + data.totalAssets,
-  );
-  final totalLiabilities = breakdown.fold<int>(
-    0,
-    (sum, data) => sum + data.totalLiabilities,
-  );
+  final primaryTotals = breakdown.length == 1 ? breakdown.first : null;
+
+  final totalAssets = primaryTotals?.totalAssets ?? 0;
+  final totalLiabilities = primaryTotals?.totalLiabilities ?? 0;
 
   return NetWorthData(
     totalAssets: totalAssets,
     totalLiabilities: totalLiabilities,
-    netWorth: totalAssets + totalLiabilities,
+    netWorth: primaryTotals?.netWorth ?? 0,
     assetAccounts: List<Account>.unmodifiable(
       breakdown.expand((entry) => entry.assetAccounts),
     ),

--- a/openbudget_app/lib/src/features/settings/screens/settings_screen.dart
+++ b/openbudget_app/lib/src/features/settings/screens/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:openbudget_app/src/features/budget/providers/budget_detail_provi
 import 'package:openbudget_app/src/features/settings/providers/budget_export_provider.dart';
 import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
 import 'package:openbudget_app/src/providers/theme_mode_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -67,15 +68,20 @@ class SettingsScreen extends HookConsumerWidget {
                     leading: const Icon(Icons.repeat_rounded),
                     title: Text(l10n.recurringListTitle),
                     trailing: const Icon(Icons.chevron_right_rounded),
-                    onTap: () =>
-                        context.go('/budgets/$budgetId/more/recurring'),
+                    onTap: () => context.goNamed(
+                      recurringListRoute,
+                      pathParameters: {'id': budgetId},
+                    ),
                   ),
                   const Divider(height: 1),
                   ListTile(
                     leading: const Icon(Icons.rule_rounded),
                     title: Text(l10n.transactionRulesTitle),
                     trailing: const Icon(Icons.chevron_right_rounded),
-                    onTap: () => context.go('/budgets/$budgetId/more/rules'),
+                    onTap: () => context.goNamed(
+                      transactionRulesRoute,
+                      pathParameters: {'id': budgetId},
+                    ),
                   ),
                 ],
               ),

--- a/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
@@ -10,7 +10,10 @@ import 'package:openbudget_app/src/features/payees/providers/payee_list_provider
 import 'package:openbudget_app/src/features/transaction_rules/providers/rule_match_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/duplicate_check_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/transaction_actions_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_app/src/theme/ynab_palette.dart';
+import 'package:openbudget_app/src/utils/currency_code_utils.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -37,6 +40,11 @@ class AddExpenseScreen extends HookConsumerWidget {
     final payeesAsync = ref.watch(payeeListProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final budgetCurrency =
+        budgetAsync.whenOrNull(
+          data: (budget) => parseCurrencyCode(budget.currencyCode),
+        ) ??
+        CurrencyCode.usd;
 
     useValueListenable(amountController);
 
@@ -49,11 +57,7 @@ class AddExpenseScreen extends HookConsumerWidget {
         duplicateCount.value = 0;
         return;
       }
-      final currency = CurrencyCode.values.firstWhere(
-        (c) => c.code == budget.currencyCode,
-        orElse: () => CurrencyCode.usd,
-      );
-      final amountCents = (amount * _pow10(currency.decimals)).round();
+      final amountCents = (amount * _pow10(budgetCurrency.decimals)).round();
       try {
         final duplicates = await ref.read(
           duplicateCheckProvider(
@@ -117,9 +121,11 @@ class AddExpenseScreen extends HookConsumerWidget {
 
     final amountText = amountController.text.trim();
     final amountValue = double.tryParse(amountText) ?? 0;
+    final amountCentsPreview = (amountValue * _pow10(budgetCurrency.decimals))
+        .round();
     final formattedAmount = amountValue == 0
-        ? r'-$0.00'
-        : r'-$' + amountValue.toStringAsFixed(2);
+        ? '-${formatCents(0, budgetCurrency)}'
+        : formatCents(-amountCentsPreview, budgetCurrency);
 
     return Scaffold(
       backgroundColor: YnabPalette.appBackground,
@@ -129,7 +135,8 @@ class AddExpenseScreen extends HookConsumerWidget {
         scrolledUnderElevation: 0,
         leadingWidth: 90,
         leading: TextButton.icon(
-          onPressed: () => context.go('/budgets/$budgetId'),
+          onPressed: () =>
+              context.goNamed(planRoute, pathParameters: {'id': budgetId}),
           icon: const Icon(Icons.arrow_back, size: 16),
           label: Text(l10n.dialogCancel),
         ),
@@ -207,7 +214,7 @@ class AddExpenseScreen extends HookConsumerWidget {
                             border: InputBorder.none,
                             isDense: true,
                             contentPadding: EdgeInsets.zero,
-                            hintText: r'-$0.00',
+                            hintText: '-${formatCents(0, budgetCurrency)}',
                             hintStyle: theme.textTheme.displaySmall?.copyWith(
                               color: YnabPalette.negative.withAlpha(120),
                               fontWeight: FontWeight.w700,
@@ -425,12 +432,9 @@ class AddExpenseScreen extends HookConsumerWidget {
                           final budget = budgetAsync.value;
                           if (budget == null) return;
 
-                          final currency = CurrencyCode.values.firstWhere(
-                            (c) => c.code == budget.currencyCode,
-                            orElse: () => CurrencyCode.usd,
-                          );
                           final amountCents =
-                              (amount * _pow10(currency.decimals)).round();
+                              (amount * _pow10(budgetCurrency.decimals))
+                                  .round();
 
                           isSubmitting.value = true;
                           final messenger = ScaffoldMessenger.of(context);
@@ -442,7 +446,7 @@ class AddExpenseScreen extends HookConsumerWidget {
                                 .addExpense(
                                   description: description,
                                   amountCents: amountCents,
-                                  currencyCode: budget.currencyCode,
+                                  currencyCode: budgetCurrency.code,
                                   budgetId: budgetId,
                                   date: selectedDate.value,
                                   envelopeId: selectedEnvelopeId.value,
@@ -453,7 +457,10 @@ class AddExpenseScreen extends HookConsumerWidget {
                             messenger.showSnackBar(
                               SnackBar(content: Text(l10n.transactionSuccess)),
                             );
-                            router.go('/budgets/$budgetId');
+                            router.goNamed(
+                              planRoute,
+                              pathParameters: {'id': budgetId},
+                            );
                           } on Exception catch (_) {
                             isSubmitting.value = false;
                             messenger.showSnackBar(

--- a/openbudget_app/lib/src/features/transactions/screens/add_income_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/add_income_screen.dart
@@ -7,7 +7,10 @@ import 'package:openbudget_app/src/features/budget/providers/budget_detail_provi
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/duplicate_check_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/transaction_actions_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_app/src/theme/ynab_palette.dart';
+import 'package:openbudget_app/src/utils/currency_code_utils.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -30,6 +33,11 @@ class AddIncomeScreen extends HookConsumerWidget {
     final payeesAsync = ref.watch(payeeListProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final budgetCurrency =
+        budgetAsync.whenOrNull(
+          data: (budget) => parseCurrencyCode(budget.currencyCode),
+        ) ??
+        CurrencyCode.usd;
 
     useValueListenable(amountController);
 
@@ -42,11 +50,7 @@ class AddIncomeScreen extends HookConsumerWidget {
         duplicateCount.value = 0;
         return;
       }
-      final currency = CurrencyCode.values.firstWhere(
-        (c) => c.code == budget.currencyCode,
-        orElse: () => CurrencyCode.usd,
-      );
-      final amountCents = (amount * _pow10(currency.decimals)).round();
+      final amountCents = (amount * _pow10(budgetCurrency.decimals)).round();
       try {
         final duplicates = await ref.read(
           duplicateCheckProvider(
@@ -77,9 +81,11 @@ class AddIncomeScreen extends HookConsumerWidget {
 
     final amountText = amountController.text.trim();
     final amountValue = double.tryParse(amountText) ?? 0;
+    final amountCentsPreview = (amountValue * _pow10(budgetCurrency.decimals))
+        .round();
     final formattedAmount = amountValue == 0
-        ? r'$0.00'
-        : r'$' + amountValue.toStringAsFixed(2);
+        ? formatCents(0, budgetCurrency)
+        : formatCents(amountCentsPreview, budgetCurrency);
 
     return Scaffold(
       backgroundColor: YnabPalette.appBackground,
@@ -89,7 +95,8 @@ class AddIncomeScreen extends HookConsumerWidget {
         scrolledUnderElevation: 0,
         leadingWidth: 90,
         leading: TextButton.icon(
-          onPressed: () => context.go('/budgets/$budgetId'),
+          onPressed: () =>
+              context.goNamed(planRoute, pathParameters: {'id': budgetId}),
           icon: const Icon(Icons.arrow_back, size: 16),
           label: Text(l10n.dialogCancel),
         ),
@@ -166,7 +173,7 @@ class AddIncomeScreen extends HookConsumerWidget {
                             border: InputBorder.none,
                             isDense: true,
                             contentPadding: EdgeInsets.zero,
-                            hintText: r'$0.00',
+                            hintText: formatCents(0, budgetCurrency),
                             hintStyle: theme.textTheme.displaySmall?.copyWith(
                               color: Colors.black.withAlpha(120),
                               fontWeight: FontWeight.w700,
@@ -329,12 +336,9 @@ class AddIncomeScreen extends HookConsumerWidget {
                           final budget = budgetAsync.value;
                           if (budget == null) return;
 
-                          final currency = CurrencyCode.values.firstWhere(
-                            (c) => c.code == budget.currencyCode,
-                            orElse: () => CurrencyCode.usd,
-                          );
                           final amountCents =
-                              (amount * _pow10(currency.decimals)).round();
+                              (amount * _pow10(budgetCurrency.decimals))
+                                  .round();
 
                           isSubmitting.value = true;
                           final messenger = ScaffoldMessenger.of(context);
@@ -346,7 +350,7 @@ class AddIncomeScreen extends HookConsumerWidget {
                                 .addIncome(
                                   description: description,
                                   amountCents: amountCents,
-                                  currencyCode: budget.currencyCode,
+                                  currencyCode: budgetCurrency.code,
                                   budgetId: budgetId,
                                   date: selectedDate.value,
                                   memo: memoText.isEmpty ? null : memoText,
@@ -354,7 +358,10 @@ class AddIncomeScreen extends HookConsumerWidget {
                             messenger.showSnackBar(
                               SnackBar(content: Text(l10n.transactionSuccess)),
                             );
-                            router.go('/budgets/$budgetId');
+                            router.goNamed(
+                              planRoute,
+                              pathParameters: {'id': budgetId},
+                            );
                           } on Exception catch (_) {
                             isSubmitting.value = false;
                             messenger.showSnackBar(

--- a/openbudget_app/lib/src/features/transactions/screens/import_transactions_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/import_transactions_screen.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/import_transactions_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
@@ -35,7 +36,8 @@ class ImportTransactionsScreen extends HookConsumerWidget {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/budgets/$budgetId/more'),
+          onPressed: () =>
+              context.goNamed(moreRoute, pathParameters: {'id': budgetId}),
         ),
         title: Text(l10n.importTitle),
       ),
@@ -244,7 +246,7 @@ class ImportTransactionsScreen extends HookConsumerWidget {
       messenger.showSnackBar(
         SnackBar(content: Text(l10n.importSuccess(count))),
       );
-      router.go('/budgets/$budgetId');
+      router.goNamed(planRoute, pathParameters: {'id': budgetId});
     } on Exception catch (_) {
       isSubmitting.value = false;
       messenger.showSnackBar(

--- a/openbudget_app/lib/src/features/transactions/screens/split_expense_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/split_expense_screen.dart
@@ -6,6 +6,9 @@ import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/split_transaction_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_app/src/utils/currency_code_utils.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
@@ -25,6 +28,11 @@ class SplitExpenseScreen extends HookConsumerWidget {
     final summaryAsync = ref.watch(budgetSummaryProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final budgetCurrency =
+        budgetAsync.whenOrNull(
+          data: (budget) => parseCurrencyCode(budget.currencyCode),
+        ) ??
+        CurrencyCode.usd;
 
     // Dynamic list of splits
     final splitControllers = useState<List<_SplitData>>([
@@ -52,12 +60,15 @@ class SplitExpenseScreen extends HookConsumerWidget {
       return sum + (double.tryParse(split.amountController.text.trim()) ?? 0);
     });
     final remaining = totalAmount - splitTotal;
+    final remainingCents = (remaining * _pow10(budgetCurrency.decimals))
+        .round();
 
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/budgets/$budgetId'),
+          onPressed: () =>
+              context.goNamed(planRoute, pathParameters: {'id': budgetId}),
         ),
         title: Text(l10n.splitTransactionTitle),
       ),
@@ -142,7 +153,7 @@ class SplitExpenseScreen extends HookConsumerWidget {
                             ),
                           ),
                           Text(
-                            remaining.toStringAsFixed(2),
+                            formatCents(remainingCents, budgetCurrency),
                             style: theme.textTheme.bodyMedium?.copyWith(
                               fontWeight: FontWeight.bold,
                               color: remaining.abs() < 0.005
@@ -284,7 +295,10 @@ class SplitExpenseScreen extends HookConsumerWidget {
                                     content: Text(l10n.splitSaveSuccess),
                                   ),
                                 );
-                                router.go('/budgets/$budgetId');
+                                router.goNamed(
+                                  planRoute,
+                                  pathParameters: {'id': budgetId},
+                                );
                               } on Exception catch (_) {
                                 isSubmitting.value = false;
                                 messenger.showSnackBar(

--- a/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
@@ -10,9 +10,10 @@ import 'package:openbudget_app/src/features/budget/providers/budget_summary_prov
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/transaction_actions_provider.dart';
 import 'package:openbudget_app/src/features/transactions/screens/edit_transaction_dialog.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_app/src/utils/currency_code_utils.dart';
 import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
-import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
 enum TransactionFilter { all, income, expense }
@@ -30,7 +31,6 @@ class TransactionListScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final transactionsAsync = ref.watch(transactionListProvider(budgetId));
-    final budgetAsync = ref.watch(budgetDetailProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -50,15 +50,6 @@ class TransactionListScreen extends HookConsumerWidget {
       searchController.addListener(listener);
       return () => searchController.removeListener(listener);
     }, [searchController]);
-
-    final currency =
-        budgetAsync.whenOrNull(
-          data: (budget) => CurrencyCode.values.firstWhere(
-            (c) => c.code == budget.currencyCode,
-            orElse: () => CurrencyCode.usd,
-          ),
-        ) ??
-        CurrencyCode.usd;
 
     return Scaffold(
       appBar: selectionMode.value
@@ -98,7 +89,10 @@ class TransactionListScreen extends HookConsumerWidget {
           : AppBar(
               leading: IconButton(
                 icon: const Icon(Icons.arrow_back),
-                onPressed: () => context.go('/budgets/$budgetId'),
+                onPressed: () => context.goNamed(
+                  planRoute,
+                  pathParameters: {'id': budgetId},
+                ),
               ),
               title: Text(l10n.transactionListTitle),
               actions: [
@@ -121,8 +115,7 @@ class TransactionListScreen extends HookConsumerWidget {
                                 IconButton(
                                   icon: const Icon(Icons.copy_rounded),
                                   tooltip: l10n.transactionExportCsv,
-                                  onPressed: () =>
-                                      _exportToCsv(context, txs, currency),
+                                  onPressed: () => _exportToCsv(context, txs),
                                 ),
                               ],
                             )
@@ -416,7 +409,6 @@ class TransactionListScreen extends HookConsumerWidget {
                       transactions: filtered,
                       childParentIds: childParentIds,
                       budgetId: budgetId,
-                      currencyCode: currency,
                       payeeMap: payeeMap,
                       envelopeMap: envelopeMap,
                       accountMap: accountMap,
@@ -837,11 +829,7 @@ class TransactionListScreen extends HookConsumerWidget {
     }
   }
 
-  void _exportToCsv(
-    BuildContext context,
-    List<Transaction> transactions,
-    CurrencyCode currency,
-  ) {
+  void _exportToCsv(BuildContext context, List<Transaction> transactions) {
     final l10n = AppLocalizations.of(context);
     final buffer = StringBuffer()
       ..writeln('Date,Description,Amount,Memo,Status');
@@ -853,6 +841,7 @@ class TransactionListScreen extends HookConsumerWidget {
     for (final tx in topLevel) {
       final date = _formatDateIso(tx.transactionDate);
       final desc = _escapeCsv(tx.description);
+      final currency = parseCurrencyCode(tx.currencyCode);
       final amount = formatCents(tx.amountCents, currency);
       final memo = _escapeCsv(tx.memo ?? '');
       final status = tx.reconciled
@@ -1229,7 +1218,6 @@ class _TransactionTile extends HookConsumerWidget {
   const _TransactionTile({
     required this.transaction,
     required this.budgetId,
-    required this.currencyCode,
     this.isSplit = false,
     this.payeeName,
     this.envelopeName,
@@ -1241,7 +1229,6 @@ class _TransactionTile extends HookConsumerWidget {
 
   final Transaction transaction;
   final String budgetId;
-  final CurrencyCode currencyCode;
   final bool isSplit;
   final String? payeeName;
   final String? envelopeName;
@@ -1260,6 +1247,7 @@ class _TransactionTile extends HookConsumerWidget {
     final icon = isIncome
         ? Icons.arrow_downward_rounded
         : Icons.arrow_upward_rounded;
+    final transactionCurrency = parseCurrencyCode(transaction.currencyCode);
 
     final statusIcon = transaction.reconciled
         ? Icons.lock_outline_rounded
@@ -1359,7 +1347,7 @@ class _TransactionTile extends HookConsumerWidget {
         ),
         subtitle: _buildSubtitle(theme, colorScheme),
         trailing: Text(
-          formatCents(transaction.amountCents, currencyCode),
+          formatCents(transaction.amountCents, transactionCurrency),
           style: theme.textTheme.titleSmall?.copyWith(
             color: color,
             fontWeight: FontWeight.bold,
@@ -1640,7 +1628,7 @@ class _TransactionTile extends HookConsumerWidget {
       builder: (_) => EditTransactionDialog(
         transaction: transaction,
         budgetId: budgetId,
-        currencyCode: currencyCode,
+        currencyCode: parseCurrencyCode(transaction.currencyCode),
       ),
     );
   }
@@ -1679,7 +1667,6 @@ class _GroupedTransactionList extends HookWidget {
     required this.transactions,
     required this.childParentIds,
     required this.budgetId,
-    required this.currencyCode,
     this.payeeMap = const {},
     this.envelopeMap = const {},
     this.accountMap = const {},
@@ -1691,7 +1678,6 @@ class _GroupedTransactionList extends HookWidget {
   final List<Transaction> transactions;
   final Set<String> childParentIds;
   final String budgetId;
-  final CurrencyCode currencyCode;
   final Map<String, String> payeeMap;
   final Map<String, String> envelopeMap;
   final Map<String, String> accountMap;
@@ -1744,7 +1730,6 @@ class _GroupedTransactionList extends HookWidget {
         return _TransactionTile(
           transaction: tx,
           budgetId: budgetId,
-          currencyCode: currencyCode,
           isSplit: isSplit,
           payeeName: payeeName,
           envelopeName: envelopeName,

--- a/openbudget_app/lib/src/features/transfers/screens/create_transfer_screen.dart
+++ b/openbudget_app/lib/src/features/transfers/screens/create_transfer_screen.dart
@@ -5,8 +5,47 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
 import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
+import 'package:openbudget_app/src/utils/currency_code_utils.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
+
+@visibleForTesting
+Account? findTransferAccountById(List<Account> accounts, String? accountId) =>
+    accounts
+        .where((account) => account.id?.toString() == accountId)
+        .firstOrNull;
+
+@visibleForTesting
+List<Account> transferDestinationAccounts(
+  List<Account> accounts, {
+  required String? fromAccountId,
+}) {
+  final fromAccount = findTransferAccountById(accounts, fromAccountId);
+  if (fromAccount == null) return accounts;
+
+  return accounts
+      .where((account) => account.currencyCode == fromAccount.currencyCode)
+      .toList();
+}
+
+@visibleForTesting
+CurrencyCode transferCurrency(
+  List<Account> accounts, {
+  required String? fromAccountId,
+}) {
+  final fromAccount = findTransferAccountById(accounts, fromAccountId);
+  return fromAccount == null
+      ? CurrencyCode.usd
+      : parseCurrencyCode(fromAccount.currencyCode);
+}
+
+@visibleForTesting
+int parseTransferAmountCents(String amountText, CurrencyCode currency) {
+  final amount = double.tryParse(amountText.trim()) ?? 0;
+  return (amount * _pow10(currency.decimals)).round();
+}
 
 class CreateTransferScreen extends HookConsumerWidget {
   const CreateTransferScreen({required this.budgetId, super.key});
@@ -40,6 +79,17 @@ class CreateTransferScreen extends HookConsumerWidget {
           ),
         ),
         data: (accounts) {
+          final selectedCurrency = transferCurrency(
+            accounts,
+            fromAccountId: fromAccountId.value,
+          );
+          final zeroAmountHint = formatCents(0, selectedCurrency);
+
+          final toAccountOptions = transferDestinationAccounts(
+            accounts,
+            fromAccountId: fromAccountId.value,
+          );
+
           if (accounts.length < 2) {
             return Center(
               child: Padding(
@@ -77,11 +127,23 @@ class CreateTransferScreen extends HookConsumerWidget {
                     .map(
                       (a) => DropdownMenuItem(
                         value: a.id?.toString(),
-                        child: Text(a.name),
+                        child: Text('${a.name} (${a.currencyCode})'),
                       ),
                     )
                     .toList(),
-                onChanged: (v) => fromAccountId.value = v,
+                onChanged: (v) {
+                  fromAccountId.value = v;
+                  final from = findTransferAccountById(accounts, v);
+                  final currentTo = findTransferAccountById(
+                    accounts,
+                    toAccountId.value,
+                  );
+                  if (from != null &&
+                      currentTo != null &&
+                      from.currencyCode != currentTo.currencyCode) {
+                    toAccountId.value = null;
+                  }
+                },
               ),
               const SizedBox(height: SpacingTokens.md),
               DropdownButtonFormField<String>(
@@ -90,11 +152,11 @@ class CreateTransferScreen extends HookConsumerWidget {
                   labelText: l10n.transferToAccount,
                   prefixIcon: const Icon(Icons.arrow_downward_rounded),
                 ),
-                items: accounts
+                items: toAccountOptions
                     .map(
                       (a) => DropdownMenuItem(
                         value: a.id?.toString(),
-                        child: Text(a.name),
+                        child: Text('${a.name} (${a.currencyCode})'),
                       ),
                     )
                     .toList(),
@@ -104,8 +166,10 @@ class CreateTransferScreen extends HookConsumerWidget {
               TextField(
                 controller: amountController,
                 decoration: InputDecoration(
-                  labelText: l10n.transactionAmountLabel,
-                  prefixIcon: const Icon(Icons.attach_money),
+                  labelText:
+                      '${l10n.transactionAmountLabel} (${selectedCurrency.code})',
+                  prefixText: '${selectedCurrency.symbol} ',
+                  hintText: zeroAmountHint,
                 ),
                 keyboardType: const TextInputType.numberWithOptions(
                   decimal: true,
@@ -148,6 +212,7 @@ class CreateTransferScreen extends HookConsumerWidget {
                         ref,
                         descController,
                         amountController,
+                        accounts,
                         fromAccountId,
                         toAccountId,
                         selectedDate,
@@ -174,6 +239,7 @@ class CreateTransferScreen extends HookConsumerWidget {
     WidgetRef ref,
     TextEditingController descController,
     TextEditingController amountController,
+    List<Account> accounts,
     ValueNotifier<String?> fromAccountId,
     ValueNotifier<String?> toAccountId,
     ValueNotifier<DateTime> selectedDate,
@@ -184,6 +250,9 @@ class CreateTransferScreen extends HookConsumerWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     if (fromAccountId.value == null || toAccountId.value == null) return;
+    final fromAccount = findTransferAccountById(accounts, fromAccountId.value);
+    final toAccount = findTransferAccountById(accounts, toAccountId.value);
+    if (fromAccount == null || toAccount == null) return;
     if (fromAccountId.value == toAccountId.value) {
       messenger.showSnackBar(
         SnackBar(
@@ -194,10 +263,24 @@ class CreateTransferScreen extends HookConsumerWidget {
       return;
     }
 
-    final amount = double.tryParse(amountController.text.trim()) ?? 0;
-    if (amount <= 0) return;
+    if (fromAccount.currencyCode != toAccount.currencyCode) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            '${l10n.transferError} (${fromAccount.currencyCode} -> ${toAccount.currencyCode})',
+          ),
+          backgroundColor: colorScheme.error,
+        ),
+      );
+      return;
+    }
 
-    final amountCents = (amount * 100).round();
+    final currency = parseCurrencyCode(fromAccount.currencyCode);
+    final amountCents = parseTransferAmountCents(
+      amountController.text,
+      currency,
+    );
+    if (amountCents <= 0) return;
     isSubmitting.value = true;
 
     try {
@@ -205,7 +288,7 @@ class CreateTransferScreen extends HookConsumerWidget {
       await client.transaction.transfer(
         descController.text.trim(),
         amountCents,
-        'USD',
+        currency.code,
         // Serverpod API requires UuidValue which is experimental in uuid package.
         // ignore: experimental_member_use
         UuidValue.fromString(budgetId),
@@ -230,4 +313,12 @@ class CreateTransferScreen extends HookConsumerWidget {
       );
     }
   }
+}
+
+double _pow10(int exponent) {
+  var result = 1.0;
+  for (var i = 0; i < exponent; i++) {
+    result *= 10;
+  }
+  return result;
 }

--- a/openbudget_app/test/features/accounts/screens/account_detail_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/account_detail_screen_test.dart
@@ -1,0 +1,137 @@
+// UuidValue is needed for constructing test model data.
+// ignore_for_file: experimental_member_use
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
+import 'package:openbudget_app/src/features/accounts/providers/account_transactions_provider.dart';
+import 'package:openbudget_app/src/features/accounts/screens/account_detail_screen.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+const _budgetId = 'test-budget-id';
+const _accountId = '00000000-0000-0000-0000-000000000111';
+final _budgetUuid = UuidValue.fromString(
+  '00000000-0000-0000-0000-000000000010',
+);
+final _accountUuid = UuidValue.fromString(_accountId);
+final _ownerUuid = UuidValue.fromString('00000000-0000-0000-0000-000000000099');
+
+Budget _makeBudget() => Budget(
+  id: _budgetUuid,
+  name: 'OpenBudget',
+  currencyCode: 'USD',
+  ownerId: _ownerUuid,
+  createdAt: DateTime(2026),
+);
+
+Account _makeAccount() => Account(
+  id: _accountUuid,
+  name: 'Daily',
+  accountType: 'checking',
+  balanceCents: 5202000,
+  currencyCode: 'USD',
+  budgetId: _budgetUuid,
+  onBudget: true,
+  sortOrder: 0,
+  isClosed: false,
+);
+
+Transaction _makeTransaction() => Transaction(
+  id: UuidValue.fromString('00000000-0000-0000-0000-000000000211'),
+  description: 'Rent',
+  amountCents: -280000,
+  currencyCode: 'USD',
+  budgetId: _budgetUuid,
+  accountId: _accountUuid,
+  transactionDate: DateTime(2026, 9, 3),
+  memo: 'September rent',
+  cleared: true,
+);
+
+BudgetSummary _makeSummary() => BudgetSummary(
+  budget: _makeBudget(),
+  categories: const [],
+  totalIncomeCents: 0,
+  totalBudgetedCents: 0,
+  readyToAssignCents: 0,
+  year: 2026,
+  month: 9,
+);
+
+Widget _buildSubject() {
+  final router = GoRouter(
+    initialLocation: '/budgets/$_budgetId/accounts/$_accountId',
+    routes: [
+      GoRoute(
+        name: accountListRoute,
+        path: accountListPath,
+        builder: (_, _) =>
+            const Scaffold(body: Center(child: Text('Accounts Route'))),
+      ),
+      GoRoute(
+        name: accountDetailRoute,
+        path: accountDetailPath,
+        builder: (context, state) => AccountDetailScreen(
+          budgetId: state.pathParameters['id']!,
+          accountId: state.pathParameters['accountId']!,
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      accountListProvider.overrideWith(
+        (ref, budgetId) async => [_makeAccount()],
+      ),
+      accountTransactionsProvider.overrideWith(
+        (ref, args) async => [_makeTransaction()],
+      ),
+      payeeListProvider.overrideWith((ref, budgetId) async => const []),
+      budgetSummaryProvider.overrideWith(
+        (ref, budgetId) async => _makeSummary(),
+      ),
+    ],
+    child: MaterialApp.router(
+      theme: OpenBudgetTheme.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('AccountDetailScreen', () {
+    testWidgets('renders account and transaction content', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Daily'), findsOneWidget);
+      expect(find.text('Rent'), findsOneWidget);
+      expect(find.text('September rent'), findsOneWidget);
+    });
+
+    testWidgets('back button navigates to account list route', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Accounts Route'), findsOneWidget);
+    });
+  });
+}

--- a/openbudget_app/test/features/accounts/screens/account_list_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/account_list_screen_test.dart
@@ -3,11 +3,13 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
 import 'package:openbudget_app/src/features/accounts/screens/account_list_screen.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -17,6 +19,7 @@ final _budgetUuid = UuidValue.fromString(
 );
 
 Account _makeAccount({
+  UuidValue? id,
   String name = 'Checking',
   String accountType = 'checking',
   int balanceCents = 100000,
@@ -26,6 +29,7 @@ Account _makeAccount({
   int sortOrder = 0,
 }) {
   return Account(
+    id: id,
     name: name,
     accountType: accountType,
     balanceCents: balanceCents,
@@ -34,6 +38,53 @@ Account _makeAccount({
     onBudget: onBudget,
     sortOrder: sortOrder,
     isClosed: isClosed,
+  );
+}
+
+Widget _buildRoutedSubject({required List<Account> accounts}) {
+  final router = GoRouter(
+    initialLocation: '/budgets/$_budgetId/accounts',
+    routes: [
+      GoRoute(
+        name: accountListRoute,
+        path: accountListPath,
+        builder: (context, state) =>
+            AccountListScreen(budgetId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        name: addAccountRoute,
+        path: addAccountPath,
+        builder: (_, _) =>
+            const Scaffold(body: Center(child: Text('Add Account Route'))),
+      ),
+      GoRoute(
+        name: createTransferRoute,
+        path: createTransferPath,
+        builder: (_, _) =>
+            const Scaffold(body: Center(child: Text('Transfer Route'))),
+      ),
+      GoRoute(
+        name: accountDetailRoute,
+        path: accountDetailPath,
+        builder: (context, state) => Scaffold(
+          body: Center(
+            child: Text('Account Detail ${state.pathParameters['accountId']!}'),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      accountListProvider.overrideWith((ref, budgetId) async => accounts),
+    ],
+    child: MaterialApp.router(
+      theme: OpenBudgetTheme.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
   );
 }
 
@@ -366,6 +417,61 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('empty-state Add Account button navigates to add account', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildRoutedSubject(accounts: const []));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Add Account'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add Account Route'), findsOneWidget);
+    });
+
+    testWidgets('FAB navigates to add account route', (tester) async {
+      await tester.pumpWidget(
+        _buildRoutedSubject(accounts: [_makeAccount(name: 'Daily')]),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add Account Route'), findsOneWidget);
+    });
+
+    testWidgets('transfer action navigates to transfer route', (tester) async {
+      await tester.pumpWidget(
+        _buildRoutedSubject(accounts: [_makeAccount(name: 'Daily')]),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.swap_horiz_rounded));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Transfer Route'), findsOneWidget);
+    });
+
+    testWidgets('tapping account row navigates to account detail route', (
+      tester,
+    ) async {
+      final accountId = UuidValue.fromString(
+        '00000000-0000-0000-0000-000000000111',
+      );
+      await tester.pumpWidget(
+        _buildRoutedSubject(
+          accounts: [_makeAccount(name: 'Daily Account', id: accountId)],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Daily Account'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Account Detail $accountId'), findsOneWidget);
     });
   });
 }

--- a/openbudget_app/test/features/budget/widgets/add_transaction_sheet_test.dart
+++ b/openbudget_app/test/features/budget/widgets/add_transaction_sheet_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/widgets/add_transaction_sheet.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
 void main() {
@@ -22,6 +24,54 @@ void main() {
         // showModalBottomSheet to avoid layout overflow in tests.
         body: AddTransactionSheet(budgetId: budgetId),
       ),
+    );
+  }
+
+  Widget buildRoutingSubject() {
+    final router = GoRouter(
+      initialLocation: '/host',
+      routes: [
+        GoRoute(
+          path: '/host',
+          builder: (context, state) => Scaffold(
+            body: Center(
+              child: FilledButton(
+                onPressed: () => showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (_) => const AddTransactionSheet(budgetId: budgetId),
+                ),
+                child: const Text('Open Add Sheet'),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          name: addIncomeRoute,
+          path: addIncomePath,
+          builder: (_, _) =>
+              const Scaffold(body: Center(child: Text('Income Route'))),
+        ),
+        GoRoute(
+          name: addExpenseRoute,
+          path: addExpensePath,
+          builder: (_, _) =>
+              const Scaffold(body: Center(child: Text('Expense Route'))),
+        ),
+        GoRoute(
+          name: createTransferRoute,
+          path: createTransferPath,
+          builder: (_, _) =>
+              const Scaffold(body: Center(child: Text('Transfer Route'))),
+        ),
+      ],
+    );
+
+    return MaterialApp.router(
+      theme: OpenBudgetTheme.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
     );
   }
 
@@ -58,6 +108,48 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.chevron_right_rounded), findsNWidgets(3));
+    });
+
+    testWidgets('navigates to add income route from sheet action', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildRoutingSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open Add Sheet'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Add Income'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Income Route'), findsOneWidget);
+    });
+
+    testWidgets('navigates to add expense route from sheet action', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildRoutingSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open Add Sheet'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Add Expense'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Expense Route'), findsOneWidget);
+    });
+
+    testWidgets('navigates to transfer route from sheet action', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildRoutingSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open Add Sheet'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Transfer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Transfer Route'), findsOneWidget);
     });
   });
 }

--- a/openbudget_app/test/features/recurring/screens/recurring_list_screen_test.dart
+++ b/openbudget_app/test/features/recurring/screens/recurring_list_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/recurring/providers/recurring_list_provider.dart';
 import 'package:openbudget_app/src/features/recurring/screens/recurring_list_screen.dart';
 import 'package:openbudget_client/openbudget_client.dart';
@@ -14,6 +15,15 @@ import 'package:openbudget_ui/openbudget_ui.dart';
 const _budgetId = 'test-budget-id';
 final _budgetUuid = UuidValue.fromString(
   '00000000-0000-0000-0000-000000000010',
+);
+final _ownerUuid = UuidValue.fromString('00000000-0000-0000-0000-000000000011');
+
+Budget _makeBudget() => Budget(
+  id: _budgetUuid,
+  name: 'Test Budget',
+  currencyCode: 'USD',
+  ownerId: _ownerUuid,
+  createdAt: DateTime(2026),
 );
 
 RecurringTransaction _makeRecurring({
@@ -64,6 +74,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith(
               (ref, budgetId) =>
                   throw Exception('Could not load recurring transactions'),
@@ -90,6 +101,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith(
               (ref, budgetId) async => <RecurringTransaction>[],
             ),
@@ -135,6 +147,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith((ref, budgetId) async => items),
           ],
           child: MaterialApp(
@@ -163,6 +176,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith((ref, budgetId) async => items),
           ],
           child: MaterialApp(
@@ -192,6 +206,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith((ref, budgetId) async => items),
           ],
           child: MaterialApp(
@@ -213,6 +228,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith(
               (ref, budgetId) async => <RecurringTransaction>[],
             ),
@@ -234,6 +250,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith(
               (ref, budgetId) async => <RecurringTransaction>[],
             ),
@@ -257,6 +274,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith(
               (ref, budgetId) async => <RecurringTransaction>[],
             ),
@@ -292,6 +310,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
             recurringListProvider.overrideWith((ref, budgetId) async => items),
           ],
           child: MaterialApp(

--- a/openbudget_app/test/features/reports/providers/net_worth_provider_test.dart
+++ b/openbudget_app/test/features/reports/providers/net_worth_provider_test.dart
@@ -62,6 +62,9 @@ void main() {
 
     expect(data.hasMultipleCurrencies, isTrue);
     expect(data.currencyBreakdown.length, 2);
+    expect(data.totalAssets, 0);
+    expect(data.totalLiabilities, 0);
+    expect(data.netWorth, 0);
 
     final usd = data.currencyBreakdown.firstWhere(
       (entry) => entry.currency == CurrencyCode.usd,
@@ -75,5 +78,36 @@ void main() {
     expect(eur.totalAssets, 120000);
     expect(eur.totalLiabilities, -30000);
     expect(eur.netWorth, 90000);
+  });
+
+  test('keeps aggregate totals for single-currency budgets', () async {
+    final container = ProviderContainer(
+      overrides: [
+        accountListProvider.overrideWith(
+          (ref, id) async => [
+            makeAccount(
+              name: 'Main Checking',
+              balanceCents: 150000,
+              currencyCode: 'USD',
+            ),
+            makeAccount(
+              name: 'Credit Card',
+              balanceCents: -25000,
+              currencyCode: 'USD',
+              accountType: 'creditCard',
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await container.read(netWorthProvider(budgetId).future);
+
+    expect(data.hasMultipleCurrencies, isFalse);
+    expect(data.currencyBreakdown.length, 1);
+    expect(data.totalAssets, 150000);
+    expect(data.totalLiabilities, -25000);
+    expect(data.netWorth, 125000);
   });
 }

--- a/openbudget_app/test/features/transactions/screens/add_expense_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/add_expense_screen_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
@@ -12,6 +13,7 @@ import 'package:openbudget_app/src/features/payees/providers/payee_last_envelope
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transaction_rules/providers/rule_match_provider.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_expense_screen.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -37,10 +39,10 @@ void main() {
     '00000000-0000-0000-0000-000000000031',
   );
 
-  Budget makeBudget() => Budget(
+  Budget makeBudget({String currencyCode = 'USD'}) => Budget(
     id: budgetUuid,
     name: 'My Budget',
-    currencyCode: 'USD',
+    currencyCode: currencyCode,
     ownerId: ownerUuid,
     createdAt: DateTime(2026),
   );
@@ -137,6 +139,61 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: const AddExpenseScreen(budgetId: budgetId),
+      ),
+    );
+  }
+
+  Widget buildRoutedSubject({
+    Budget? budget,
+    List<Payee>? payees,
+    BudgetSummary? summary,
+    String? Function(Ref, (String, String))? ruleMatchOverride,
+    String? Function(Ref, (String, String))? payeeLastEnvelopeOverride,
+  }) {
+    final router = GoRouter(
+      initialLocation: '/budgets/$budgetId/expenses/add',
+      routes: [
+        GoRoute(
+          name: planRoute,
+          path: planPath,
+          builder: (_, _) =>
+              const Scaffold(body: Center(child: Text('Plan Route'))),
+        ),
+        GoRoute(
+          name: addExpenseRoute,
+          path: addExpensePath,
+          builder: (context, state) =>
+              AddExpenseScreen(budgetId: state.pathParameters['id']!),
+        ),
+      ],
+    );
+
+    return ProviderScope(
+      overrides: [
+        budgetDetailProvider.overrideWith(
+          (ref, id) async => budget ?? makeBudget(),
+        ),
+        payeeListProvider.overrideWith(
+          (ref, id) async => payees ?? makePayees(),
+        ),
+        budgetSummaryProvider.overrideWith(
+          (ref, id) async => summary ?? makeSummary(),
+        ),
+        ruleMatchEnvelopeProvider.overrideWith(
+          (ref, args) async =>
+              ruleMatchOverride != null ? ruleMatchOverride(ref, args) : null,
+        ),
+        payeeLastEnvelopeProvider.overrideWith(
+          (ref, args) async => payeeLastEnvelopeOverride != null
+              ? payeeLastEnvelopeOverride(ref, args)
+              : null,
+        ),
+      ],
+      child: MaterialApp.router(
+        theme: OpenBudgetTheme.light,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: router,
       ),
     );
   }
@@ -314,6 +371,17 @@ void main() {
       expect(find.text('42.50'), findsOneWidget);
     });
 
+    testWidgets('shows negative amount hint in budget currency', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(budget: makeBudget(currencyCode: 'JPY')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('-¥0'), findsAtLeast(1));
+    });
+
     testWidgets('can enter memo text', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
@@ -349,6 +417,16 @@ void main() {
         ),
         findsNothing,
       );
+    });
+
+    testWidgets('cancel navigates back to plan route', (tester) async {
+      await tester.pumpWidget(buildRoutedSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Plan Route'), findsOneWidget);
     });
   });
 }

--- a/openbudget_app/test/features/transactions/screens/add_income_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/add_income_screen_test.dart
@@ -3,12 +3,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transactions/screens/add_income_screen.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 
@@ -19,10 +21,10 @@ void main() {
 
   const budgetId = 'test-budget-1';
 
-  Budget makeBudget() => Budget(
+  Budget makeBudget({String currencyCode = 'USD'}) => Budget(
     id: UuidValue.fromString('00000000-0000-0000-0000-000000000001'),
     name: 'My Budget',
-    currencyCode: 'USD',
+    currencyCode: currencyCode,
     ownerId: UuidValue.fromString('00000000-0000-0000-0000-000000000099'),
     createdAt: DateTime(2026),
   );
@@ -55,6 +57,43 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: const AddIncomeScreen(budgetId: budgetId),
+      ),
+    );
+  }
+
+  Widget buildRoutedSubject({Budget? budget, List<Payee>? payees}) {
+    final router = GoRouter(
+      initialLocation: '/budgets/$budgetId/income/add',
+      routes: [
+        GoRoute(
+          name: planRoute,
+          path: planPath,
+          builder: (_, _) =>
+              const Scaffold(body: Center(child: Text('Plan Route'))),
+        ),
+        GoRoute(
+          name: addIncomeRoute,
+          path: addIncomePath,
+          builder: (context, state) =>
+              AddIncomeScreen(budgetId: state.pathParameters['id']!),
+        ),
+      ],
+    );
+
+    return ProviderScope(
+      overrides: [
+        budgetDetailProvider.overrideWith(
+          (ref, id) async => budget ?? makeBudget(),
+        ),
+        payeeListProvider.overrideWith(
+          (ref, id) async => payees ?? makePayees(),
+        ),
+      ],
+      child: MaterialApp.router(
+        theme: OpenBudgetTheme.light,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: router,
       ),
     );
   }
@@ -219,6 +258,15 @@ void main() {
       expect(find.text('5000'), findsOneWidget);
     });
 
+    testWidgets('shows amount hint in budget currency', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(budget: makeBudget(currencyCode: 'JPY')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('¥0'), findsAtLeast(1));
+    });
+
     testWidgets('can enter memo text', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
@@ -250,6 +298,16 @@ void main() {
 
       // The Focus widget wrapping the amount field exists.
       expect(find.byType(Focus), findsWidgets);
+    });
+
+    testWidgets('cancel navigates back to plan route', (tester) async {
+      await tester.pumpWidget(buildRoutedSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Plan Route'), findsOneWidget);
     });
   });
 }

--- a/openbudget_app/test/features/transactions/screens/transaction_list_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/transaction_list_screen_test.dart
@@ -35,6 +35,7 @@ void main() {
     required String id,
     required String description,
     required int amountCents,
+    String currencyCode = 'USD',
     DateTime? date,
     bool cleared = false,
     bool reconciled = false,
@@ -48,7 +49,7 @@ void main() {
     id: UuidValue.fromString(id),
     description: description,
     amountCents: amountCents,
-    currencyCode: 'USD',
+    currencyCode: currencyCode,
     budgetId: UuidValue.fromString('00000000-0000-0000-0000-000000000001'),
     transactionDate: date ?? DateTime(2026, 2, 15),
     cleared: cleared,
@@ -163,6 +164,34 @@ void main() {
       expect(find.text('Monthly Salary'), findsOneWidget);
       expect(find.text('Coffee Shop'), findsOneWidget);
       expect(find.text('Gas Station'), findsOneWidget);
+    });
+
+    testWidgets('renders per-transaction currencies in amount labels', (
+      tester,
+    ) async {
+      final mixedCurrencyTransactions = [
+        makeTx(
+          id: '00000000-0000-0000-0000-000000000021',
+          description: 'USD Expense',
+          amountCents: -5000,
+          date: DateTime(2026, 2, 15),
+        ),
+        makeTx(
+          id: '00000000-0000-0000-0000-000000000022',
+          description: 'EUR Income',
+          amountCents: 123456,
+          currencyCode: 'EUR',
+          date: DateTime(2026, 2, 15),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        buildSubject(transactions: mixedCurrencyTransactions),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining(r'-$50.00'), findsOneWidget);
+      expect(find.textContaining('€1,234.56'), findsOneWidget);
     });
 
     testWidgets('shows search field', (tester) async {

--- a/openbudget_app/test/features/transfers/screens/create_transfer_screen_test.dart
+++ b/openbudget_app/test/features/transfers/screens/create_transfer_screen_test.dart
@@ -1,0 +1,81 @@
+// Serverpod's UuidValue.fromString is marked experimental.
+// ignore_for_file: experimental_member_use
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openbudget_app/src/features/transfers/screens/create_transfer_screen.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_core/openbudget_core.dart';
+
+void main() {
+  final budgetId = UuidValue.fromString('00000000-0000-0000-0000-000000000001');
+
+  Account makeAccount({
+    required String id,
+    required String name,
+    required String currencyCode,
+  }) => Account(
+    id: UuidValue.fromString(id),
+    name: name,
+    accountType: 'checking',
+    balanceCents: 0,
+    currencyCode: currencyCode,
+    budgetId: budgetId,
+    onBudget: true,
+    sortOrder: 0,
+    isClosed: false,
+  );
+
+  final accounts = [
+    makeAccount(
+      id: '00000000-0000-0000-0000-000000000101',
+      name: 'USD Checking',
+      currencyCode: 'USD',
+    ),
+    makeAccount(
+      id: '00000000-0000-0000-0000-000000000102',
+      name: 'USD Savings',
+      currencyCode: 'USD',
+    ),
+    makeAccount(
+      id: '00000000-0000-0000-0000-000000000103',
+      name: 'EUR Wallet',
+      currencyCode: 'EUR',
+    ),
+  ];
+
+  test('transferDestinationAccounts keeps only matching currency accounts', () {
+    final fromId = accounts.first.id!.toString();
+    final options = transferDestinationAccounts(
+      accounts,
+      fromAccountId: fromId,
+    );
+
+    expect(options.length, 2);
+    expect(options.every((account) => account.currencyCode == 'USD'), isTrue);
+  });
+
+  test('transferDestinationAccounts returns all accounts when no source', () {
+    final options = transferDestinationAccounts(accounts, fromAccountId: null);
+
+    expect(options, hasLength(accounts.length));
+  });
+
+  test('transferCurrency falls back to USD without a selected source', () {
+    final currency = transferCurrency(accounts, fromAccountId: null);
+
+    expect(currency, CurrencyCode.usd);
+  });
+
+  test('transferCurrency matches selected source account currency', () {
+    final fromId = accounts.last.id!.toString();
+    final currency = transferCurrency(accounts, fromAccountId: fromId);
+
+    expect(currency, CurrencyCode.eur);
+  });
+
+  test('parseTransferAmountCents respects decimal precision by currency', () {
+    expect(parseTransferAmountCents('12.34', CurrencyCode.usd), 1234);
+    expect(parseTransferAmountCents('12.34', CurrencyCode.jpy), 12);
+    expect(parseTransferAmountCents('0.00000042', CurrencyCode.btc), 42);
+  });
+}


### PR DESCRIPTION
## Problem
The YNAB-style flow implementation was partially integrated and several navigation paths still relied on hardcoded route strings. Multi-currency behavior was also inconsistent in key flows (transaction list rendering/export, transfer creation, recurring amount entry, and aggregate net-worth totals), which could produce misleading values or force USD assumptions.

## User impact
Without these fixes, users could hit inconsistent navigation in core budget/account/transaction flows and see incorrect currency handling when working across non-USD budgets/accounts. That makes the experience brittle and undermines trust in balances and transaction amounts.

## Root cause
The app had a mix of newer named-route navigation and older direct path navigation. Currency logic was implemented in some surfaces but not others, with hardcoded `USD` and `* 100` assumptions remaining in transfer/recurring/move-money/reconcile inputs and list rendering paths.

## Fix
This PR completes the YNAB flow integration and closes multi-currency gaps.

### Navigation and flow integration
- Completed named-route navigation wiring (`goNamed`) across plan/accounts/more/settings/payees/transactions flows.
- Kept add-income/add-expense cancel/save behavior returning to `planRoute` consistently.
- Added/expanded widget and integration coverage for account and transaction navigation flows.

### Multi-currency support improvements
- `net_worth_provider`: prevents cross-currency aggregate summation by only exposing aggregate totals when a single currency is present; keeps per-currency breakdowns for mixed-currency data.
- `transaction_list_screen`: renders/edits/exports each transaction using its own `transaction.currencyCode` instead of budget currency.
- `create_transfer_screen`: removes hardcoded `USD`; uses selected source account currency, currency-aware cents parsing, and same-currency destination filtering.
- `add_income_screen` / `add_expense_screen`: currency-aware amount preview/hints and cents conversion based on budget currency decimals.
- `recurring_list_screen` dialogs: removes hardcoded USD/2-decimal assumptions for create/edit recurring amounts.
- `move_money_dialog` and account reconcile input: currency-aware cents conversion.

### Testing
- Added new tests:
  - `openbudget_app/test/features/accounts/screens/account_detail_screen_test.dart`
  - `openbudget_app/test/features/transfers/screens/create_transfer_screen_test.dart`
- Expanded existing widget/provider tests for:
  - add transaction sheet route navigation
  - add income/expense cancel navigation and currency hints
  - account list route navigation
  - transaction list per-transaction currency rendering
  - recurring list provider dependencies
  - net worth provider multi-currency aggregate behavior
- Refactored integration tests into deterministic provider/router-driven coverage for account, tab, auth, budget, app, and transaction flows.

## Validation
- `cd openbudget_app && fvm flutter analyze`
- `cd openbudget_app && fvm flutter test`
- `cd openbudget_app && fvm flutter test integration_test/account_flow_test.dart -d macos`
- `cd openbudget_app && fvm flutter test integration_test/app_test.dart -d macos`
- `cd openbudget_app && fvm flutter test integration_test/auth_flow_test.dart -d macos`
- `cd openbudget_app && fvm flutter test integration_test/budget_flow_test.dart -d macos`
- `cd openbudget_app && fvm flutter test integration_test/tab_navigation_test.dart -d macos`
- `cd openbudget_app && fvm flutter test integration_test/transaction_flow_test.dart -d macos`

## Screenshots
### Accounts
![Accounts](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase3/accounts-screen.png)

### Account Detail
![Account Detail](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase3/account-detail-screen.png)

### Add Expense
![Add Expense](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase3/add-expense-screen.png)

### Add Income
![Add Income](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase3/add-income-screen.png)

### Transfer
![Transfer](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase3/transfer-screen.png)

### Transaction List
![Transaction List](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase3/transaction-list-screen.png)

### Recurring
![Recurring](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase3/recurring-screen.png)

## Conventional commit/PR rule
Conventional commit and PR-title enforcement is active in CI (`.github/workflows/ci.yml`, job: `Enforce Conventional Commits and PR Title`).
