### PR TITLE
feat(app): polish ynab transaction, recurring, and rules flows

### DIFF
--- a/openbudget_app/integration_test/more_flow_test.dart
+++ b/openbudget_app/integration_test/more_flow_test.dart
@@ -1,0 +1,206 @@
+// Serverpod's UuidValue.fromString is marked experimental.
+// ignore_for_file: experimental_member_use
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
+import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
+import 'package:openbudget_app/src/features/more/screens/more_screen.dart';
+import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
+import 'package:openbudget_app/src/features/recurring/providers/recurring_list_provider.dart';
+import 'package:openbudget_app/src/features/recurring/screens/recurring_list_screen.dart';
+import 'package:openbudget_app/src/features/transaction_rules/providers/rule_list_provider.dart';
+import 'package:openbudget_app/src/features/transaction_rules/screens/rule_list_screen.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_client/openbudget_client.dart';
+import 'package:openbudget_ui/openbudget_ui.dart';
+
+const _budgetId = 'test-budget-id';
+final _budgetUuid = UuidValue.fromString(
+  '00000000-0000-0000-0000-000000000201',
+);
+final _ownerUuid = UuidValue.fromString('00000000-0000-0000-0000-000000000202');
+final _payeeUuid = UuidValue.fromString('00000000-0000-0000-0000-000000000203');
+final _envelopeUuid = UuidValue.fromString(
+  '00000000-0000-0000-0000-000000000204',
+);
+final _categoryUuid = UuidValue.fromString(
+  '00000000-0000-0000-0000-000000000205',
+);
+
+Budget _makeBudget() => Budget(
+  id: _budgetUuid,
+  name: 'OpenBudget',
+  currencyCode: 'USD',
+  ownerId: _ownerUuid,
+  createdAt: DateTime(2026),
+);
+
+BudgetSummary _makeSummary() {
+  final category = Category(
+    id: _categoryUuid,
+    name: 'Bills',
+    budgetId: _budgetUuid,
+    sortOrder: 0,
+    isHidden: false,
+  );
+  final envelope = Envelope(
+    id: _envelopeUuid,
+    name: 'Rent',
+    budgetedAmountCents: 0,
+    spentAmountCents: 0,
+    currencyCode: 'USD',
+    categoryId: _categoryUuid,
+    sortOrder: 0,
+  );
+
+  return BudgetSummary(
+    budget: _makeBudget(),
+    categories: [
+      CategoryWithEnvelopes(
+        category: category,
+        envelopes: [envelope],
+        monthlyEnvelopes: const [],
+        totalBudgetedCents: 0,
+        totalSpentCents: 0,
+        totalAvailableCents: 0,
+      ),
+    ],
+    totalIncomeCents: 0,
+    totalBudgetedCents: 0,
+    readyToAssignCents: 0,
+    year: 2026,
+    month: 9,
+  );
+}
+
+Widget _buildApp() {
+  final router = GoRouter(
+    initialLocation: '/budgets/$_budgetId/more',
+    routes: [
+      GoRoute(
+        name: moreRoute,
+        path: morePath,
+        builder: (context, state) =>
+            MoreScreen(budgetId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        name: recurringListRoute,
+        path: recurringListPath,
+        builder: (context, state) =>
+            RecurringListScreen(budgetId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        name: recurringCalendarRoute,
+        path: recurringCalendarPath,
+        builder: (_, __) => const Scaffold(body: Text('Recurring Calendar')),
+      ),
+      GoRoute(
+        name: transactionRulesRoute,
+        path: transactionRulesPath,
+        builder: (context, state) =>
+            RuleListScreen(budgetId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        name: payeeListRoute,
+        path: payeeListPath,
+        builder: (_, __) => const Scaffold(body: Text('Payees')),
+      ),
+      GoRoute(
+        name: importTransactionsRoute,
+        path: importTransactionsPath,
+        builder: (_, __) => const Scaffold(body: Text('Import')),
+      ),
+      GoRoute(
+        name: settingsRoute,
+        path: settingsPath,
+        builder: (_, __) => const Scaffold(body: Text('Settings')),
+      ),
+    ],
+  );
+
+  final recurring = [
+    RecurringTransaction(
+      id: UuidValue.fromString('00000000-0000-0000-0000-000000000206'),
+      description: 'Rent',
+      amountCents: -250000,
+      currencyCode: 'USD',
+      budgetId: _budgetUuid,
+      frequency: 'monthly',
+      nextOccurrence: DateTime(2026, 9),
+      isActive: true,
+    ),
+  ];
+
+  final rules = [
+    TransactionRule(
+      id: UuidValue.fromString('00000000-0000-0000-0000-000000000207'),
+      budgetId: _budgetUuid,
+      payeeId: _payeeUuid,
+      targetEnvelopeId: _envelopeUuid,
+      enabled: true,
+    ),
+  ];
+
+  return ProviderScope(
+    overrides: [
+      budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
+      budgetSummaryProvider.overrideWith((ref, id) async => _makeSummary()),
+      payeeListProvider.overrideWith(
+        (ref, id) async => [
+          Payee(id: _payeeUuid, name: 'Landlord', budgetId: _budgetUuid),
+        ],
+      ),
+      recurringListProvider.overrideWith((ref, id) async => recurring),
+      ruleListProvider.overrideWith((ref, id) async => rules),
+    ],
+    child: MaterialApp.router(
+      theme: OpenBudgetTheme.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('navigates from More to recurring and opens add dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Recurring Transactions'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recurring Transactions'), findsWidgets);
+
+    await tester.tap(find.byIcon(Icons.add).first);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+  });
+
+  testWidgets('navigates from More to rules and opens add rule dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Transaction Rules'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Transaction Rules'), findsWidgets);
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+  });
+}

--- a/openbudget_app/lib/l10n/app_en.arb
+++ b/openbudget_app/lib/l10n/app_en.arb
@@ -171,6 +171,13 @@
       }
     }
   },
