### PR TITLE
feat(lints): add configurable stateful widget analyzer rule

### DIFF
--- a/openbudget_lints/README.md
+++ b/openbudget_lints/README.md
@@ -9,3 +9,53 @@ Add to your package's `analysis_options.yaml`:
 ```yaml
 include: package:openbudget_lints/analysis_options.yaml
 ```
+
+## Enforced Rules
+
+- `avoid_stateful_widgets`: Disallows classes that extend
+  `StatefulWidget`, `ConsumerStatefulWidget`, or
+  `StatefulHookConsumerWidget`.
+
+## Enable Plugin Rules
+
+To enable analyzer plugin rules in a package, add:
+
+```yaml
+plugins:
+  openbudget_lints:
+    path: ../openbudget_lints
+```
+
+For the workspace root package, use:
+
+```yaml
+plugins:
+  openbudget_lints:
+    path: ./openbudget_lints
+```
+
+## Rule Configuration
+
+The analyzer plugin configuration model only supports plugin source
+(`path`/`git`/`version`) and `diagnostics` severity toggles natively.
+`openbudget_lints` reads additional keys from the same plugin block to support
+rule-specific options.
+
+You can override disallowed widget base classes per package:
+
+```yaml
+plugins:
+  openbudget_lints:
+    path: ../openbudget_lints
+    disallowed_classes:
+      - StatefulWidget
+      - ConsumerStatefulWidget
+      - StatefulHookConsumerWidget
+      - CustomLegacyStatefulBase
+```
+
+Notes:
+
+- If `disallowed_classes` is omitted, the default list above is used.
+- If `disallowed_classes` is present, the configured list fully replaces the
+  defaults.

--- a/openbudget_lints/lib/main.dart
+++ b/openbudget_lints/lib/main.dart
@@ -1,0 +1,15 @@
+import 'package:analysis_server_plugin/plugin.dart';
+import 'package:analysis_server_plugin/registry.dart';
+import 'package:openbudget_lints/src/rules/disallow_stateful_widgets_rule.dart';
+
+final plugin = OpenBudgetPlugin();
+
+class OpenBudgetPlugin extends Plugin {
+  @override
+  String get name => 'OpenBudget Lints';
+
+  @override
+  void register(PluginRegistry registry) {
+    registry.registerWarningRule(DisallowStatefulWidgetsRule());
+  }
+}

