### PR TITLE
ci: fix dprint formatting drift

### DIFF
--- a/openbudget_app/flutter_launcher_icons.yaml
+++ b/openbudget_app/flutter_launcher_icons.yaml
@@ -10,8 +10,8 @@ flutter_launcher_icons:
   web:
     generate: true
     image_path: assets/branding/logos/ob_primary_light_1024.png
-    background_color: '#F2F7FF'
-    theme_color: '#2C4BAA'
+    background_color: "#F2F7FF"
+    theme_color: "#2C4BAA"
   windows:
     generate: true
     image_path: assets/branding/logos/ob_primary_light_1024.png

--- a/openbudget_app/flutter_native_splash.yaml
+++ b/openbudget_app/flutter_native_splash.yaml
@@ -1,6 +1,6 @@
 flutter_native_splash:
-  color: '#F2F7FF'
-  color_dark: '#050A13'
+  color: "#F2F7FF"
+  color_dark: "#050A13"
   image: assets/branding/logos/ob_primary_light_1024.png
   image_dark: assets/branding/logos/ob_primary_dark_1024.png
   android: true
@@ -8,9 +8,9 @@ flutter_native_splash:
   web: true
   fullscreen: true
   android_12:
-    color: '#F2F7FF'
-    color_dark: '#050A13'
+    color: "#F2F7FF"
+    color_dark: "#050A13"
     image: assets/branding/logos/ob_primary_light_1024.png
     image_dark: assets/branding/logos/ob_primary_dark_1024.png
-    icon_background_color: '#F2F7FF'
-    icon_background_color_dark: '#050A13'
+    icon_background_color: "#F2F7FF"
+    icon_background_color_dark: "#050A13"

