### PR TITLE
feat(app): complete transaction mode-switch and quick-add flows

### DIFF
--- a/openbudget_app/integration_test/transaction_flow_test.dart
+++ b/openbudget_app/integration_test/transaction_flow_test.dart
@@ -126,6 +126,38 @@ void main() {
     expect(find.text('Add Income'), findsNWidgets(2));
   });
 
+  testWidgets('expense screen mode switch routes to income screen', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Open Add Sheet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Expense'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Income').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Add Income'), findsNWidgets(2));
+  });
+
+  testWidgets('income screen mode switch routes to expense screen', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Open Add Sheet'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Income'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add Expense').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Add Expense'), findsNWidgets(2));
+  });
+
   testWidgets('add transaction sheet routes to transfer', (tester) async {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();

--- a/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
@@ -186,6 +186,10 @@ class AddExpenseScreen extends HookConsumerWidget {
                                 icon: Icons.arrow_downward_rounded,
                                 selected: false,
                                 color: YnabPalette.mutedText,
+                                onTap: () => context.goNamed(
+                                  addIncomeRoute,
+                                  pathParameters: {'id': budgetId},
+                                ),
                               ),
                             ),
                           ],
@@ -503,38 +507,47 @@ class _ModeChip extends HookWidget {
     required this.icon,
     required this.selected,
     required this.color,
+    this.onTap,
   });
 
   final String label;
   final IconData icon;
   final bool selected;
   final Color color;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      decoration: BoxDecoration(
-        color: selected ? Colors.white : Colors.transparent,
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
         borderRadius: BorderRadius.circular(RadiusTokens.sm),
-      ),
-      padding: const EdgeInsets.symmetric(vertical: SpacingTokens.sm),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(icon, size: 16, color: color),
-          const SizedBox(width: 4),
-          Flexible(
-            child: Text(
-              label,
-              style: theme.textTheme.labelMedium?.copyWith(
-                color: color,
-                fontWeight: FontWeight.w700,
-              ),
-              overflow: TextOverflow.ellipsis,
-            ),
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            color: selected ? Colors.white : Colors.transparent,
+            borderRadius: BorderRadius.circular(RadiusTokens.sm),
           ),
-        ],
+          padding: const EdgeInsets.symmetric(vertical: SpacingTokens.sm),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 16, color: color),
+              const SizedBox(width: 4),
+              Flexible(
+                child: Text(
+                  label,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/openbudget_app/lib/src/features/transactions/screens/add_income_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/add_income_screen.dart
@@ -137,6 +137,10 @@ class AddIncomeScreen extends HookConsumerWidget {
                                 icon: Icons.arrow_upward_rounded,
                                 selected: false,
                                 color: YnabPalette.mutedText,
+                                onTap: () => context.goNamed(
+                                  addExpenseRoute,
+                                  pathParameters: {'id': budgetId},
+                                ),
                               ),
                             ),
                             Expanded(
@@ -404,38 +408,47 @@ class _ModeChip extends HookWidget {
     required this.icon,
     required this.selected,
     required this.color,
+    this.onTap,
   });
 
   final String label;
   final IconData icon;
   final bool selected;
   final Color color;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      decoration: BoxDecoration(
-        color: selected ? Colors.white : Colors.transparent,
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
         borderRadius: BorderRadius.circular(RadiusTokens.sm),
-      ),
-      padding: const EdgeInsets.symmetric(vertical: SpacingTokens.sm),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(icon, size: 16, color: color),
-          const SizedBox(width: 4),
-          Flexible(
-            child: Text(
-              label,
-              style: theme.textTheme.labelMedium?.copyWith(
-                color: color,
-                fontWeight: FontWeight.w700,
-              ),
-              overflow: TextOverflow.ellipsis,
-            ),
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            color: selected ? Colors.white : Colors.transparent,
+            borderRadius: BorderRadius.circular(RadiusTokens.sm),
           ),
-        ],
+          padding: const EdgeInsets.symmetric(vertical: SpacingTokens.sm),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 16, color: color),
+              const SizedBox(width: 4),
+              Flexible(
+                child: Text(
+                  label,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
@@ -7,6 +7,7 @@ import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/budget/widgets/add_transaction_sheet.dart';
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transactions/providers/transaction_actions_provider.dart';
 import 'package:openbudget_app/src/features/transactions/screens/edit_transaction_dialog.dart';
@@ -429,6 +430,14 @@ class TransactionListScreen extends HookConsumerWidget {
             ],
           );
         },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          builder: (_) => AddTransactionSheet(budgetId: budgetId),