+  "@recurringTotalCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@spendingByPayeeTransactionCount": {
     "placeholders": {
       "count": {
@@ -193,6 +200,13 @@
     }
   },
   "@transactionResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@transactionRulesTotalCount": {
     "placeholders": {
       "count": {
         "type": "int"
@@ -564,6 +578,7 @@
   "recurringPostDue": "Post Now",
   "recurringPostError": "Could not post scheduled transactions. Please try again.",
   "recurringPostSuccess": "{count, plural, =1{1 transaction posted} other{{count} transactions posted}}",
+  "recurringTotalCount": "{count, plural, =1{1 recurring transaction} other{{count} recurring transactions}}",
   "recurringPosting": "Posting...",
   "recurringSkipButton": "Skip",
   "recurringSkipError": "Could not skip occurrence. Please try again.",
@@ -734,7 +749,9 @@
   "transactionRulesDeleteError": "Could not delete rule. Please try again.",
   "transactionRulesDeleteSuccess": "Rule deleted",
   "transactionRulesToggleError": "Could not update rule. Please try again.",
+  "transactionRulesEnabled": "Enabled",
   "transactionRulesDisabled": "Disabled",
+  "transactionRulesTotalCount": "{count, plural, =1{1 total} other{{count} total}}",
   "transactionRulesAutoAssigned": "Auto-assigned by rule",
   "transferToAccount": "To Account",
   "undoAction": "Undo",

--- a/openbudget_app/lib/l10n/generated/app_localizations.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations.dart
@@ -1948,6 +1948,12 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 transaction posted} other{{count} transactions posted}}'**
   String recurringPostSuccess(int count);
 
+  /// No description provided for @recurringTotalCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 recurring transaction} other{{count} recurring transactions}}'**
+  String recurringTotalCount(int count);
+
   /// No description provided for @recurringPosting.
   ///
   /// In en, this message translates to:
@@ -2968,11 +2974,23 @@ abstract class AppLocalizations {
   /// **'Could not update rule. Please try again.'**
   String get transactionRulesToggleError;
 
+  /// No description provided for @transactionRulesEnabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Enabled'**
+  String get transactionRulesEnabled;
+
   /// No description provided for @transactionRulesDisabled.
   ///
   /// In en, this message translates to:
   /// **'Disabled'**
   String get transactionRulesDisabled;
+
+  /// No description provided for @transactionRulesTotalCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 total} other{{count} total}}'**
+  String transactionRulesTotalCount(int count);
 
   /// No description provided for @transactionRulesAutoAssigned.
   ///

--- a/openbudget_app/lib/l10n/generated/app_localizations_en.dart
+++ b/openbudget_app/lib/l10n/generated/app_localizations_en.dart
@@ -1189,6 +1189,17 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String recurringTotalCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count recurring transactions',
+      one: '1 recurring transaction',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get recurringPosting => 'Posting...';
 
   @override
@@ -1754,7 +1765,21 @@ class AppLocalizationsEn extends AppLocalizations {
       'Could not update rule. Please try again.';
 
   @override
+  String get transactionRulesEnabled => 'Enabled';
+
+  @override
   String get transactionRulesDisabled => 'Disabled';
+
+  @override
+  String transactionRulesTotalCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count total',
+      one: '1 total',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get transactionRulesAutoAssigned => 'Auto-assigned by rule';

--- a/openbudget_app/lib/src/features/recurring/screens/recurring_list_screen.dart
+++ b/openbudget_app/lib/src/features/recurring/screens/recurring_list_screen.dart
@@ -7,10 +7,14 @@ import 'package:openbudget_app/src/features/budget/providers/budget_detail_provi
 import 'package:openbudget_app/src/features/recurring/providers/recurring_actions_provider.dart';
 import 'package:openbudget_app/src/features/recurring/providers/recurring_list_provider.dart';
 import 'package:openbudget_app/src/routing/route_names.dart';
+import 'package:openbudget_app/src/theme/ynab_palette.dart';
 import 'package:openbudget_app/src/utils/currency_code_utils.dart';
+import 'package:openbudget_app/src/utils/currency_formatter.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
+
+enum RecurringViewFilter { all, expenses, income, due }
 
 class RecurringListScreen extends HookConsumerWidget {
   const RecurringListScreen({required this.budgetId, super.key});
@@ -24,6 +28,7 @@ class RecurringListScreen extends HookConsumerWidget {
     final budgetAsync = ref.watch(budgetDetailProvider(budgetId));
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final viewFilter = useState(RecurringViewFilter.all);
     final budgetCurrency =
         budgetAsync.whenOrNull(
           data: (budget) => parseCurrencyCode(budget.currencyCode),
@@ -31,7 +36,11 @@ class RecurringListScreen extends HookConsumerWidget {
         CurrencyCode.usd;
 
     return Scaffold(
+      backgroundColor: YnabPalette.appBackground,
       appBar: AppBar(
+        backgroundColor: YnabPalette.appBackground,
+        surfaceTintColor: Colors.transparent,
+        scrolledUnderElevation: 0,
         title: Text(l10n.recurringListTitle),
         actions: [
           IconButton(
@@ -73,56 +82,173 @@ class RecurringListScreen extends HookConsumerWidget {
         data: (items) {
           if (items.isEmpty) {
             return Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.repeat_rounded,
-                    size: 48,
-                    color: colorScheme.outlineVariant,
+              child: Card(
+                margin: const EdgeInsets.all(SpacingTokens.lg),
+                color: YnabPalette.surface,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(RadiusTokens.md),
+                  side: const BorderSide(color: YnabPalette.divider),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(SpacingTokens.lg),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.repeat_rounded,
+                        size: 48,
+                        color: colorScheme.outlineVariant,
+                      ),
+                      const SizedBox(height: SpacingTokens.md),
+                      Text(
+                        l10n.recurringEmptyTitle,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: SpacingTokens.sm),
+                      Text(
+                        l10n.recurringEmptySubtitle,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: SpacingTokens.lg),
+                      FilledButton.icon(
+                        onPressed: () =>
+                            _showAddDialog(context, budgetCurrency),
+                        icon: const Icon(Icons.add),
+                        label: Text(l10n.recurringAddButton),
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: SpacingTokens.md),
-                  Text(
-                    l10n.recurringEmptyTitle,
-                    style: theme.textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: SpacingTokens.sm),
-                  Text(
-                    l10n.recurringEmptySubtitle,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: SpacingTokens.lg),
-                  FilledButton.icon(
-                    onPressed: () => _showAddDialog(context, budgetCurrency),
-                    icon: const Icon(Icons.add),
-                    label: Text(l10n.recurringAddButton),
-                  ),
-                ],
+                ),
               ),
             );
           }
+
+          final now = DateTime.now();
+          final activeItems = items.where((item) => item.isActive).toList();
+          final dueCount = activeItems.where((item) {
+            final dueDate = DateTime(
+              item.nextOccurrence.year,
+              item.nextOccurrence.month,
+              item.nextOccurrence.day,
+            );
+            final today = DateTime(now.year, now.month, now.day);
+            return !dueDate.isAfter(today);
+          }).length;
+          final expenseTotals = aggregateCentsByCurrency(
+            activeItems.where((item) => item.amountCents < 0),
+            currencyCodeOf: (item) => item.currencyCode,
+            amountCentsOf: (item) => item.amountCents.abs(),
+          );
+          final incomeTotals = aggregateCentsByCurrency(
+            activeItems.where((item) => item.amountCents > 0),
+            currencyCodeOf: (item) => item.currencyCode,
+            amountCentsOf: (item) => item.amountCents,
+          );
+          final filteredItems = items.where((item) {
+            return switch (viewFilter.value) {
+              RecurringViewFilter.all => true,
+              RecurringViewFilter.expenses => item.amountCents < 0,
+              RecurringViewFilter.income => item.amountCents > 0,
+              RecurringViewFilter.due =>
+                item.isActive && !item.nextOccurrence.isAfter(now),
+            };
+          }).toList();
 
           return RefreshIndicator(
             onRefresh: () async {
               ref.invalidate(recurringListProvider(budgetId));
             },
-            child: ListView.builder(
+            child: ListView(
               padding: const EdgeInsets.all(SpacingTokens.md),
-              itemCount: items.length,
-              itemBuilder: (context, index) {
-                final item = items[index];
-                return _RecurringTile(
-                  recurring: item,
-                  budgetId: budgetId,
-                  onEdit: () => _showEditDialog(context, item),
-                  onDelete: () => _confirmDelete(context, ref, item),
-                  onToggle: () => _toggleActive(ref, item),
-                  onSkip: () => _skipOccurrence(context, ref, item),
-                );
-              },
+              children: [
+                _RecurringSummaryCard(
+                  totalItems: items.length,
+                  dueCount: dueCount,
+                  totalExpenses: expenseTotals.isEmpty
+                      ? formatCents(0, budgetCurrency)
+                      : formatCurrencyBreakdown(
+                          expenseTotals,
+                          includeCurrencyCode: expenseTotals.length > 1,
+                        ),
+                  totalIncome: incomeTotals.isEmpty
+                      ? formatCents(0, budgetCurrency)
+                      : formatCurrencyBreakdown(
+                          incomeTotals,
+                          includeCurrencyCode: incomeTotals.length > 1,
+                        ),
+                ),
+                const SizedBox(height: SpacingTokens.md),
+                SizedBox(
+                  height: 36,
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    children: [
+                      _RecurringFilterChip(
+                        label: l10n.transactionFilterAll,
+                        selected: viewFilter.value == RecurringViewFilter.all,
+                        onTap: () => viewFilter.value = RecurringViewFilter.all,
+                      ),
+                      const SizedBox(width: SpacingTokens.sm),
+                      _RecurringFilterChip(
+                        label: l10n.transactionFilterExpense,
+                        selected:
+                            viewFilter.value == RecurringViewFilter.expenses,
+                        onTap: () =>
+                            viewFilter.value = RecurringViewFilter.expenses,
+                        color: YnabPalette.negative,
+                      ),
+                      const SizedBox(width: SpacingTokens.sm),
+                      _RecurringFilterChip(
+                        label: l10n.transactionFilterIncome,
+                        selected:
+                            viewFilter.value == RecurringViewFilter.income,
+                        onTap: () =>
+                            viewFilter.value = RecurringViewFilter.income,
+                        color: YnabPalette.progressGreen,
+                      ),
+                      const SizedBox(width: SpacingTokens.sm),
+                      _RecurringFilterChip(
+                        label: l10n.recurringDueLabel,
+                        selected: viewFilter.value == RecurringViewFilter.due,
+                        onTap: () => viewFilter.value = RecurringViewFilter.due,
+                        color: YnabPalette.accentBlue,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: SpacingTokens.md),
+                if (filteredItems.isEmpty)
+                  Card(
+                    margin: EdgeInsets.zero,
+                    color: YnabPalette.surface,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(RadiusTokens.md),
+                      side: const BorderSide(color: YnabPalette.divider),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(SpacingTokens.md),
+                      child: Text(
+                        l10n.transactionNoResults,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: YnabPalette.mutedText,
+                        ),
+                      ),
+                    ),
+                  ),
+                ...filteredItems.map(
+                  (item) => _RecurringTile(
+                    recurring: item,
+                    budgetId: budgetId,
+                    onEdit: () => _showEditDialog(context, item),
+                    onDelete: () => _confirmDelete(context, ref, item),
+                    onToggle: () => _toggleActive(ref, item),
+                    onSkip: () => _skipOccurrence(context, ref, item),
+                  ),
+                ),
+              ],
             ),
           );
         },
@@ -250,6 +376,184 @@ class RecurringListScreen extends HookConsumerWidget {
   }
 }
 
+class _RecurringSummaryCard extends HookWidget {
+  const _RecurringSummaryCard({
+    required this.totalItems,
+    required this.dueCount,
+    required this.totalExpenses,
+    required this.totalIncome,
+  });
+
+  final int totalItems;
+  final int dueCount;
+  final String totalExpenses;
+  final String totalIncome;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: EdgeInsets.zero,
+      color: YnabPalette.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(RadiusTokens.md),
+        side: const BorderSide(color: YnabPalette.divider),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(SpacingTokens.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(SpacingTokens.md),
+              decoration: BoxDecoration(
+                color: YnabPalette.accentPurple,
+                borderRadius: BorderRadius.circular(RadiusTokens.md),
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    l10n.recurringListTitle,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: SpacingTokens.xs),
+                  Text(
+                    l10n.recurringTotalCount(totalItems),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: YnabPalette.mutedText,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: SpacingTokens.md),
+            Row(
+              children: [
+                Expanded(
+                  child: _SummaryMetric(
+                    label: l10n.transactionFilterExpense,
+                    value: totalExpenses,
+                    color: YnabPalette.negative,
+                  ),
+                ),
+                const SizedBox(width: SpacingTokens.sm),
+                Expanded(
+                  child: _SummaryMetric(
+                    label: l10n.transactionFilterIncome,
+                    value: totalIncome,
+                    color: YnabPalette.progressGreen,
+                  ),
+                ),
+                const SizedBox(width: SpacingTokens.sm),
+                Expanded(
+                  child: _SummaryMetric(
+                    label: l10n.recurringDueLabel,
+                    value: '$dueCount',
+                    color: YnabPalette.accentBlue,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryMetric extends HookWidget {
+  const _SummaryMetric({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SpacingTokens.sm,
+        vertical: SpacingTokens.xs,
+      ),
+      decoration: BoxDecoration(
+        color: color.withAlpha(28),
+        borderRadius: BorderRadius.circular(RadiusTokens.sm),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: YnabPalette.mutedText,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecurringFilterChip extends HookWidget {
+  const _RecurringFilterChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.color,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final chipColor = color ?? YnabPalette.accentBlue;
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      onSelected: (_) => onTap(),
+      backgroundColor: YnabPalette.surface,
+      selectedColor: chipColor.withAlpha(26),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(RadiusTokens.sm),
+        side: BorderSide(
+          color: selected ? chipColor.withAlpha(130) : YnabPalette.divider,
+        ),
+      ),
+      labelStyle: theme.textTheme.labelMedium?.copyWith(
+        color: selected ? chipColor : YnabPalette.mutedText,
+        fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+      ),
+      visualDensity: VisualDensity.compact,
+      showCheckmark: false,
+    );
+  }
+}
+
 class _RecurringTile extends HookWidget {
   const _RecurringTile({
     required this.recurring,
@@ -271,7 +575,6 @@ class _RecurringTile extends HookWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
     final currency = CurrencyCode.values.firstWhere(
       (c) => c.code == recurring.currencyCode,
       orElse: () => CurrencyCode.usd,
@@ -301,50 +604,86 @@ class _RecurringTile extends HookWidget {
       background: Container(
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: SpacingTokens.md),
-        color: colorScheme.error,
-        child: Icon(Icons.delete, color: colorScheme.onError),
+        decoration: BoxDecoration(
+          color: YnabPalette.negative,
+          borderRadius: BorderRadius.circular(RadiusTokens.md),
+        ),
+        child: const Icon(Icons.delete, color: Colors.white),
       ),
       confirmDismiss: (_) async {
         onDelete();
         return false;
       },
       child: Card(
+        margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
+        color: YnabPalette.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(RadiusTokens.md),
+          side: const BorderSide(color: YnabPalette.divider),
+        ),
         child: Column(
           children: [
             ListTile(
-              leading: Icon(
-                recurring.isActive
-                    ? Icons.repeat_rounded
-                    : Icons.repeat_rounded,
-                color: recurring.isActive
-                    ? colorScheme.primary
-                    : colorScheme.outlineVariant,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: SpacingTokens.md,
+                vertical: SpacingTokens.xs,
+              ),
+              leading: CircleAvatar(
+                radius: 18,
+                backgroundColor: recurring.isActive
+                    ? YnabPalette.accentPurple.withAlpha(90)
+                    : YnabPalette.surfaceMuted,
+                child: Icon(
+                  Icons.repeat_rounded,
+                  color: recurring.isActive
+                      ? YnabPalette.accentBlue
+                      : YnabPalette.mutedText,
+                  size: 18,
+                ),
               ),
               title: Text(
                 recurring.description,
-                style: TextStyle(
+                style: theme.textTheme.titleMedium?.copyWith(
                   decoration: recurring.isActive
-                      ? null
+                      ? TextDecoration.none
                       : TextDecoration.lineThrough,
                 ),
               ),
               subtitle: Text(
                 '$frequencyLabel \u2022 ${l10n.recurringNextDate}: $dateStr',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: YnabPalette.mutedText,
+                ),
               ),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    isIncome ? '+$formattedAmount' : '-$formattedAmount',
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      color: isIncome ? colorScheme.primary : colorScheme.error,
-                      fontWeight: FontWeight.w600,
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: SpacingTokens.sm,
+                      vertical: 3,
+                    ),
+                    decoration: BoxDecoration(
+                      color: isIncome
+                          ? YnabPalette.progressGreen.withAlpha(26)
+                          : YnabPalette.negative.withAlpha(18),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      isIncome ? '+$formattedAmount' : '-$formattedAmount',
+                      style: theme.textTheme.labelLarge?.copyWith(
+                        color: isIncome
+                            ? YnabPalette.progressGreen
+                            : YnabPalette.negative,
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                   ),
                   const SizedBox(width: SpacingTokens.xs),
-                  Switch(
+                  Switch.adaptive(
                     value: recurring.isActive,
                     onChanged: (_) => onToggle(),
+                    activeTrackColor: YnabPalette.accentBlue,
                   ),
                 ],
               ),
@@ -359,18 +698,18 @@ class _RecurringTile extends HookWidget {
                 ),
                 child: Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.schedule_rounded,
                       size: 16,
-                      color: colorScheme.tertiary,
+                      color: YnabPalette.accentBlue,
                     ),
                     const SizedBox(width: SpacingTokens.xs),
                     Expanded(
                       child: Text(
                         l10n.recurringDueLabel,
                         style: theme.textTheme.labelSmall?.copyWith(
-                          color: colorScheme.tertiary,
-                          fontWeight: FontWeight.w600,
+                          color: YnabPalette.accentBlue,
+                          fontWeight: FontWeight.w700,
                         ),
                       ),
                     ),
@@ -379,7 +718,7 @@ class _RecurringTile extends HookWidget {
                       icon: const Icon(Icons.skip_next_rounded, size: 18),
                       label: Text(l10n.recurringSkipButton),
                       style: TextButton.styleFrom(
-                        foregroundColor: colorScheme.onSurfaceVariant,
+                        foregroundColor: YnabPalette.mutedText,
                         visualDensity: VisualDensity.compact,
                       ),
                     ),

--- a/openbudget_app/lib/src/features/transaction_rules/screens/rule_list_screen.dart
+++ b/openbudget_app/lib/src/features/transaction_rules/screens/rule_list_screen.dart
@@ -6,7 +6,10 @@ import 'package:openbudget_app/src/features/budget/providers/budget_summary_prov
 import 'package:openbudget_app/src/features/payees/providers/payee_list_provider.dart';
 import 'package:openbudget_app/src/features/transaction_rules/providers/rule_actions_provider.dart';
 import 'package:openbudget_app/src/features/transaction_rules/providers/rule_list_provider.dart';
+import 'package:openbudget_app/src/theme/ynab_palette.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
+
+enum RuleViewFilter { all, enabled, disabled }
 
 class RuleListScreen extends HookConsumerWidget {
   const RuleListScreen({required this.budgetId, super.key});
@@ -18,6 +21,7 @@ class RuleListScreen extends HookConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final viewFilter = useState(RuleViewFilter.all);
     final rulesAsync = ref.watch(ruleListProvider(budgetId));
     final payeesAsync = ref.watch(payeeListProvider(budgetId));
     final summaryAsync = ref.watch(budgetSummaryProvider(budgetId));
@@ -44,9 +48,17 @@ class RuleListScreen extends HookConsumerWidget {
     }
 
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.transactionRulesTitle)),
+      backgroundColor: YnabPalette.appBackground,
+      appBar: AppBar(
+        backgroundColor: YnabPalette.appBackground,
+        surfaceTintColor: Colors.transparent,
+        scrolledUnderElevation: 0,
+        title: Text(l10n.transactionRulesTitle),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _showAddRuleDialog(context, ref),
+        backgroundColor: YnabPalette.accentBlue,
+        foregroundColor: Colors.white,
         child: const Icon(Icons.add),
       ),
       body: rulesAsync.when(
@@ -62,95 +74,129 @@ class RuleListScreen extends HookConsumerWidget {
         data: (rules) {
           if (rules.isEmpty) {
             return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(SpacingTokens.xl),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.rule_rounded,
-                      size: 64,
-                      color: colorScheme.onSurfaceVariant.withAlpha(100),
-                    ),
-                    const SizedBox(height: SpacingTokens.md),
-                    Text(
-                      l10n.transactionRulesEmptyTitle,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: SpacingTokens.xs),
-                    Text(
-                      l10n.transactionRulesEmptySubtitle,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
+              child: Card(
+                margin: const EdgeInsets.all(SpacingTokens.lg),
+                color: YnabPalette.surface,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(RadiusTokens.md),
+                  side: const BorderSide(color: YnabPalette.divider),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(SpacingTokens.lg),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.rule_rounded,
+                        size: 64,
+                        color: colorScheme.onSurfaceVariant.withAlpha(100),
                       ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
+                      const SizedBox(height: SpacingTokens.md),
+                      Text(
+                        l10n.transactionRulesEmptyTitle,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: SpacingTokens.xs),
+                      Text(
+                        l10n.transactionRulesEmptySubtitle,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             );
           }
 
-          return ListView.builder(
-            padding: const EdgeInsets.all(SpacingTokens.md),
-            itemCount: rules.length,
-            itemBuilder: (context, index) {
-              final rule = rules[index];
-              final ruleId = rule.id?.toString() ?? '';
-              final payeeName =
-                  payeeNames[rule.payeeId.toString()] ?? 'Unknown';
-              final envelopeName =
-                  envelopeNames[rule.targetEnvelopeId.toString()] ?? 'Unknown';
+          final enabledCount = rules.where((rule) => rule.enabled).length;
+          final disabledCount = rules.length - enabledCount;
+          final filteredRules = rules.where((rule) {
+            return switch (viewFilter.value) {
+              RuleViewFilter.all => true,
+              RuleViewFilter.enabled => rule.enabled,
+              RuleViewFilter.disabled => !rule.enabled,
+            };
+          }).toList();
 
-              return Card(
-                child: ListTile(
-                  leading: Icon(
-                    Icons.rule_rounded,
-                    color: rule.enabled
-                        ? colorScheme.primary
-                        : colorScheme.onSurfaceVariant,
-                  ),
-                  title: Text(payeeName),
-                  subtitle: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(envelopeName),
-                      if (!rule.enabled)
-                        Text(
-                          l10n.transactionRulesDisabled,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: colorScheme.error,
-                            fontStyle: FontStyle.italic,
-                          ),
-                        ),
-                    ],
-                  ),
-                  trailing: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Switch(
-                        value: rule.enabled,
-                        onChanged: (enabled) => _toggleRule(
-                          context,
-                          ref,
-                          ruleId: ruleId,
-                          enabled: enabled,
-                        ),
-                      ),
-                      IconButton(
-                        icon: Icon(
-                          Icons.delete_outline,
-                          color: colorScheme.error,
-                        ),
-                        onPressed: () =>
-                            _deleteRule(context, ref, ruleId: ruleId),
-                      ),
-                    ],
-                  ),
-                  isThreeLine: !rule.enabled,
+          return ListView(
+            padding: const EdgeInsets.all(SpacingTokens.md),
+            children: [
+              _RuleSummaryCard(
+                totalRules: rules.length,
+                enabledRules: enabledCount,
+                disabledRules: disabledCount,
+              ),
+              const SizedBox(height: SpacingTokens.md),
+              SizedBox(
+                height: 36,
+                child: ListView(
+                  scrollDirection: Axis.horizontal,
+                  children: [
+                    _RuleFilterChip(
+                      label: l10n.transactionFilterAll,
+                      selected: viewFilter.value == RuleViewFilter.all,
+                      onTap: () => viewFilter.value = RuleViewFilter.all,
+                    ),
+                    const SizedBox(width: SpacingTokens.sm),
+                    _RuleFilterChip(
+                      label: l10n.transactionRulesEnabled,
+                      selected: viewFilter.value == RuleViewFilter.enabled,
+                      onTap: () => viewFilter.value = RuleViewFilter.enabled,
+                      color: YnabPalette.progressGreen,
+                    ),
+                    const SizedBox(width: SpacingTokens.sm),
+                    _RuleFilterChip(
+                      label: l10n.transactionRulesDisabled,
+                      selected: viewFilter.value == RuleViewFilter.disabled,
+                      onTap: () => viewFilter.value = RuleViewFilter.disabled,
+                      color: YnabPalette.negative,
+                    ),
+                  ],
                 ),
-              );
-            },
+              ),
+              const SizedBox(height: SpacingTokens.md),
+              if (filteredRules.isEmpty)
+                Card(
+                  margin: EdgeInsets.zero,
+                  color: YnabPalette.surface,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(RadiusTokens.md),
+                    side: const BorderSide(color: YnabPalette.divider),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(SpacingTokens.md),
+                    child: Text(
+                      l10n.transactionNoResults,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: YnabPalette.mutedText,
+                      ),
+                    ),
+                  ),
+                ),
+              ...filteredRules.map((rule) {
+                final ruleId = rule.id?.toString() ?? '';
+                final payeeName =
+                    payeeNames[rule.payeeId.toString()] ?? 'Unknown';
+                final envelopeName =
+                    envelopeNames[rule.targetEnvelopeId.toString()] ??
+                    'Unknown';
+                return _RuleTile(
+                  payeeName: payeeName,
+                  envelopeName: envelopeName,
+                  enabled: rule.enabled,
+                  onToggle: (enabled) => _toggleRule(
+                    context,
+                    ref,
+                    ruleId: ruleId,
+                    enabled: enabled,
+                  ),
+                  onDelete: () => _deleteRule(context, ref, ruleId: ruleId),
+                );
+              }),
+            ],
           );
         },
       ),
@@ -260,6 +306,255 @@ class RuleListScreen extends HookConsumerWidget {
         ),
       );
     }
+  }
+}
+
+class _RuleSummaryCard extends HookWidget {
+  const _RuleSummaryCard({
+    required this.totalRules,
+    required this.enabledRules,
+    required this.disabledRules,
+  });
+
+  final int totalRules;
+  final int enabledRules;
+  final int disabledRules;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      color: YnabPalette.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(RadiusTokens.md),
+        side: const BorderSide(color: YnabPalette.divider),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(SpacingTokens.md),
+        child: Column(
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(SpacingTokens.md),
+              decoration: BoxDecoration(
+                color: YnabPalette.accentPurple,
+                borderRadius: BorderRadius.circular(RadiusTokens.md),
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    l10n.transactionRulesTitle,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: SpacingTokens.xs),
+                  Text(
+                    l10n.transactionRulesTotalCount(totalRules),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: YnabPalette.mutedText,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: SpacingTokens.md),
+            Row(
+              children: [
+                Expanded(
+                  child: _RuleMetric(
+                    label: l10n.transactionRulesEnabled,
+                    value: '$enabledRules',
+                    color: YnabPalette.progressGreen,
+                  ),
+                ),
+                const SizedBox(width: SpacingTokens.sm),
+                Expanded(
+                  child: _RuleMetric(
+                    label: l10n.transactionRulesDisabled,
+                    value: '$disabledRules',
+                    color: YnabPalette.negative,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RuleMetric extends HookWidget {
+  const _RuleMetric({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SpacingTokens.sm,
+        vertical: SpacingTokens.xs,
+      ),
+      decoration: BoxDecoration(
+        color: color.withAlpha(26),
+        borderRadius: BorderRadius.circular(RadiusTokens.sm),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: YnabPalette.mutedText,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: theme.textTheme.titleSmall?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RuleFilterChip extends HookWidget {
+  const _RuleFilterChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.color,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final chipColor = color ?? YnabPalette.accentBlue;
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      onSelected: (_) => onTap(),
+      backgroundColor: YnabPalette.surface,
+      selectedColor: chipColor.withAlpha(24),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(RadiusTokens.sm),
+        side: BorderSide(
+          color: selected ? chipColor.withAlpha(130) : YnabPalette.divider,
+        ),
+      ),
+      labelStyle: theme.textTheme.labelMedium?.copyWith(
+        color: selected ? chipColor : YnabPalette.mutedText,
+        fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+      ),
+      showCheckmark: false,
+      visualDensity: VisualDensity.compact,
+    );
+  }
+}
+
+class _RuleTile extends HookWidget {
+  const _RuleTile({
+    required this.payeeName,
+    required this.envelopeName,
+    required this.enabled,
+    required this.onToggle,
+    required this.onDelete,
+  });
+
+  final String payeeName;
+  final String envelopeName;
+  final bool enabled;
+  final ValueChanged<bool> onToggle;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.only(bottom: SpacingTokens.sm),
+      color: YnabPalette.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(RadiusTokens.md),
+        side: const BorderSide(color: YnabPalette.divider),
+      ),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: SpacingTokens.md,
+          vertical: SpacingTokens.xs,
+        ),
+        leading: CircleAvatar(
+          backgroundColor: enabled
+              ? YnabPalette.accentPurple.withAlpha(90)
+              : YnabPalette.surfaceMuted,
+          child: Icon(
+            Icons.rule_rounded,
+            color: enabled ? YnabPalette.accentBlue : YnabPalette.mutedText,
+            size: 18,
+          ),
+        ),
+        title: Text(payeeName, style: theme.textTheme.titleMedium),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              envelopeName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: YnabPalette.mutedText,
+              ),
+            ),
+            if (!enabled)
+              Text(
+                l10n.transactionRulesDisabled,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: YnabPalette.negative,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+          ],
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Switch.adaptive(
+              value: enabled,
+              onChanged: onToggle,
+              activeTrackColor: YnabPalette.accentBlue,
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              color: YnabPalette.negative,
+              onPressed: onDelete,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/add_expense_screen.dart
@@ -133,12 +133,18 @@ class AddExpenseScreen extends HookConsumerWidget {
         backgroundColor: YnabPalette.appBackground,
         surfaceTintColor: Colors.transparent,
         scrolledUnderElevation: 0,
-        leadingWidth: 90,
-        leading: TextButton.icon(
-          onPressed: () =>
-              context.goNamed(planRoute, pathParameters: {'id': budgetId}),
-          icon: const Icon(Icons.arrow_back, size: 16),
-          label: Text(l10n.dialogCancel),
+        leadingWidth: 88,
+        leading: Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton(
+            onPressed: () =>
+                context.goNamed(planRoute, pathParameters: {'id': budgetId}),
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: SpacingTokens.sm),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(l10n.dialogCancel),
+          ),
         ),
         title: Text(l10n.addTransactionSheetTitle),
       ),

--- a/openbudget_app/lib/src/features/transactions/screens/add_income_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/add_income_screen.dart
@@ -93,12 +93,18 @@ class AddIncomeScreen extends HookConsumerWidget {
         backgroundColor: YnabPalette.appBackground,
         surfaceTintColor: Colors.transparent,
         scrolledUnderElevation: 0,
-        leadingWidth: 90,
-        leading: TextButton.icon(
-          onPressed: () =>
-              context.goNamed(planRoute, pathParameters: {'id': budgetId}),
-          icon: const Icon(Icons.arrow_back, size: 16),
-          label: Text(l10n.dialogCancel),
+        leadingWidth: 88,
+        leading: Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton(
+            onPressed: () =>
+                context.goNamed(planRoute, pathParameters: {'id': budgetId}),
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: SpacingTokens.sm),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(l10n.dialogCancel),
+          ),
         ),
         title: Text(l10n.addTransactionSheetTitle),
       ),

--- a/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
@@ -293,88 +293,88 @@ class TransactionListScreen extends HookConsumerWidget {
                   horizontal: SpacingTokens.md,
                   vertical: SpacingTokens.sm,
                 ),
-                child: SizedBox(
-                  height: 36,
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: ListView(
-                          scrollDirection: Axis.horizontal,
-                          children: [
-                            _FilterChip(
-                              label: l10n.transactionFilterAll,
-                              selected: filter.value == TransactionFilter.all,
-                              onSelected: () =>
-                                  filter.value = TransactionFilter.all,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    SizedBox(
+                      height: 36,
+                      child: ListView(
+                        scrollDirection: Axis.horizontal,
+                        children: [
+                          _FilterChip(
+                            label: l10n.transactionFilterAll,
+                            selected: filter.value == TransactionFilter.all,
+                            onSelected: () =>
+                                filter.value = TransactionFilter.all,
+                          ),
+                          const SizedBox(width: SpacingTokens.sm),
+                          _FilterChip(
+                            label: l10n.transactionFilterIncome,
+                            selected: filter.value == TransactionFilter.income,
+                            onSelected: () =>
+                                filter.value = TransactionFilter.income,
+                            color: ColorTokens.secondary,
+                          ),
+                          const SizedBox(width: SpacingTokens.sm),
+                          _FilterChip(
+                            label: l10n.transactionFilterExpense,
+                            selected: filter.value == TransactionFilter.expense,
+                            onSelected: () =>
+                                filter.value = TransactionFilter.expense,
+                            color: ColorTokens.error,
+                          ),
+                          const SizedBox(width: SpacingTokens.sm),
+                          _FilterChip(
+                            label: dateRangeStart.value != null
+                                ? _formatShortDate(dateRangeStart.value!)
+                                : l10n.transactionDateRangeFilter,
+                            selected: dateRangeStart.value != null,
+                            onSelected: () => _pickDateRange(
+                              context,
+                              dateRangeStart,
+                              dateRangeEnd,
+                              transactions,
                             ),
-                            const SizedBox(width: SpacingTokens.sm),
-                            _FilterChip(
-                              label: l10n.transactionFilterIncome,
-                              selected:
-                                  filter.value == TransactionFilter.income,
-                              onSelected: () =>
-                                  filter.value = TransactionFilter.income,
-                              color: ColorTokens.secondary,
-                            ),
-                            const SizedBox(width: SpacingTokens.sm),
-                            _FilterChip(
-                              label: l10n.transactionFilterExpense,
-                              selected:
-                                  filter.value == TransactionFilter.expense,
-                              onSelected: () =>
-                                  filter.value = TransactionFilter.expense,
-                              color: ColorTokens.error,
-                            ),
-                            const SizedBox(width: SpacingTokens.sm),
-                            _FilterChip(
-                              label: dateRangeStart.value != null
-                                  ? _formatShortDate(dateRangeStart.value!)
-                                  : l10n.transactionDateRangeFilter,
-                              selected: dateRangeStart.value != null,
-                              onSelected: () => _pickDateRange(
-                                context,
-                                dateRangeStart,
-                                dateRangeEnd,
-                                transactions,
+                          ),
+                          if (dateRangeStart.value != null) ...[
+                            IconButton(
+                              icon: const Icon(Icons.clear, size: 16),
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(
+                                minWidth: 24,
+                                minHeight: 24,
                               ),
-                            ),
-                            if (dateRangeStart.value != null) ...[
-                              IconButton(
-                                icon: const Icon(Icons.clear, size: 16),
-                                padding: EdgeInsets.zero,
-                                constraints: const BoxConstraints(
-                                  minWidth: 24,
-                                  minHeight: 24,
-                                ),
-                                tooltip: l10n.transactionDateRangeClear,
-                                onPressed: () {
-                                  dateRangeStart.value = null;
-                                  dateRangeEnd.value = null;
-                                },
-                              ),
-                            ],
-                            const SizedBox(width: SpacingTokens.sm),
-                            _FlagFilterChip(
-                              selectedFlag: flagFilter.value,
-                              onSelected: (flag) => flagFilter.value = flag,
-                            ),
-                            const SizedBox(width: SpacingTokens.sm),
-                            _StatusFilterChip(
-                              value: statusFilter.value,
-                              onSelected: (v) => statusFilter.value = v,
+                              tooltip: l10n.transactionDateRangeClear,
+                              onPressed: () {
+                                dateRangeStart.value = null;
+                                dateRangeEnd.value = null;
+                              },
                             ),
                           ],
-                        ),
+                          const SizedBox(width: SpacingTokens.sm),
+                          _FlagFilterChip(
+                            selectedFlag: flagFilter.value,
+                            onSelected: (flag) => flagFilter.value = flag,
+                          ),
+                          const SizedBox(width: SpacingTokens.sm),
+                          _StatusFilterChip(
+                            value: statusFilter.value,
+                            onSelected: (v) => statusFilter.value = v,
+                          ),
+                        ],
                       ),
-                      const SizedBox(width: SpacingTokens.sm),
-                      Text(
+                    ),
+                    const SizedBox(height: SpacingTokens.xs),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: Text(
                         l10n.transactionResultCount(filtered.length),
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: colorScheme.onSurfaceVariant,
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
               if (filtered.isEmpty)

--- a/openbudget_app/test/features/recurring/screens/recurring_list_screen_test.dart
+++ b/openbudget_app/test/features/recurring/screens/recurring_list_screen_test.dart
@@ -29,6 +29,7 @@ Budget _makeBudget() => Budget(
 RecurringTransaction _makeRecurring({
   String description = 'Netflix Subscription',
   int amountCents = -1499,
+  String currencyCode = 'USD',
   String frequency = 'monthly',
   DateTime? nextOccurrence,
   bool isActive = true,
@@ -38,7 +39,7 @@ RecurringTransaction _makeRecurring({
     id: id,
     description: description,
     amountCents: amountCents,
-    currencyCode: 'USD',
+    currencyCode: currencyCode,
     budgetId: _budgetUuid,
     frequency: frequency,
     nextOccurrence: nextOccurrence ?? DateTime(2099, 12, 31),
@@ -324,6 +325,121 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(Switch), findsWidgets);
+    });
+
+    testWidgets('renders summary card and filter chips', (tester) async {
+      final items = [
+        _makeRecurring(
+          description: 'Rent',
+          amountCents: -150000,
+          nextOccurrence: DateTime(2020),
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000061'),
+        ),
+        _makeRecurring(
+          description: 'Salary',
+          amountCents: 500000,
+          nextOccurrence: DateTime(2099),
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000062'),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
+            recurringListProvider.overrideWith((ref, budgetId) async => items),
+          ],
+          child: MaterialApp(
+            theme: OpenBudgetTheme.light,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const RecurringListScreen(budgetId: _budgetId),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Expense'), findsWidgets);
+      expect(find.text('Income'), findsWidgets);
+      expect(find.byType(ChoiceChip), findsWidgets);
+    });
+
+    testWidgets('shows multi-currency totals in summary card', (tester) async {
+      final items = [
+        _makeRecurring(
+          description: 'Rent',
+          amountCents: -280000,
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000081'),
+        ),
+        _makeRecurring(
+          description: 'Insurance',
+          amountCents: -50000,
+          currencyCode: 'EUR',
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000082'),
+        ),
+        _makeRecurring(
+          description: 'Salary',
+          amountCents: 800000,
+          currencyCode: 'EUR',
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000083'),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
+            recurringListProvider.overrideWith((ref, budgetId) async => items),
+          ],
+          child: MaterialApp(
+            theme: OpenBudgetTheme.light,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const RecurringListScreen(budgetId: _budgetId),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('USD'), findsWidgets);
+      expect(find.textContaining('EUR'), findsWidgets);
+    });
+
+    testWidgets('filters recurring list by selected chip', (tester) async {
+      final items = [
+        _makeRecurring(
+          description: 'Rent',
+          amountCents: -150000,
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000071'),
+        ),
+        _makeRecurring(
+          description: 'Salary',
+          amountCents: 500000,
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000072'),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
+            recurringListProvider.overrideWith((ref, budgetId) async => items),
+          ],
+          child: MaterialApp(
+            theme: OpenBudgetTheme.light,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const RecurringListScreen(budgetId: _budgetId),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Income'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Salary'), findsOneWidget);
+      expect(find.text('Rent'), findsNothing);
     });
   });
 }

--- a/openbudget_app/test/features/transaction_rules/screens/rule_list_screen_test.dart
+++ b/openbudget_app/test/features/transaction_rules/screens/rule_list_screen_test.dart
@@ -371,7 +371,94 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Disabled'), findsOneWidget);
+      expect(find.text('Disabled'), findsWidgets);
+    });
+
+    testWidgets('renders summary card and filter chips', (tester) async {
+      final payee = _makePayee(name: 'Amazon');
+      final rules = [
+        _makeRule(
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000101'),
+          payeeId: payee.id,
+        ),
+        _makeRule(
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000102'),
+          payeeId: payee.id,
+          enabled: false,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ruleListProvider.overrideWith((ref, budgetId) async => rules),
+            payeeListProvider.overrideWith((ref, budgetId) async => [payee]),
+            budgetSummaryProvider.overrideWith(
+              (ref, budgetId) async => _makeEmptySummary(),
+            ),
+          ],
+          child: MaterialApp(
+            theme: OpenBudgetTheme.light,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const RuleListScreen(budgetId: _budgetId),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Enabled'), findsWidgets);
+      expect(find.text('Disabled'), findsWidgets);
+      expect(find.widgetWithText(ChoiceChip, 'All'), findsOneWidget);
+    });
+
+    testWidgets('filters by disabled rules chip', (tester) async {
+      final payeeEnabled = _makePayee(
+        name: 'Enabled Payee',
+        id: UuidValue.fromString('00000000-0000-0000-0000-000000000111'),
+      );
+      final payeeDisabled = _makePayee(
+        name: 'Disabled Payee',
+        id: UuidValue.fromString('00000000-0000-0000-0000-000000000112'),
+      );
+      final rules = [
+        _makeRule(
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000121'),
+          payeeId: payeeEnabled.id,
+        ),
+        _makeRule(
+          id: UuidValue.fromString('00000000-0000-0000-0000-000000000122'),
+          payeeId: payeeDisabled.id,
+          enabled: false,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ruleListProvider.overrideWith((ref, budgetId) async => rules),
+            payeeListProvider.overrideWith(
+              (ref, budgetId) async => [payeeEnabled, payeeDisabled],
+            ),
+            budgetSummaryProvider.overrideWith(
+              (ref, budgetId) async => _makeEmptySummary(),
+            ),
+          ],
+          child: MaterialApp(
+            theme: OpenBudgetTheme.light,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const RuleListScreen(budgetId: _budgetId),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Disabled'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Disabled Payee'), findsOneWidget);
+      expect(find.text('Enabled Payee'), findsNothing);
     });
   });
 }

--- a/openbudget_app/test/features/transactions/screens/add_expense_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/add_expense_screen_test.dart
@@ -236,11 +236,11 @@ void main() {
       expect(find.byIcon(Icons.arrow_upward_rounded), findsOneWidget);
     });
 
-    testWidgets('shows back button', (tester) async {
+    testWidgets('shows cancel button', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
     });
 
     testWidgets('shows description text field', (tester) async {

--- a/openbudget_app/test/features/transactions/screens/add_income_screen_test.dart
+++ b/openbudget_app/test/features/transactions/screens/add_income_screen_test.dart
@@ -193,11 +193,11 @@ void main() {
       expect(find.byIcon(Icons.arrow_downward_rounded), findsOneWidget);
     });
 
-    testWidgets('shows back button', (tester) async {
+    testWidgets('shows cancel button', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
     });
 
     testWidgets('renders payee dropdown items when payees available', (


### PR DESCRIPTION
## Problem
The YNAB-parity flow work still had a few production gaps in this branch:
- iOS add transaction headers and filters had layout clipping/overflow issues.
- Recurring and Transaction Rules screens needed closer YNAB-style list/summary/filter behavior.
- New labels in those screens were hardcoded instead of localization-backed.
- Additional end-to-end flow coverage for More → Recurring/Rules was missing.

## Root Cause
The earlier implementation covered most base flows, but summary/filter UX and iOS-specific layout constraints were not fully finalized, and test coverage did not include the new More-menu entry points.

## What Changed
- Polished transaction flows:
  - Updated add expense/income app-bar cancel actions for iOS-safe layout.
  - Refined transaction list filter row so `Date range` and result count render cleanly.
- Polished recurring flows:
  - Added YNAB-styled summary card, filters (`All/Expense/Income/Due now`), and filtered list behavior.
  - Added multi-currency summary formatting support for recurring totals.
- Polished rules flows:
  - Added YNAB-styled summary card, filters (`All/Enabled/Disabled`), and filtered list behavior.
  - Replaced hardcoded labels with localization-backed strings.
- Localization additions:
  - Added `recurringTotalCount`, `transactionRulesEnabled`, and `transactionRulesTotalCount`.
  - Regenerated localization artifacts.
- Test coverage:
  - Added `integration_test/more_flow_test.dart` for More → Recurring and More → Rules navigation/dialog flows.
  - Expanded recurring/rules widget tests for summary/filter behavior and multi-currency recurring summary.
  - Updated add income/expense widget tests to reflect new cancel-header behavior.

## Multi-Currency
This update improves multi-currency support in the new recurring flow UI by aggregating and formatting recurring summary totals across currencies (including currency code when multiple currencies are present), while preserving existing cross-currency transaction/account behavior.

## Validation
### Static analysis
- `cd openbudget_app && fvm flutter analyze`

### Unit/Widget tests
- `cd openbudget_app && fvm flutter test`

### iOS integration/e2e flow tests (iPhone 17 simulator)
- `cd openbudget_app && fvm flutter test integration_test/account_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/app_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/auth_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/budget_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/more_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/tab_navigation_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`
- `cd openbudget_app && fvm flutter test integration_test/transaction_flow_test.dart -d 0B8897AE-9596-48C7-A582-D1D4BB9AA055`

## iOS Screenshots
### Transactions
![Transaction list](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase5-ios-v2/transaction-list-v2.png)

### Add Expense
![Add expense](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase5-ios-v2/add-expense-v2.png)

### Add Income
![Add income](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase5-ios-v2/add-income-v2.png)

### Recurring Transactions
![Recurring transactions](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase5-ios-v2/recurring-v2.png)

### Transaction Rules
![Transaction rules](https://f002.backblazeb2.com/file/openbudget/uploads/2026/02/ynab-phase5-ios-v2/rules-v2.png)