--- a/openbudget_app/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/openbudget_app/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,1 +1,290 @@
-{"images":[{"size":"20x20","idiom":"universal","filename":"Icon-App-20x20@2x.png","scale":"2x","platform":"ios"},{"size":"20x20","idiom":"universal","filename":"Icon-App-20x20@3x.png","scale":"3x","platform":"ios"},{"size":"29x29","idiom":"universal","filename":"Icon-App-29x29@2x.png","scale":"2x","platform":"ios"},{"size":"29x29","idiom":"universal","filename":"Icon-App-29x29@3x.png","scale":"3x","platform":"ios"},{"size":"38x38","idiom":"universal","filename":"Icon-App-38x38@2x.png","scale":"2x","platform":"ios"},{"size":"38x38","idiom":"universal","filename":"Icon-App-38x38@3x.png","scale":"3x","platform":"ios"},{"size":"40x40","idiom":"universal","filename":"Icon-App-40x40@2x.png","scale":"2x","platform":"ios"},{"size":"40x40","idiom":"universal","filename":"Icon-App-40x40@3x.png","scale":"3x","platform":"ios"},{"size":"60x60","idiom":"universal","filename":"Icon-App-60x60@2x.png","scale":"2x","platform":"ios"},{"size":"60x60","idiom":"universal","filename":"Icon-App-60x60@3x.png","scale":"3x","platform":"ios"},{"size":"64x64","idiom":"universal","filename":"Icon-App-64x64@2x.png","scale":"2x","platform":"ios"},{"size":"64x64","idiom":"universal","filename":"Icon-App-64x64@3x.png","scale":"3x","platform":"ios"},{"size":"68x68","idiom":"universal","filename":"Icon-App-68x68@2x.png","scale":"2x","platform":"ios"},{"size":"76x76","idiom":"universal","filename":"Icon-App-76x76@2x.png","scale":"2x","platform":"ios"},{"size":"83.5x83.5","idiom":"universal","filename":"Icon-App-83.5x83.5@2x.png","scale":"2x","platform":"ios"},{"size":"1024x1024","idiom":"universal","filename":"Icon-App-1024x1024@1x.png","scale":"1x","platform":"ios"},{"size":"1024x1024","idiom":"ios-marketing","filename":"Icon-App-1024x1024@1x.png","scale":"1x"},{"size":"20x20","idiom":"universal","filename":"Icon-App-Dark-20x20@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"20x20","idiom":"universal","filename":"Icon-App-Dark-20x20@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"29x29","idiom":"universal","filename":"Icon-App-Dark-29x29@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"29x29","idiom":"universal","filename":"Icon-App-Dark-29x29@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"38x38","idiom":"universal","filename":"Icon-App-Dark-38x38@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"38x38","idiom":"universal","filename":"Icon-App-Dark-38x38@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"40x40","idiom":"universal","filename":"Icon-App-Dark-40x40@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"40x40","idiom":"universal","filename":"Icon-App-Dark-40x40@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"60x60","idiom":"universal","filename":"Icon-App-Dark-60x60@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"60x60","idiom":"universal","filename":"Icon-App-Dark-60x60@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"64x64","idiom":"universal","filename":"Icon-App-Dark-64x64@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"64x64","idiom":"universal","filename":"Icon-App-Dark-64x64@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"68x68","idiom":"universal","filename":"Icon-App-Dark-68x68@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"76x76","idiom":"universal","filename":"Icon-App-Dark-76x76@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"83.5x83.5","idiom":"universal","filename":"Icon-App-Dark-83.5x83.5@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"1024x1024","idiom":"universal","filename":"Icon-App-Dark-1024x1024@1x.png","scale":"1x","platform":"ios","appearances":[{"appearance":"luminosity","value":"dark"}]},{"size":"20x20","idiom":"universal","filename":"Icon-App-Tinted-20x20@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"20x20","idiom":"universal","filename":"Icon-App-Tinted-20x20@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"29x29","idiom":"universal","filename":"Icon-App-Tinted-29x29@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"29x29","idiom":"universal","filename":"Icon-App-Tinted-29x29@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"38x38","idiom":"universal","filename":"Icon-App-Tinted-38x38@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"38x38","idiom":"universal","filename":"Icon-App-Tinted-38x38@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"40x40","idiom":"universal","filename":"Icon-App-Tinted-40x40@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"40x40","idiom":"universal","filename":"Icon-App-Tinted-40x40@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"60x60","idiom":"universal","filename":"Icon-App-Tinted-60x60@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"60x60","idiom":"universal","filename":"Icon-App-Tinted-60x60@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"64x64","idiom":"universal","filename":"Icon-App-Tinted-64x64@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"64x64","idiom":"universal","filename":"Icon-App-Tinted-64x64@3x.png","scale":"3x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"68x68","idiom":"universal","filename":"Icon-App-Tinted-68x68@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"76x76","idiom":"universal","filename":"Icon-App-Tinted-76x76@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"83.5x83.5","idiom":"universal","filename":"Icon-App-Tinted-83.5x83.5@2x.png","scale":"2x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]},{"size":"1024x1024","idiom":"universal","filename":"Icon-App-Tinted-1024x1024@1x.png","scale":"1x","platform":"ios","appearances":[{"appearance":"luminosity","value":"tinted"}]}],"info":{"version":1,"author":"xcode"}}
+{
+  "images": [
+    { "size": "20x20", "idiom": "universal", "filename": "Icon-App-20x20@2x.png", "scale": "2x", "platform": "ios" },
+    { "size": "20x20", "idiom": "universal", "filename": "Icon-App-20x20@3x.png", "scale": "3x", "platform": "ios" },
+    { "size": "29x29", "idiom": "universal", "filename": "Icon-App-29x29@2x.png", "scale": "2x", "platform": "ios" },
+    { "size": "29x29", "idiom": "universal", "filename": "Icon-App-29x29@3x.png", "scale": "3x", "platform": "ios" },
+    { "size": "38x38", "idiom": "universal", "filename": "Icon-App-38x38@2x.png", "scale": "2x", "platform": "ios" },
+    { "size": "38x38", "idiom": "universal", "filename": "Icon-App-38x38@3x.png", "scale": "3x", "platform": "ios" },
+    { "size": "40x40", "idiom": "universal", "filename": "Icon-App-40x40@2x.png", "scale": "2x", "platform": "ios" },
+    { "size": "40x40", "idiom": "universal", "filename": "Icon-App-40x40@3x.png", "scale": "3x", "platform": "ios" },
+    { "size": "60x60", "idiom": "universal", "filename": "Icon-App-60x60@2x.png", "scale": "2x", "platform": "ios" },
+    { "size": "60x60", "idiom": "universal", "filename": "Icon-App-60x60@3x.png", "scale": "3x", "platform": "ios" },
+    { "size": "64x64", "idiom": "universal", "filename": "Icon-App-64x64@2x.png", "scale": "2x", "platform": "ios" },
+    { "size": "64x64", "idiom": "universal", "filename": "Icon-App-64x64@3x.png", "scale": "3x", "platform": "ios" },
+    { "size": "68x68", "idiom": "universal", "filename": "Icon-App-68x68@2x.png", "scale": "2x", "platform": "ios" },
+    { "size": "76x76", "idiom": "universal", "filename": "Icon-App-76x76@2x.png", "scale": "2x", "platform": "ios" },
+    {
+      "size": "83.5x83.5",
+      "idiom": "universal",
+      "filename": "Icon-App-83.5x83.5@2x.png",
+      "scale": "2x",
+      "platform": "ios"
+    },
+    {
+      "size": "1024x1024",
+      "idiom": "universal",
+      "filename": "Icon-App-1024x1024@1x.png",
+      "scale": "1x",
+      "platform": "ios"
+    },
+    { "size": "1024x1024", "idiom": "ios-marketing", "filename": "Icon-App-1024x1024@1x.png", "scale": "1x" },
+    {
+      "size": "20x20",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-20x20@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "20x20",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-20x20@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "29x29",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-29x29@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "29x29",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-29x29@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "38x38",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-38x38@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "38x38",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-38x38@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "40x40",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-40x40@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "40x40",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-40x40@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "60x60",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-60x60@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "60x60",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-60x60@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "64x64",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-64x64@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "64x64",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-64x64@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "68x68",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-68x68@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "76x76",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-76x76@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "83.5x83.5",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-83.5x83.5@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "1024x1024",
+      "idiom": "universal",
+      "filename": "Icon-App-Dark-1024x1024@1x.png",
+      "scale": "1x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "dark" }]
+    },
+    {
+      "size": "20x20",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-20x20@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "20x20",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-20x20@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "29x29",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-29x29@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "29x29",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-29x29@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "38x38",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-38x38@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "38x38",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-38x38@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "40x40",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-40x40@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "40x40",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-40x40@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "60x60",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-60x60@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "60x60",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-60x60@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "64x64",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-64x64@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "64x64",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-64x64@3x.png",
+      "scale": "3x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "68x68",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-68x68@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "76x76",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-76x76@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "83.5x83.5",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-83.5x83.5@2x.png",
+      "scale": "2x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    },
+    {
+      "size": "1024x1024",
+      "idiom": "universal",
+      "filename": "Icon-App-Tinted-1024x1024@1x.png",
+      "scale": "1x",
+      "platform": "ios",
+      "appearances": [{ "appearance": "luminosity", "value": "tinted" }]
+    }
+  ],
+  "info": { "version": 1, "author": "xcode" }
+}

--- a/openbudget_app/ios/Runner/Assets.xcassets/LaunchBackground.imageset/Contents.json
+++ b/openbudget_app/ios/Runner/Assets.xcassets/LaunchBackground.imageset/Contents.json
@@ -1,22 +1,22 @@
 {
-  "images" : [
+  "images": [
     {
-      "filename" : "background.png",
-      "idiom" : "universal"
+      "filename": "background.png",
+      "idiom": "universal"
     },
     {
-      "appearances" : [
+      "appearances": [
         {
-          "appearance" : "luminosity",
-          "value" : "dark"
+          "appearance": "luminosity",
+          "value": "dark"
         }
       ],
-      "filename" : "darkbackground.png",
-      "idiom" : "universal"
+      "filename": "darkbackground.png",
+      "idiom": "universal"
     }
   ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
+  "info": {
+    "author": "xcode",
+    "version": 1
   }
 }

--- a/openbudget_app/ios/Runner/Assets.xcassets/LaunchImage.imageset/Contents.json
+++ b/openbudget_app/ios/Runner/Assets.xcassets/LaunchImage.imageset/Contents.json
@@ -1,56 +1,56 @@
 {
-  "images" : [
+  "images": [
     {
-      "filename" : "LaunchImage.png",
-      "idiom" : "universal",
-      "scale" : "1x"
+      "filename": "LaunchImage.png",
+      "idiom": "universal",
+      "scale": "1x"
     },
     {
-      "appearances" : [
+      "appearances": [
         {
-          "appearance" : "luminosity",
-          "value" : "dark"
+          "appearance": "luminosity",
+          "value": "dark"
         }
       ],
-      "filename" : "LaunchImageDark.png",
-      "idiom" : "universal",
-      "scale" : "1x"
+      "filename": "LaunchImageDark.png",
+      "idiom": "universal",
+      "scale": "1x"
     },
     {
-      "filename" : "LaunchImage@2x.png",
-      "idiom" : "universal",
-      "scale" : "2x"
+      "filename": "LaunchImage@2x.png",
+      "idiom": "universal",
+      "scale": "2x"
     },
     {
-      "appearances" : [
+      "appearances": [
         {
-          "appearance" : "luminosity",
-          "value" : "dark"
+          "appearance": "luminosity",
+          "value": "dark"
         }
       ],
-      "filename" : "LaunchImageDark@2x.png",
-      "idiom" : "universal",
-      "scale" : "2x"
+      "filename": "LaunchImageDark@2x.png",
+      "idiom": "universal",
+      "scale": "2x"
     },
     {
-      "filename" : "LaunchImage@3x.png",
-      "idiom" : "universal",
-      "scale" : "3x"
+      "filename": "LaunchImage@3x.png",
+      "idiom": "universal",
+      "scale": "3x"
     },
     {
-      "appearances" : [
+      "appearances": [
         {
-          "appearance" : "luminosity",
-          "value" : "dark"
+          "appearance": "luminosity",
+          "value": "dark"
         }
       ],
-      "filename" : "LaunchImageDark@3x.png",
-      "idiom" : "universal",
-      "scale" : "3x"
+      "filename": "LaunchImageDark@3x.png",
+      "idiom": "universal",
+      "scale": "3x"
     }
   ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
+  "info": {
+    "author": "xcode",
+    "version": 1
   }
 }

--- a/openbudget_app/macos/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/openbudget_app/macos/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,68 +1,68 @@
 {
-    "info": {
-        "version": 1,
-        "author": "xcode"
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "images": [
+    {
+      "size": "16x16",
+      "idiom": "mac",
+      "filename": "app_icon_16.png",
+      "scale": "1x"
     },
-    "images": [
-        {
-            "size": "16x16",
-            "idiom": "mac",
-            "filename": "app_icon_16.png",
-            "scale": "1x"
-        },
-        {
-            "size": "16x16",
-            "idiom": "mac",
-            "filename": "app_icon_32.png",
-            "scale": "2x"
-        },
-        {
-            "size": "32x32",
-            "idiom": "mac",
-            "filename": "app_icon_32.png",
-            "scale": "1x"
-        },
-        {
-            "size": "32x32",
-            "idiom": "mac",
-            "filename": "app_icon_64.png",
-            "scale": "2x"
-        },
-        {
-            "size": "128x128",
-            "idiom": "mac",
-            "filename": "app_icon_128.png",
-            "scale": "1x"
-        },
-        {
-            "size": "128x128",
-            "idiom": "mac",
-            "filename": "app_icon_256.png",
-            "scale": "2x"
-        },
-        {
-            "size": "256x256",
-            "idiom": "mac",
-            "filename": "app_icon_256.png",
-            "scale": "1x"
-        },
-        {
-            "size": "256x256",
-            "idiom": "mac",
-            "filename": "app_icon_512.png",
-            "scale": "2x"
-        },
-        {
-            "size": "512x512",
-            "idiom": "mac",
-            "filename": "app_icon_512.png",
-            "scale": "1x"
-        },
-        {
-            "size": "512x512",
-            "idiom": "mac",
-            "filename": "app_icon_1024.png",
-            "scale": "2x"
-        }
-    ]
+    {
+      "size": "16x16",
+      "idiom": "mac",
+      "filename": "app_icon_32.png",
+      "scale": "2x"
+    },
+    {
+      "size": "32x32",
+      "idiom": "mac",
+      "filename": "app_icon_32.png",
+      "scale": "1x"
+    },
+    {
+      "size": "32x32",
+      "idiom": "mac",
+      "filename": "app_icon_64.png",
+      "scale": "2x"
+    },
+    {
+      "size": "128x128",
+      "idiom": "mac",
+      "filename": "app_icon_128.png",
+      "scale": "1x"
+    },
+    {
+      "size": "128x128",
+      "idiom": "mac",
+      "filename": "app_icon_256.png",
+      "scale": "2x"
+    },
+    {
+      "size": "256x256",
+      "idiom": "mac",
+      "filename": "app_icon_256.png",
+      "scale": "1x"
+    },
+    {
+      "size": "256x256",
+      "idiom": "mac",
+      "filename": "app_icon_512.png",
+      "scale": "2x"
+    },
+    {
+      "size": "512x512",
+      "idiom": "mac",
+      "filename": "app_icon_512.png",
+      "scale": "1x"
+    },
+    {
+      "size": "512x512",
+      "idiom": "mac",
+      "filename": "app_icon_1024.png",
+      "scale": "2x"
+    }
+  ]
 }

--- a/openbudget_app/web/manifest.json
+++ b/openbudget_app/web/manifest.json
@@ -1,35 +1,35 @@
 {
-    "name": "OpenBudget",
-    "short_name": "OpenBudget",
-    "start_url": ".",
-    "display": "standalone",
-    "background_color": "#F2F7FF",
-    "theme_color": "#2C4BAA",
-    "description": "OpenBudget envelope budgeting app.",
-    "orientation": "portrait-primary",
-    "prefer_related_applications": false,
-    "icons": [
-        {
-            "src": "icons/Icon-192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "icons/Icon-512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        },
-        {
-            "src": "icons/Icon-maskable-192.png",
-            "sizes": "192x192",
-            "type": "image/png",
-            "purpose": "maskable"
-        },
-        {
-            "src": "icons/Icon-maskable-512.png",
-            "sizes": "512x512",
-            "type": "image/png",
-            "purpose": "maskable"
-        }
-    ]
+  "name": "OpenBudget",
+  "short_name": "OpenBudget",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#F2F7FF",
+  "theme_color": "#2C4BAA",
+  "description": "OpenBudget envelope budgeting app.",
+  "orientation": "portrait-primary",
+  "prefer_related_applications": false,
+  "icons": [
+    {
+      "src": "icons/Icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/Icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/Icon-maskable-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "icons/Icon-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
 }

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -58,35 +58,27 @@ class EndpointAccount extends _i1.EndpointRef {
     _i1.UuidValue budgetId, {
     required bool onBudget,
     required int sortOrder,
-  }) => caller.callServerEndpoint<_i3.Account>(
-    'account',
-    'create',
-    {
-      'name': name,
-      'accountType': accountType,
-      'balanceCents': balanceCents,
-      'currencyCode': currencyCode,
-      'budgetId': budgetId,
-      'onBudget': onBudget,
-      'sortOrder': sortOrder,
-    },
-  );
+  }) => caller.callServerEndpoint<_i3.Account>('account', 'create', {
+    'name': name,
+    'accountType': accountType,
+    'balanceCents': balanceCents,
+    'currencyCode': currencyCode,
+    'budgetId': budgetId,
+    'onBudget': onBudget,
+    'sortOrder': sortOrder,
+  });
 
   /// Lists all accounts for a budget.
   _i2.Future<List<_i3.Account>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i3.Account>>(
-        'account',
-        'list',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<List<_i3.Account>>('account', 'list', {
+        'budgetId': budgetId,
+      });
 
   /// Gets a single account by ID.
   _i2.Future<_i3.Account> get(_i1.UuidValue accountId) =>
-      caller.callServerEndpoint<_i3.Account>(
-        'account',
-        'get',
-        {'accountId': accountId},
-      );
+      caller.callServerEndpoint<_i3.Account>('account', 'get', {
+        'accountId': accountId,
+      });
 
   /// Updates an account by ID.
   _i2.Future<_i3.Account> update(
@@ -97,27 +89,21 @@ class EndpointAccount extends _i1.EndpointRef {
     bool? onBudget,
     int? sortOrder,
     bool? isClosed,
-  }) => caller.callServerEndpoint<_i3.Account>(
-    'account',
-    'update',
-    {
-      'accountId': accountId,
-      'name': name,
-      'accountType': accountType,
-      'balanceCents': balanceCents,
-      'onBudget': onBudget,
-      'sortOrder': sortOrder,
-      'isClosed': isClosed,
-    },
-  );
+  }) => caller.callServerEndpoint<_i3.Account>('account', 'update', {
+    'accountId': accountId,
+    'name': name,
+    'accountType': accountType,
+    'balanceCents': balanceCents,
+    'onBudget': onBudget,
+    'sortOrder': sortOrder,
+    'isClosed': isClosed,
+  });
 
   /// Deletes an account by ID.
   _i2.Future<_i3.Account> delete(_i1.UuidValue accountId) =>
-      caller.callServerEndpoint<_i3.Account>(
-        'account',
-        'delete',
-        {'accountId': accountId},
-      );
+      caller.callServerEndpoint<_i3.Account>('account', 'delete', {
+        'accountId': accountId,
+      });
 }
 
 /// By extending [AppleIdpBaseEndpoint], the Apple identity provider endpoint
@@ -145,24 +131,17 @@ class EndpointAppleIdp extends _i4.EndpointAppleIdpBase {
     required bool isNativeApplePlatformSignIn,
     String? firstName,
     String? lastName,
-  }) => caller.callServerEndpoint<_i5.AuthSuccess>(
-    'appleIdp',
-    'login',
-    {
-      'identityToken': identityToken,
-      'authorizationCode': authorizationCode,
-      'isNativeApplePlatformSignIn': isNativeApplePlatformSignIn,
-      'firstName': firstName,
-      'lastName': lastName,
-    },
-  );
+  }) => caller.callServerEndpoint<_i5.AuthSuccess>('appleIdp', 'login', {
+    'identityToken': identityToken,
+    'authorizationCode': authorizationCode,
+    'isNativeApplePlatformSignIn': isNativeApplePlatformSignIn,
+    'firstName': firstName,
+    'lastName': lastName,
+  });
 
   @override
-  _i2.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
-    'appleIdp',
-    'hasAccount',
-    {},
-  );
+  _i2.Future<bool> hasAccount() =>
+      caller.callServerEndpoint<bool>('appleIdp', 'hasAccount', {});
 }
 
 /// By extending [EmailIdpBaseEndpoint], the email identity provider endpoints
@@ -188,14 +167,10 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<_i5.AuthSuccess> login({
     required String email,
     required String password,
-  }) => caller.callServerEndpoint<_i5.AuthSuccess>(
-    'emailIdp',
-    'login',
-    {
-      'email': email,
-      'password': password,
-    },
-  );
+  }) => caller.callServerEndpoint<_i5.AuthSuccess>('emailIdp', 'login', {
+    'email': email,
+    'password': password,
+  });
 
   /// Starts the registration for a new user account with an email-based login
   /// associated to it.
@@ -229,14 +204,11 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<String> verifyRegistrationCode({
     required _i1.UuidValue accountRequestId,
     required String verificationCode,
-  }) => caller.callServerEndpoint<String>(
-    'emailIdp',
-    'verifyRegistrationCode',
-    {
-      'accountRequestId': accountRequestId,
-      'verificationCode': verificationCode,
-    },
-  );
+  }) =>
+      caller.callServerEndpoint<String>('emailIdp', 'verifyRegistrationCode', {
+        'accountRequestId': accountRequestId,
+        'verificationCode': verificationCode,
+      });
 
   /// Completes a new account registration, creating a new auth user with a
   /// profile and attaching the given email account to it.