+        ),
+        child: const Icon(Icons.add),
       ),
       bottomNavigationBar: selectionMode.value && selectedIds.value.isNotEmpty
           ? SafeArea(

--- a/openbudget_app/test/features/transactions/screens/add_expense_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/add_expense_screen_test.dart
@@ -165,6 +165,12 @@ void main() {
           builder: (context, state) =>
               AddExpenseScreen(budgetId: state.pathParameters['id']!),
         ),
+        GoRoute(
+          name: addIncomeRoute,
+          path: addIncomePath,
+          builder: (_, _) =>
+              const Scaffold(body: Center(child: Text('Add Income Route'))),
+        ),
       ],
     );
 
@@ -427,6 +433,18 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Plan Route'), findsOneWidget);
+    });
+
+    testWidgets('tapping Add Income mode navigates to add income route', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildRoutedSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Add Income').first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add Income Route'), findsOneWidget);
     });
   });
 }

--- a/openbudget_app/test/features/transactions/screens/add_income_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/add_income_screen_test.dart
@@ -77,6 +77,12 @@ void main() {
           builder: (context, state) =>
               AddIncomeScreen(budgetId: state.pathParameters['id']!),
         ),
+        GoRoute(
+          name: addExpenseRoute,
+          path: addExpensePath,
+          builder: (_, _) =>
+              const Scaffold(body: Center(child: Text('Add Expense Route'))),
+        ),
       ],
     );
 
@@ -308,6 +314,18 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Plan Route'), findsOneWidget);
+    });
+
+    testWidgets('tapping Add Expense mode navigates to add expense route', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildRoutedSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Add Expense').first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add Expense Route'), findsOneWidget);
     });
   });
 }

--- a/openbudget_app/test/features/transactions/screens/transaction_list_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/transaction_list_screen_test.dart
@@ -238,6 +238,27 @@ void main() {
       expect(find.byIcon(Icons.copy_rounded), findsOneWidget);
     });
 
+    testWidgets('shows add transaction FAB', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+
+    testWidgets('tapping add FAB opens add transaction sheet', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add Transaction'), findsOneWidget);
+      expect(find.text('Add Income'), findsOneWidget);
+      expect(find.text('Add Expense'), findsOneWidget);
+      expect(find.text('Transfer'), findsOneWidget);
+    });
+
     testWidgets('hides app bar actions when transactions empty', (
       tester,
     ) async {


### PR DESCRIPTION
## Problem
The transaction entry flow still had a parity gap with the YNAB-style references: the outflow/inflow segmented control was visual-only and did not actually switch modes. In addition, the transaction list had no direct in-context add-entry affordance, forcing users to navigate away before creating entries.

## User impact
Users could not quickly switch between expense and income while composing entries, which made the flow feel disconnected from the expected YNAB interaction model. Creating a transaction from the transaction list also required extra navigation steps.

## Root cause
- `_ModeChip` in both `add_expense_screen.dart` and `add_income_screen.dart` rendered static containers without tap handlers.
- `transaction_list_screen.dart` did not expose add-transaction entry from the list surface.

## Fix
This PR completes the next flow integration pass by wiring mode switching and quick-add behavior.

### Transaction entry flow
- Made add-transaction mode chips interactive in both screens:
  - Expense screen now routes the `Add Income` chip to `addIncomeRoute`.
  - Income screen now routes the `Add Expense` chip to `addExpenseRoute`.
- Updated `_ModeChip` to use `InkWell` + `onTap` so mode toggles are actionable instead of decorative.

### Transaction list flow
- Added a `FloatingActionButton` to `TransactionListScreen`.
- FAB opens the existing `AddTransactionSheet` in-place so users can add income/expense/transfer directly from the list.

## Testing
### Added/expanded widget tests
- `openbudget_app/test/features/transactions/screens/add_expense_screen_test.dart`
  - Added route coverage asserting `Add Income` chip navigation.
- `openbudget_app/test/features/transactions/screens/add_income_screen_test.dart`
  - Added route coverage asserting `Add Expense` chip navigation.
- `openbudget_app/test/features/transactions/screens/transaction_list_screen_test.dart`
  - Added FAB presence assertion.
  - Added assertion that tapping FAB opens add-transaction sheet options.

### Added/expanded integration tests
- `openbudget_app/integration_test/transaction_flow_test.dart`
  - Added end-to-end mode-switch tests for expense->income and income->expense.

## Validation
- `cd openbudget_app && fvm flutter analyze`
- `cd openbudget_app && fvm flutter test`
- `cd openbudget_app && fvm flutter test integration_test/account_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/app_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/auth_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/budget_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/tab_navigation_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/transaction_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`

## iOS Simulator Screenshots
### Add Expense
![Add Expense](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase4-ios/add_expense.png)

### Add Income
![Add Income](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase4-ios/add_income.png)

### Transaction List (with quick-add FAB)
![Transaction List](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase4-ios/transaction_list.png)
