### PR TITLE
feat(lints): enforce pinned app dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,25 +163,3 @@ jobs:
           else
             echo "No native dependency changes detected. Safe for Shorebird patch (minor/patch bump)."
           fi
-
-  pinned-deps:
-    name: Enforce pinned app dependencies
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@v4
-      - name: check for unpinned dependencies
-        run: |
-          VIOLATIONS=$(sed -n '/^dependencies:/,/^[^ ]/p' openbudget_app/pubspec.yaml \
-            | grep -E ':\s*[\^>~]' \
-            | grep -v '^\s*#' \
-            || true)
-
-          if [ -n "$VIOLATIONS" ]; then
-            echo "::error::openbudget_app has unpinned dependencies. All app dependencies must use exact versions (no ^, >=, ~)."
-            echo ""
-            echo "$VIOLATIONS"
-            echo ""
-            echo "Pin to exact versions (e.g., 'cupertino_icons: 1.0.8' instead of 'cupertino_icons: ^1.0.8')"
-            exit 1
-          fi
-          echo "All app dependencies are pinned to exact versions."

--- a/openbudget_lints/README.md
+++ b/openbudget_lints/README.md
@@ -15,6 +15,9 @@ include: package:openbudget_lints/analysis_options.yaml
 - `avoid_stateful_widgets`: Disallows classes that extend
   `StatefulWidget`, `ConsumerStatefulWidget`, or
   `StatefulHookConsumerWidget`.
+- `enforce_pinned_app_dependencies`: In `openbudget_app/pubspec.yaml`,
+  requires exact versions in `dependencies` and rejects constraints starting
+  with `^`, `>`, or `~`.
 
 ## Enable Plugin Rules
 

--- a/openbudget_lints/lib/main.dart
+++ b/openbudget_lints/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:analysis_server_plugin/plugin.dart';
 import 'package:analysis_server_plugin/registry.dart';
 import 'package:openbudget_lints/src/rules/disallow_stateful_widgets_rule.dart';
+import 'package:openbudget_lints/src/rules/enforce_pinned_app_dependencies_rule.dart';
 
 final plugin = OpenBudgetPlugin();
 
@@ -10,6 +11,8 @@ class OpenBudgetPlugin extends Plugin {
 
   @override
   void register(PluginRegistry registry) {
-    registry.registerWarningRule(DisallowStatefulWidgetsRule());
+    registry
+      ..registerWarningRule(DisallowStatefulWidgetsRule())
+      ..registerWarningRule(EnforcePinnedAppDependenciesRule());
   }
 }