@@ -259,10 +231,7 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   }) => caller.callServerEndpoint<_i5.AuthSuccess>(
     'emailIdp',
     'finishRegistration',
-    {
-      'registrationToken': registrationToken,
-      'password': password,
-    },
+    {'registrationToken': registrationToken, 'password': password},
   );
 
   /// Requests a password reset for [email].
@@ -304,14 +273,11 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<String> verifyPasswordResetCode({
     required _i1.UuidValue passwordResetRequestId,
     required String verificationCode,
-  }) => caller.callServerEndpoint<String>(
-    'emailIdp',
-    'verifyPasswordResetCode',
-    {
-      'passwordResetRequestId': passwordResetRequestId,
-      'verificationCode': verificationCode,
-    },
-  );
+  }) =>
+      caller.callServerEndpoint<String>('emailIdp', 'verifyPasswordResetCode', {
+        'passwordResetRequestId': passwordResetRequestId,
+        'verificationCode': verificationCode,
+      });
 
   /// Completes a password reset request by setting a new password.
   ///
@@ -331,21 +297,14 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<void> finishPasswordReset({
     required String finishPasswordResetToken,
     required String newPassword,
-  }) => caller.callServerEndpoint<void>(
-    'emailIdp',
-    'finishPasswordReset',
-    {
-      'finishPasswordResetToken': finishPasswordResetToken,
-      'newPassword': newPassword,
-    },
-  );
+  }) => caller.callServerEndpoint<void>('emailIdp', 'finishPasswordReset', {
+    'finishPasswordResetToken': finishPasswordResetToken,
+    'newPassword': newPassword,
+  });
 
   @override