--- a/openbudget_lints/lib/src/rules/disallow_stateful_widgets_rule.dart
+++ b/openbudget_lints/lib/src/rules/disallow_stateful_widgets_rule.dart
@@ -1,0 +1,170 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/file_system/file_system.dart';
+import 'package:yaml/yaml.dart';
+
+final class DisallowStatefulWidgetsRule extends AnalysisRule {
+  DisallowStatefulWidgetsRule()
+    : super(
+        name: 'avoid_stateful_widgets',
+        description: 'Disallow StatefulWidget-based classes in OpenBudget.',
+      );
+
+  static const LintCode code = LintCode(
+    'avoid_stateful_widgets',
+    'Stateful widgets are not allowed in OpenBudget. '
+        'Use HookWidget, HookConsumerWidget, or StatelessWidget instead.',
+    correctionMessage:
+        'Replace this widget with a hook-based or stateless implementation.',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    final visitor = _DisallowStatefulWidgetsVisitor(
+      this,
+      _DisallowedClassNamesResolver.resolve(context),
+    );
+    registry
+      ..addClassDeclaration(this, visitor)
+      ..addClassTypeAlias(this, visitor);
+  }
+}
+
+final class _DisallowStatefulWidgetsVisitor extends SimpleAstVisitor<void> {
+  _DisallowStatefulWidgetsVisitor(this.rule, this.disallowedWidgetTypes);
+
+  final AnalysisRule rule;
+  final Set<String> disallowedWidgetTypes;
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    _reportIfDisallowed(node.extendsClause?.superclass);
+  }
+
+  @override
+  void visitClassTypeAlias(ClassTypeAlias node) {
+    _reportIfDisallowed(node.superclass);
+  }
+
+  void _reportIfDisallowed(NamedType? superclass) {
+    if (superclass == null) {
+      return;
+    }
+
+    final type = superclass.type;
+    if (type is InterfaceType && _isDisallowedOrStatefulDescendant(type)) {
+      rule.reportAtNode(superclass);
+      return;
+    }
+
+    if (disallowedWidgetTypes.contains(superclass.name.lexeme)) {
+      rule.reportAtNode(superclass);
+    }
+  }
+
+  bool _isDisallowedOrStatefulDescendant(InterfaceType type) {
+    if (disallowedWidgetTypes.contains(type.element.name)) {
+      return true;
+    }
+
+    for (final supertype in type.allSupertypes) {
+      if (disallowedWidgetTypes.contains(supertype.element.name)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+final class _DisallowedClassNamesResolver {
+  static const String _analysisOptionsYaml = 'analysis_options.yaml';
+  static const String _analysisOptionsYml = 'analysis_options.yml';
+  static const String _pluginsKey = 'plugins';
+  static const String _pluginName = 'openbudget_lints';
+  static const String _disallowedClassesKey = 'disallowed_classes';
+
+  static const Set<String> _defaults = {
+    'StatefulWidget',
+    'ConsumerStatefulWidget',
+    'StatefulHookConsumerWidget',
+  };
+
+  static final Map<String, Set<String>> _cache = {};
+
+  static Set<String> resolve(RuleContext context) {
+    final packageRoot = context.package?.root;
+    if (packageRoot == null) {
+      return _defaults;
+    }
+
+    return _cache.putIfAbsent(packageRoot.path, () {
+      final parsed = _tryReadConfiguredClassNames(packageRoot);
+      return parsed ?? _defaults;
+    });
+  }
+
+  static Set<String>? _tryReadConfiguredClassNames(Folder packageRoot) {
+    final optionsFile = _analysisOptionsFile(packageRoot);
+    if (optionsFile == null || !optionsFile.exists) {
+      return null;
+    }
+
+    final yaml = loadYaml(optionsFile.readAsStringSync());
+    if (yaml is! YamlMap) {
+      return null;
+    }
+
+    final plugins = yaml[_pluginsKey];
+    if (plugins is! YamlMap) {
+      return null;
+    }
+
+    final pluginConfig = plugins[_pluginName];
+    if (pluginConfig is! YamlMap) {
+      return null;
+    }
+
+    final disallowedClasses = pluginConfig[_disallowedClassesKey];
+    if (disallowedClasses is! YamlList) {
+      return null;
+    }
+
+    final configuredNames = <String>{};
+    for (final value in disallowedClasses) {
+      if (value is String) {
+        final className = value.trim();
+        if (className.isNotEmpty) {
+          configuredNames.add(className);
+        }
+      }
+    }
+    return configuredNames;
+  }
+
+  static File? _analysisOptionsFile(Folder packageRoot) {
+    final yamlFile = packageRoot.getChildAssumingFile(_analysisOptionsYaml);
+    if (yamlFile.exists) {
+      return yamlFile;
+    }
+
+    final ymlFile = packageRoot.getChildAssumingFile(_analysisOptionsYml);
+    if (ymlFile.exists) {
+      return ymlFile;
+    }
+
+    return null;
+  }
+}

--- a/openbudget_lints/pubspec.yaml
+++ b/openbudget_lints/pubspec.yaml
@@ -9,5 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
+  analysis_server_plugin: ^0.3.4
+  analyzer: ^9.0.0
   riverpod_lint: ^3.1.2
   very_good_analysis: ^7.0.0
+  yaml: ^3.1.3


### PR DESCRIPTION
## Summary
This PR adds a custom analyzer plugin rule in `openbudget_lints` that detects and reports StatefulWidget-based classes, and makes the disallowed base-class names configurable from `analysis_options.yaml`.

## Problem
We needed a project-level lint that can block `StatefulWidget` usage, while also allowing teams/packages to adjust which widget bases are disallowed.

## Root Cause
The shared lints package only included static analysis options and did not provide a custom analyzer plugin entrypoint/rule implementation.

## What Changed
- Added analyzer plugin entrypoint:
  - `openbudget_lints/lib/main.dart`
- Added new rule implementation:
  - `openbudget_lints/lib/src/rules/disallow_stateful_widgets_rule.dart`
- Added diagnostic:
  - `avoid_stateful_widgets`
- Added plugin/runtime dependencies:
  - `analysis_server_plugin`
  - `analyzer`
  - `yaml`
- Updated docs in `openbudget_lints/README.md` with:
  - rule behavior
  - plugin enablement examples
  - `disallowed_classes` configuration example

## Configuration Behavior
- Default disallowed classes:
  - `StatefulWidget`
  - `ConsumerStatefulWidget`
  - `StatefulHookConsumerWidget`
- Optional override from `analysis_options.yaml`:

```yaml
plugins:
  openbudget_lints:
    path: ../openbudget_lints
    disallowed_classes:
      - StatefulWidget
      - ConsumerStatefulWidget
      - StatefulHookConsumerWidget
      - CustomLegacyStatefulBase
```

If `disallowed_classes` is present, it replaces the defaults for that package.

## Validation
- `fvm dart analyze` (workspace root)
- `fvm dart analyze` (`openbudget_lints` package)
- Temporary-package smoke tests confirming:
  - default config flags `StatefulWidget`
  - custom `disallowed_classes` changes matching behavior