--- a/openbudget_lints/lib/src/rules/enforce_pinned_app_dependencies_rule.dart
+++ b/openbudget_lints/lib/src/rules/enforce_pinned_app_dependencies_rule.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/file_system/file_system.dart';
+
+final class EnforcePinnedAppDependenciesRule extends AnalysisRule {
+  EnforcePinnedAppDependenciesRule()
+    : super(
+        name: 'enforce_pinned_app_dependencies',
+        description:
+            'Require exact versions in openbudget_app dependencies section.',
+      );
+
+  static const LintCode code = LintCode(
+    'enforce_pinned_app_dependencies',
+    'openbudget_app dependency `{0}` must use an exact version. '
+        'Do not use `^`, `>`, `>=`, or `~` constraints.',
+    correctionMessage: 'Pin to an exact version, for example: `{0}: 1.2.3`.',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addCompilationUnit(
+      this,
+      _PinnedDependenciesVisitor(this, context),
+    );
+  }
+}
+
+final class _PinnedDependenciesVisitor extends SimpleAstVisitor<void> {
+  _PinnedDependenciesVisitor(this.rule, this.context);
+
+  static const String _appFolderName = 'openbudget_app';
+  static const String _mainDartPath = 'lib/main.dart';
+  static const String _pubspecPath = 'pubspec.yaml';
+
+  final AnalysisRule rule;
+  final RuleContext context;
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    final packageRoot = context.package?.root;
+    final currentFile = context.currentUnit?.file;
+    if (packageRoot == null || currentFile == null) {
+      return;
+    }
+    if (packageRoot.shortName != _appFolderName) {
+      return;
+    }
+
+    final pathContext = packageRoot.provider.pathContext;
+    final anchorPath = pathContext.normalize(
+      pathContext.join(packageRoot.path, _mainDartPath),
+    );
+    if (pathContext.normalize(currentFile.path) != anchorPath) {
+      return;
+    }
+
+    for (final dependencyName in _PinnedDependenciesCache.readViolations(
+      packageRoot,
+    )) {
+      rule.reportAtToken(node.beginToken, arguments: [dependencyName]);
+    }
+  }
+}
+
+final class _PinnedDependenciesCache {
+  static const _constraintPattern = r':\s*[\^>~]';
+  static final RegExp _unpinnedConstraintRegex = RegExp(_constraintPattern);
+
+  static final Map<String, _CacheEntry> _cache = {};
+
+  static List<String> readViolations(Folder packageRoot) {
+    final pubspecFile = packageRoot.getChildAssumingFile(
+      _PinnedDependenciesVisitor._pubspecPath,
+    );
+    if (!pubspecFile.exists) {
+      return const [];
+    }
+
+    final cacheKey = packageRoot.path;
+    final stamp = pubspecFile.modificationStamp;
+    final cached = _cache[cacheKey];
+    if (cached != null && cached.modificationStamp == stamp) {
+      return cached.violations;
+    }
+
+    final violations = _extractViolations(pubspecFile.readAsStringSync());
+    _cache[cacheKey] = _CacheEntry(stamp, violations);
+    return violations;
+  }
+
+  static List<String> _extractViolations(String pubspecContent) {
+    final lines = const LineSplitter().convert(pubspecContent);
+    var inDependencies = false;
+    final violations = <String>[];
+
+    for (final line in lines) {
+      if (!inDependencies) {
+        if (line.startsWith('dependencies:')) {
+          inDependencies = true;
+        }
+        continue;
+      }
+
+      if (line.isNotEmpty && !line.startsWith(' ')) {
+        break;
+      }
+
+      if (line.trimLeft().startsWith('#')) {
+        continue;
+      }
+
+      if (_unpinnedConstraintRegex.hasMatch(line)) {
+        final dependencyName = line.split(':').first.trim();
+        if (dependencyName.isNotEmpty) {
+          violations.add(dependencyName);
+        }
+      }
+    }
+
+    return violations;
+  }
+}
+
+final class _CacheEntry {
+  const _CacheEntry(this.modificationStamp, this.violations);
+
+  final int modificationStamp;
+  final List<String> violations;
+}


### PR DESCRIPTION
## Summary
This PR moves app dependency pin enforcement from a dedicated CI shell step into `openbudget_lints` so the rule is enforced through analyzer linting.

## Problem
The repository had a separate `pinned-deps` workflow job that parsed `openbudget_app/pubspec.yaml` with shell commands to reject unpinned dependency constraints. That policy lived outside our lint system, so enforcement was split across mechanisms and harder to evolve with the rest of project rules.

## Root Cause
Pinned dependency enforcement was implemented only as a workflow script, not as a project lint rule.

## Fix
- Added `enforce_pinned_app_dependencies` in `openbudget_lints`.
- Registered the new rule in the plugin entrypoint.
- Implemented rule behavior to mirror the former CI check:
  - target only `openbudget_app/pubspec.yaml`
  - inspect only the top-level `dependencies:` block
  - reject constraints starting with `^`, `>`, or `~`
  - ignore commented lines
- Added caching by `pubspec.yaml` modification stamp to avoid repeated parsing overhead during analysis.
- Documented the new rule in `openbudget_lints/README.md`.
- Removed the standalone `pinned-deps` job from `.github/workflows/ci.yml` now that the rule is lint-enforced.

## User Impact
Developers now get immediate analyzer feedback when app dependencies are unpinned, and CI enforces the same policy through linting without a separate ad-hoc workflow step.

## Validation
- `fvm dart analyze`
- `devenv shell -- lint:all`
- Manual verification: temporarily changed `openbudget_app/pubspec.yaml` to `cupertino_icons: ^1.0.8` and confirmed analyzer reports `enforce_pinned_app_dependencies`; then restored the file.