-  _i2.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
-    'emailIdp',
-    'hasAccount',
-    {},
-  );
+  _i2.Future<bool> hasAccount() =>
+      caller.callServerEndpoint<bool>('emailIdp', 'hasAccount', {});
 }
 
 /// By extending [GoogleIdpBaseEndpoint], the Google identity provider endpoint
@@ -366,21 +325,14 @@ class EndpointGoogleIdp extends _i4.EndpointGoogleIdpBase {
   _i2.Future<_i5.AuthSuccess> login({
     required String idToken,
     required String? accessToken,
-  }) => caller.callServerEndpoint<_i5.AuthSuccess>(
-    'googleIdp',
-    'login',
-    {
-      'idToken': idToken,
-      'accessToken': accessToken,
-    },
-  );
+  }) => caller.callServerEndpoint<_i5.AuthSuccess>('googleIdp', 'login', {
+    'idToken': idToken,
+    'accessToken': accessToken,
+  });
 
   @override
-  _i2.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
-    'googleIdp',
-    'hasAccount',
-    {},
-  );
+  _i2.Future<bool> hasAccount() =>
+      caller.callServerEndpoint<bool>('googleIdp', 'hasAccount', {});
 }
 
 /// By extending [RefreshJwtTokensEndpoint], the JWT token refresh endpoint
@@ -440,12 +392,7 @@ class EndpointBudgetTemplate extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i6.BudgetTemplate>(
     'budgetTemplate',
     'saveFromMonth',
-    {
-      'budgetId': budgetId,
-      'name': name,
-      'year': year,
-      'month': month,
-    },
+    {'budgetId': budgetId, 'name': name, 'year': year, 'month': month},
   );
 
   /// Lists all templates for a budget.
@@ -493,64 +440,42 @@ class EndpointBudget extends _i1.EndpointRef {
   String get name => 'budget';
 
   /// Creates a new budget for the authenticated user.
-  _i2.Future<_i8.Budget> create(
-    String name,
-    String currencyCode,
-  ) => caller.callServerEndpoint<_i8.Budget>(
-    'budget',
-    'create',
-    {
-      'name': name,
-      'currencyCode': currencyCode,
-    },
-  );
+  _i2.Future<_i8.Budget> create(String name, String currencyCode) =>
+      caller.callServerEndpoint<_i8.Budget>('budget', 'create', {
+        'name': name,
+        'currencyCode': currencyCode,
+      });
 
   /// Lists all budgets for the authenticated user.
   _i2.Future<List<_i8.Budget>> list() =>
-      caller.callServerEndpoint<List<_i8.Budget>>(
-        'budget',
-        'list',
-        {},
-      );
+      caller.callServerEndpoint<List<_i8.Budget>>('budget', 'list', {});
 
   /// Gets a single budget by ID, verifying ownership.
-  _i2.Future<_i8.Budget> get(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<_i8.Budget>(
-        'budget',
-        'get',
-        {'budgetId': budgetId},
-      );
+  _i2.Future<_i8.Budget> get(_i1.UuidValue budgetId) => caller
+      .callServerEndpoint<_i8.Budget>('budget', 'get', {'budgetId': budgetId});
 
   /// Updates a budget by ID, verifying ownership.
   _i2.Future<_i8.Budget> update(
     _i1.UuidValue budgetId, {
     String? name,
     String? currencyCode,
-  }) => caller.callServerEndpoint<_i8.Budget>(
-    'budget',
-    'update',
-    {
-      'budgetId': budgetId,
-      'name': name,
-      'currencyCode': currencyCode,
-    },
-  );
+  }) => caller.callServerEndpoint<_i8.Budget>('budget', 'update', {
+    'budgetId': budgetId,
+    'name': name,
+    'currencyCode': currencyCode,
+  });
 
   /// Deletes a budget by ID, verifying ownership.
   _i2.Future<_i8.Budget> delete(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<_i8.Budget>(
-        'budget',
-        'delete',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<_i8.Budget>('budget', 'delete', {
+        'budgetId': budgetId,
+      });
 
   /// Exports all budget data as a JSON string for data portability.
   _i2.Future<String> exportData(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<String>(
-        'budget',
-        'exportData',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<String>('budget', 'exportData', {
+        'budgetId': budgetId,
+      });
 }
 
 /// Streaming endpoint for real-time budget updates.
@@ -593,31 +518,23 @@ class EndpointCategory extends _i1.EndpointRef {
     String name,
     _i1.UuidValue budgetId,
     int sortOrder,
-  ) => caller.callServerEndpoint<_i9.Category>(
-    'category',
-    'create',
-    {
-      'name': name,
-      'budgetId': budgetId,
-      'sortOrder': sortOrder,
-    },
-  );
+  ) => caller.callServerEndpoint<_i9.Category>('category', 'create', {
+    'name': name,
+    'budgetId': budgetId,
+    'sortOrder': sortOrder,
+  });
 
   /// Lists all categories for a budget.
   _i2.Future<List<_i9.Category>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i9.Category>>(
-        'category',
-        'list',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<List<_i9.Category>>('category', 'list', {
+        'budgetId': budgetId,
+      });
 
   /// Gets a single category by ID.
   _i2.Future<_i9.Category> get(_i1.UuidValue categoryId) =>
-      caller.callServerEndpoint<_i9.Category>(
-        'category',
-        'get',
-        {'categoryId': categoryId},
-      );
+      caller.callServerEndpoint<_i9.Category>('category', 'get', {
+        'categoryId': categoryId,
+      });
 
   /// Updates a category by ID.
   _i2.Future<_i9.Category> update(
@@ -625,16 +542,12 @@ class EndpointCategory extends _i1.EndpointRef {
     String? name,
     int? sortOrder,
     bool? isHidden,
-  }) => caller.callServerEndpoint<_i9.Category>(
-    'category',
-    'update',
-    {
-      'categoryId': categoryId,
-      'name': name,
-      'sortOrder': sortOrder,
-      'isHidden': isHidden,
-    },
-  );
+  }) => caller.callServerEndpoint<_i9.Category>('category', 'update', {
+    'categoryId': categoryId,
+    'name': name,
+    'sortOrder': sortOrder,
+    'isHidden': isHidden,
+  });
 
   /// Batch-reorders categories by their new position.
   ///
@@ -643,22 +556,16 @@ class EndpointCategory extends _i1.EndpointRef {
   _i2.Future<List<_i9.Category>> reorder(
     _i1.UuidValue budgetId,
     List<_i1.UuidValue> categoryIds,
-  ) => caller.callServerEndpoint<List<_i9.Category>>(
-    'category',
-    'reorder',
-    {
-      'budgetId': budgetId,
-      'categoryIds': categoryIds,
-    },
-  );
+  ) => caller.callServerEndpoint<List<_i9.Category>>('category', 'reorder', {
+    'budgetId': budgetId,
+    'categoryIds': categoryIds,
+  });
 
   /// Deletes a category by ID.
   _i2.Future<_i9.Category> delete(_i1.UuidValue categoryId) =>
-      caller.callServerEndpoint<_i9.Category>(
-        'category',
-        'delete',
-        {'categoryId': categoryId},
-      );
+      caller.callServerEndpoint<_i9.Category>('category', 'delete', {
+        'categoryId': categoryId,
+      });
 }
 
 /// API surface for envelope goal operations.
@@ -678,17 +585,13 @@ class EndpointEnvelopeGoal extends _i1.EndpointRef {
     int targetAmountCents, {
     DateTime? targetDate,
     int? monthlyFundingCents,
-  }) => caller.callServerEndpoint<_i10.EnvelopeGoal>(
-    'envelopeGoal',
-    'upsert',
-    {
-      'envelopeId': envelopeId,
-      'goalType': goalType,
-      'targetAmountCents': targetAmountCents,
-      'targetDate': targetDate,
-      'monthlyFundingCents': monthlyFundingCents,
-    },
-  );
+  }) => caller.callServerEndpoint<_i10.EnvelopeGoal>('envelopeGoal', 'upsert', {
+    'envelopeId': envelopeId,
+    'goalType': goalType,
+    'targetAmountCents': targetAmountCents,
+    'targetDate': targetDate,
+    'monthlyFundingCents': monthlyFundingCents,
+  });
 
   /// Gets the goal for an envelope.
   _i2.Future<_i10.EnvelopeGoal?> getForEnvelope(_i1.UuidValue envelopeId) =>
@@ -709,11 +612,9 @@ class EndpointEnvelopeGoal extends _i1.EndpointRef {
 
   /// Deletes a goal by ID.
   _i2.Future<_i10.EnvelopeGoal> delete(_i1.UuidValue goalId) =>
-      caller.callServerEndpoint<_i10.EnvelopeGoal>(
-        'envelopeGoal',
-        'delete',
-        {'goalId': goalId},
-      );
+      caller.callServerEndpoint<_i10.EnvelopeGoal>('envelopeGoal', 'delete', {
+        'goalId': goalId,
+      });
 }
 
 /// API surface for envelope operations.
@@ -732,32 +633,24 @@ class EndpointEnvelope extends _i1.EndpointRef {
     _i1.UuidValue categoryId,
     int budgetedAmountCents,
     String currencyCode,
-  ) => caller.callServerEndpoint<_i11.Envelope>(
-    'envelope',
-    'create',
-    {
-      'name': name,
-      'categoryId': categoryId,
-      'budgetedAmountCents': budgetedAmountCents,
-      'currencyCode': currencyCode,
-    },
-  );
+  ) => caller.callServerEndpoint<_i11.Envelope>('envelope', 'create', {
+    'name': name,
+    'categoryId': categoryId,
+    'budgetedAmountCents': budgetedAmountCents,
+    'currencyCode': currencyCode,
+  });
 
   /// Lists all envelopes for a category.
   _i2.Future<List<_i11.Envelope>> list(_i1.UuidValue categoryId) =>
-      caller.callServerEndpoint<List<_i11.Envelope>>(
-        'envelope',
-        'list',
-        {'categoryId': categoryId},
-      );
+      caller.callServerEndpoint<List<_i11.Envelope>>('envelope', 'list', {
+        'categoryId': categoryId,
+      });
 
   /// Gets a single envelope by ID.
   _i2.Future<_i11.Envelope> get(_i1.UuidValue envelopeId) =>
-      caller.callServerEndpoint<_i11.Envelope>(
-        'envelope',
-        'get',
-        {'envelopeId': envelopeId},
-      );
+      caller.callServerEndpoint<_i11.Envelope>('envelope', 'get', {
+        'envelopeId': envelopeId,
+      });
 
   /// Updates an envelope by ID.
   _i2.Future<_i11.Envelope> update(
@@ -767,39 +660,29 @@ class EndpointEnvelope extends _i1.EndpointRef {
     int? spentAmountCents,
     String? note,
     bool? isHidden,
-  }) => caller.callServerEndpoint<_i11.Envelope>(
-    'envelope',
-    'update',
-    {
-      'envelopeId': envelopeId,
-      'name': name,
-      'budgetedAmountCents': budgetedAmountCents,
-      'spentAmountCents': spentAmountCents,
-      'note': note,
-      'isHidden': isHidden,
-    },
-  );
+  }) => caller.callServerEndpoint<_i11.Envelope>('envelope', 'update', {
+    'envelopeId': envelopeId,
+    'name': name,
+    'budgetedAmountCents': budgetedAmountCents,
+    'spentAmountCents': spentAmountCents,
+    'note': note,
+    'isHidden': isHidden,
+  });
 
   /// Reorders envelopes within a category.
   _i2.Future<List<_i11.Envelope>> reorder(
     _i1.UuidValue categoryId,
     List<String> envelopeIds,
-  ) => caller.callServerEndpoint<List<_i11.Envelope>>(
-    'envelope',
-    'reorder',
-    {
-      'categoryId': categoryId,
-      'envelopeIds': envelopeIds,
-    },
-  );
+  ) => caller.callServerEndpoint<List<_i11.Envelope>>('envelope', 'reorder', {
+    'categoryId': categoryId,
+    'envelopeIds': envelopeIds,
+  });
 
   /// Deletes an envelope by ID.
   _i2.Future<_i11.Envelope> delete(_i1.UuidValue envelopeId) =>
-      caller.callServerEndpoint<_i11.Envelope>(
-        'envelope',
-        'delete',
-        {'envelopeId': envelopeId},
-      );
+      caller.callServerEndpoint<_i11.Envelope>('envelope', 'delete', {
+        'envelopeId': envelopeId,
+      });
 }
 
 /// Endpoint for receiving log entries from Flutter clients.
@@ -815,11 +698,9 @@ class EndpointLogIngest extends _i1.EndpointRef {
   /// Accepts a JSON array of [LogEntry] objects and writes them to the
   /// shared dev log file.
   _i2.Future<void> ingest(String entriesJson) =>
-      caller.callServerEndpoint<void>(
-        'logIngest',
-        'ingest',
-        {'entriesJson': entriesJson},
-      );
+      caller.callServerEndpoint<void>('logIngest', 'ingest', {
+        'entriesJson': entriesJson,
+      });
 }
 
 /// API surface for monthly allocation operations.
@@ -861,11 +742,7 @@ class EndpointMonthlyAllocation extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i7.MonthlyAllocation>>(
     'monthlyAllocation',
     'list',
-    {
-      'budgetId': budgetId,
-      'year': year,
-      'month': month,
-    },
+    {'budgetId': budgetId, 'year': year, 'month': month},
   );
 
   /// Copies all allocations from a source month to a target month.
@@ -928,46 +805,28 @@ class EndpointPayee extends _i1.EndpointRef {
   String get name => 'payee';
 
   /// Creates a new payee within a budget.
-  _i2.Future<_i12.Payee> create(
-    String name,
-    _i1.UuidValue budgetId,
-  ) => caller.callServerEndpoint<_i12.Payee>(
-    'payee',
-    'create',
-    {
-      'name': name,
-      'budgetId': budgetId,
-    },
-  );
+  _i2.Future<_i12.Payee> create(String name, _i1.UuidValue budgetId) =>
+      caller.callServerEndpoint<_i12.Payee>('payee', 'create', {
+        'name': name,
+        'budgetId': budgetId,
+      });
 
   /// Lists all payees for a budget.
   _i2.Future<List<_i12.Payee>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i12.Payee>>(
-        'payee',
-        'list',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<List<_i12.Payee>>('payee', 'list', {
+        'budgetId': budgetId,
+      });
 
   /// Gets a single payee by ID.
-  _i2.Future<_i12.Payee> get(_i1.UuidValue payeeId) =>
-      caller.callServerEndpoint<_i12.Payee>(
-        'payee',
-        'get',
-        {'payeeId': payeeId},
-      );
+  _i2.Future<_i12.Payee> get(_i1.UuidValue payeeId) => caller
+      .callServerEndpoint<_i12.Payee>('payee', 'get', {'payeeId': payeeId});
 
   /// Updates a payee by ID.
-  _i2.Future<_i12.Payee> update(
-    _i1.UuidValue payeeId, {
-    String? name,
-  }) => caller.callServerEndpoint<_i12.Payee>(
-    'payee',
-    'update',
-    {
-      'payeeId': payeeId,
-      'name': name,
-    },
-  );
+  _i2.Future<_i12.Payee> update(_i1.UuidValue payeeId, {String? name}) =>
+      caller.callServerEndpoint<_i12.Payee>('payee', 'update', {
+        'payeeId': payeeId,
+        'name': name,
+      });
 
   /// Returns the envelope ID from the most recent transaction for a payee.
   _i2.Future<_i1.UuidValue?> lastUsedEnvelopeId(
@@ -976,10 +835,7 @@ class EndpointPayee extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i1.UuidValue?>(
     'payee',
     'lastUsedEnvelopeId',
-    {
-      'payeeId': payeeId,
-      'budgetId': budgetId,
-    },
+    {'payeeId': payeeId, 'budgetId': budgetId},
   );
 
   /// Merges the source payee into the target payee.
@@ -990,22 +846,14 @@ class EndpointPayee extends _i1.EndpointRef {
   _i2.Future<int> merge(
     _i1.UuidValue sourcePayeeId,
     _i1.UuidValue targetPayeeId,
-  ) => caller.callServerEndpoint<int>(
-    'payee',
-    'merge',
-    {
-      'sourcePayeeId': sourcePayeeId,
-      'targetPayeeId': targetPayeeId,
-    },
-  );
+  ) => caller.callServerEndpoint<int>('payee', 'merge', {
+    'sourcePayeeId': sourcePayeeId,
+    'targetPayeeId': targetPayeeId,
+  });
 
   /// Deletes a payee by ID.
-  _i2.Future<_i12.Payee> delete(_i1.UuidValue payeeId) =>
-      caller.callServerEndpoint<_i12.Payee>(
-        'payee',
-        'delete',
-        {'payeeId': payeeId},
-      );
+  _i2.Future<_i12.Payee> delete(_i1.UuidValue payeeId) => caller
+      .callServerEndpoint<_i12.Payee>('payee', 'delete', {'payeeId': payeeId});
 }
 
 /// API surface for recurring transaction operations.
@@ -1054,10 +902,7 @@ class EndpointRecurringTransaction extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<List<_i13.RecurringTransaction>>(
     'recurringTransaction',
     'list',
-    {
-      'budgetId': budgetId,
-      'activeOnly': activeOnly,
-    },
+    {'budgetId': budgetId, 'activeOnly': activeOnly},
   );
 
   /// Gets a recurring transaction by ID.
@@ -1121,19 +966,15 @@ class EndpointRecurringTransaction extends _i1.EndpointRef {
   /// transactions and advancing the schedule. Returns the count of created
   /// transactions.
   _i2.Future<int> postDue(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<int>(
-        'recurringTransaction',
-        'postDue',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<int>('recurringTransaction', 'postDue', {
+        'budgetId': budgetId,
+      });
 
   /// Returns the count of active recurring transactions that are currently due.
   _i2.Future<int> countDue(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<int>(
-        'recurringTransaction',
-        'countDue',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<int>('recurringTransaction', 'countDue', {
+        'budgetId': budgetId,
+      });
 }
 
 /// API surface for transaction rule operations.
@@ -1199,10 +1040,7 @@ class EndpointTransactionRule extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i1.UuidValue?>(
     'transactionRule',
     'findMatchingEnvelope',
-    {
-      'budgetId': budgetId,
-      'payeeId': payeeId,
-    },
+    {'budgetId': budgetId, 'payeeId': payeeId},
   );
 
   /// Deletes a transaction rule.
@@ -1234,28 +1072,22 @@ class EndpointTransaction extends _i1.EndpointRef {
     _i1.UuidValue? envelopeId,
     _i1.UuidValue? payeeId,
     String? memo,
-  }) => caller.callServerEndpoint<_i15.Transaction>(
-    'transaction',
-    'create',
-    {
-      'description': description,
-      'amountCents': amountCents,
-      'currencyCode': currencyCode,
-      'budgetId': budgetId,
-      'transactionDate': transactionDate,
-      'envelopeId': envelopeId,
-      'payeeId': payeeId,
-      'memo': memo,
-    },
-  );
+  }) => caller.callServerEndpoint<_i15.Transaction>('transaction', 'create', {
+    'description': description,
+    'amountCents': amountCents,
+    'currencyCode': currencyCode,
+    'budgetId': budgetId,
+    'transactionDate': transactionDate,
+    'envelopeId': envelopeId,
+    'payeeId': payeeId,
+    'memo': memo,
+  });
 
   /// Lists all transactions for a budget.
   _i2.Future<List<_i15.Transaction>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i15.Transaction>>(
-        'transaction',
-        'list',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<List<_i15.Transaction>>('transaction', 'list', {
+        'budgetId': budgetId,
+      });
 
   /// Lists transactions for a budget within a specific month.
   _i2.Future<List<_i15.Transaction>> listByMonth(
@@ -1265,20 +1097,14 @@ class EndpointTransaction extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i15.Transaction>>(
     'transaction',
     'listByMonth',
-    {
-      'budgetId': budgetId,
-      'year': year,
-      'month': month,
-    },
+    {'budgetId': budgetId, 'year': year, 'month': month},
   );
 
   /// Gets a single transaction by ID.
   _i2.Future<_i15.Transaction> get(_i1.UuidValue transactionId) =>
-      caller.callServerEndpoint<_i15.Transaction>(
-        'transaction',
-        'get',
-        {'transactionId': transactionId},
-      );
+      caller.callServerEndpoint<_i15.Transaction>('transaction', 'get', {
+        'transactionId': transactionId,
+      });
 
   /// Updates a transaction by ID.
   _i2.Future<_i15.Transaction> update(
@@ -1290,33 +1116,25 @@ class EndpointTransaction extends _i1.EndpointRef {
     DateTime? transactionDate,
     String? memo,
     String? flagColor,
-  }) => caller.callServerEndpoint<_i15.Transaction>(
-    'transaction',
-    'update',
-    {
-      'transactionId': transactionId,
-      'description': description,
-      'amountCents': amountCents,
-      'envelopeId': envelopeId,
-      'payeeId': payeeId,
-      'transactionDate': transactionDate,
-      'memo': memo,
-      'flagColor': flagColor,
-    },
-  );
+  }) => caller.callServerEndpoint<_i15.Transaction>('transaction', 'update', {
+    'transactionId': transactionId,
+    'description': description,
+    'amountCents': amountCents,
+    'envelopeId': envelopeId,
+    'payeeId': payeeId,
+    'transactionDate': transactionDate,
+    'memo': memo,
+    'flagColor': flagColor,
+  });
 
   /// Sets or clears the flag color on a transaction.
   _i2.Future<_i15.Transaction> setFlag(
     _i1.UuidValue transactionId, {
     String? flagColor,
-  }) => caller.callServerEndpoint<_i15.Transaction>(
-    'transaction',
-    'setFlag',
-    {
-      'transactionId': transactionId,
-      'flagColor': flagColor,
-    },
-  );
+  }) => caller.callServerEndpoint<_i15.Transaction>('transaction', 'setFlag', {
+    'transactionId': transactionId,
+    'flagColor': flagColor,
+  });
 
   /// Creates a transfer between two accounts.
   _i2.Future<List<_i15.Transaction>> transfer(
@@ -1327,19 +1145,16 @@ class EndpointTransaction extends _i1.EndpointRef {
     _i1.UuidValue fromAccountId,
     _i1.UuidValue toAccountId,
     DateTime transactionDate,
-  ) => caller.callServerEndpoint<List<_i15.Transaction>>(
-    'transaction',
-    'transfer',
-    {
-      'description': description,
-      'amountCents': amountCents,
-      'currencyCode': currencyCode,
-      'budgetId': budgetId,
-      'fromAccountId': fromAccountId,
-      'toAccountId': toAccountId,
-      'transactionDate': transactionDate,
-    },
-  );
+  ) => caller
+      .callServerEndpoint<List<_i15.Transaction>>('transaction', 'transfer', {
+        'description': description,
+        'amountCents': amountCents,
+        'currencyCode': currencyCode,
+        'budgetId': budgetId,
+        'fromAccountId': fromAccountId,
+        'toAccountId': toAccountId,
+        'transactionDate': transactionDate,
+      });
 
   /// Lists transactions for a specific account.
   _i2.Future<List<_i15.Transaction>> listByAccount(
@@ -1348,10 +1163,7 @@ class EndpointTransaction extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i15.Transaction>>(
     'transaction',
     'listByAccount',
-    {
-      'accountId': accountId,
-      'budgetId': budgetId,
-    },
+    {'accountId': accountId, 'budgetId': budgetId},
   );
 
   /// Toggles the cleared status of a transaction.
@@ -1366,14 +1178,10 @@ class EndpointTransaction extends _i1.EndpointRef {
   _i2.Future<int> reconcileAccount(
     _i1.UuidValue accountId,
     _i1.UuidValue budgetId,
-  ) => caller.callServerEndpoint<int>(
-    'transaction',
-    'reconcileAccount',
-    {
-      'accountId': accountId,
-      'budgetId': budgetId,
-    },
-  );
+  ) => caller.callServerEndpoint<int>('transaction', 'reconcileAccount', {
+    'accountId': accountId,
+    'budgetId': budgetId,
+  });
 
   /// Reconciles an account with a statement balance.
   ///
@@ -1383,26 +1191,21 @@ class EndpointTransaction extends _i1.EndpointRef {
     _i1.UuidValue accountId,
     _i1.UuidValue budgetId,
     int statementBalanceCents,
-  ) => caller.callServerEndpoint<List<int>>(
-    'transaction',
-    'reconcileWithBalance',
-    {
-      'accountId': accountId,
-      'budgetId': budgetId,
-      'statementBalanceCents': statementBalanceCents,
-    },
-  );
+  ) => caller
+      .callServerEndpoint<List<int>>('transaction', 'reconcileWithBalance', {
+        'accountId': accountId,
+        'budgetId': budgetId,
+        'statementBalanceCents': statementBalanceCents,
+      });
 
   /// Calculates the "Age of Money" for a budget.
   ///
   /// Returns the average days between income and spending, or null if
   /// there is insufficient data.
   _i2.Future<int?> ageOfMoney(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<int?>(
-        'transaction',
-        'ageOfMoney',
-        {'budgetId': budgetId},
-      );
+      caller.callServerEndpoint<int?>('transaction', 'ageOfMoney', {
+        'budgetId': budgetId,
+      });
 
   /// Creates a split transaction with multiple envelope assignments.
   _i2.Future<List<_i15.Transaction>> createSplit(
@@ -1446,16 +1249,12 @@ class EndpointTransaction extends _i1.EndpointRef {
     String currencyCode,
     List<_i17.ImportRow> rows, {
     _i1.UuidValue? accountId,
-  }) => caller.callServerEndpoint<int>(
-    'transaction',
-    'bulkImport',
-    {
-      'budgetId': budgetId,
-      'currencyCode': currencyCode,
-      'rows': rows,
-      'accountId': accountId,
-    },
-  );
+  }) => caller.callServerEndpoint<int>('transaction', 'bulkImport', {
+    'budgetId': budgetId,
+    'currencyCode': currencyCode,
+    'rows': rows,
+    'accountId': accountId,
+  });
 
   /// Finds potential duplicate transactions with the same amount near a date.
   _i2.Future<List<_i15.Transaction>> findDuplicates(
@@ -1474,11 +1273,9 @@ class EndpointTransaction extends _i1.EndpointRef {
 
   /// Deletes a transaction by ID.
   _i2.Future<_i15.Transaction> delete(_i1.UuidValue transactionId) =>
-      caller.callServerEndpoint<_i15.Transaction>(
-        'transaction',
-        'delete',
-        {'transactionId': transactionId},
-      );
+      caller.callServerEndpoint<_i15.Transaction>('transaction', 'delete', {
+        'transactionId': transactionId,
+      });
 }
 
 class Modules {
@@ -1502,12 +1299,7 @@ class Client extends _i1.ServerpodClientShared {
     super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
-    Function(
-      _i1.MethodCallContext,
-      Object,
-      StackTrace,
-    )?
-    onFailedCall,
+    Function(_i1.MethodCallContext, Object, StackTrace)? onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(

--- a/openbudget_client/lib/src/protocol/payees/payee.dart
+++ b/openbudget_client/lib/src/protocol/payees/payee.dart
@@ -88,12 +88,7 @@ class _PayeeImpl extends Payee {
     required String name,
     required _i1.UuidValue budgetId,
     DateTime? createdAt,
-  }) : super._(
-         id: id,
-         name: name,
-         budgetId: budgetId,
-         createdAt: createdAt,
-       );
+  }) : super._(id: id, name: name, budgetId: budgetId, createdAt: createdAt);
 
   /// Returns a shallow copy of this [Payee]
   /// with some or all fields replaced by the given arguments.

--- a/openbudget_client/lib/src/protocol/protocol.dart
+++ b/openbudget_client/lib/src/protocol/protocol.dart
@@ -79,10 +79,7 @@ class Protocol extends _i1.SerializationManager {
   }
 
   @override
-  T deserialize<T>(
-    dynamic data, [
-    Type? t,
-  ]) {
+  T deserialize<T>(dynamic data, [Type? t]) {
     t ??= T;
 
     final dataClassName = getClassNameFromObjectJson(data);

--- a/openbudget_client/lib/src/protocol/transactions/split_item.dart
+++ b/openbudget_client/lib/src/protocol/transactions/split_item.dart
@@ -14,11 +14,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 /// A single split within a split transaction.
 abstract class SplitItem implements _i1.SerializableModel {
-  SplitItem._({
-    required this.amountCents,
-    this.envelopeId,
-    this.memo,
-  });
+  SplitItem._({required this.amountCents, this.envelopeId, this.memo});
 
   factory SplitItem({
     required int amountCents,
@@ -78,11 +74,7 @@ class _SplitItemImpl extends SplitItem {
     required int amountCents,
     _i1.UuidValue? envelopeId,
     String? memo,
-  }) : super._(
-         amountCents: amountCents,
-         envelopeId: envelopeId,
-         memo: memo,
-       );
+  }) : super._(amountCents: amountCents, envelopeId: envelopeId, memo: memo);
 
   /// Returns a shallow copy of this [SplitItem]
   /// with some or all fields replaced by the given arguments.


### PR DESCRIPTION
## Summary
Fixes the failing GitHub Actions `format` job (`dprint check`) by applying formatter output to the exact files reported in CI.

## Root cause
The previous merge introduced generated JSON/YAML/protocol files that were functionally correct but not in dprint's canonical style. The CI `format` job runs `dprint check` and failed with:
- `Found 11 not formatted files. Run dprint fmt to fix.`

## What changed
Formatted only the 11 files CI flagged:
- `openbudget_app/web/manifest.json`
- `openbudget_app/flutter_launcher_icons.yaml`
- `openbudget_app/flutter_native_splash.yaml`
- `openbudget_app/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json`
- `openbudget_app/ios/Runner/Assets.xcassets/LaunchBackground.imageset/Contents.json`
- `openbudget_app/ios/Runner/Assets.xcassets/LaunchImage.imageset/Contents.json`
- `openbudget_app/macos/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json`
- `openbudget_client/lib/src/protocol/protocol.dart`
- `openbudget_client/lib/src/protocol/client.dart`
- `openbudget_client/lib/src/protocol/payees/payee.dart`
- `openbudget_client/lib/src/protocol/transactions/split_item.dart`

No behavior changes; formatting-only diff.

## Validation
- Reproduced CI failure details from run `22263870672` (`format` job).
- Ran `dprint check` against those 11 files with Flutter/Dart on PATH.
- Ran full `dprint check` locally (same formatter stack) successfully.
