### PR TITLE
docs: expand iOS OpenBudget usage guide flows

### DIFF
--- a/docs/how-to-use-openbudget-plan-and-priorities.md
+++ b/docs/how-to-use-openbudget-plan-and-priorities.md
@@ -1,0 +1,30 @@
+# Plan And Priorities Flow (iOS)
+
+Use this flow to budget your month and focus on high-impact categories.
+
+## 1. Start on the Plan screen
+
+The Plan screen is your budgeting command center. It shows ready-to-assign
+money, monthly totals, and quick actions.
+
+![OpenBudget iOS plan screen](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-ios-guide/plan-screen.png)
+
+## 2. Complete onboarding prompts
+
+If onboarding cards are visible, finish them early so your workspace stays
+focused on monthly budgeting tasks.
+
+![OpenBudget iOS onboarding on plan screen](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-ios-guide/plan-screen-onboarding-dismissed.png)
+
+## 3. Switch to Spotlight for focus mode
+
+Use Spotlight to surface top priorities for the month and keep your plan tight.
+
+![OpenBudget iOS spotlight tab](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-ios-guide/spotlight-screen.png)
+
+## 4. Use the Plan actions menu
+
+Use the overflow menu (`...`) for quick controls such as visibility toggles,
+undo actions, and fast navigation into recent moves.
+
+![OpenBudget iOS plan actions menu](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-ios-guide/plan-menu.png)

--- a/docs/how-to-use-openbudget-recent-moves-and-envelopes.md
+++ b/docs/how-to-use-openbudget-recent-moves-and-envelopes.md
@@ -1,0 +1,38 @@
+# Recent Moves And Envelope Details Flow (iOS)
+
+Use this flow to audit movement between envelopes and inspect category-level
+activity.
+
+## 1. Open Recent Moves
+
+From the Plan menu, open **Recent Moves** to view assignment and movement
+history.
+
+![OpenBudget iOS recent moves list](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-22-step7/recent-moves-screen.png)
+
+## 2. Filter for moved activity
+
+Switch views to inspect movement-specific events and quickly validate why
+balances changed.
+
+![OpenBudget iOS recent moves filtered](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-22-step7/recent-moves-moved-screen.png)
+
+## 3. Drill into envelope move history
+
+Tap an envelope to open its move history and verify where money came from or
+where it was reassigned.
+
+![OpenBudget iOS envelope moves](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-22-step7/envelope-moves-screen.png)
+
+## 4. Inspect category details
+
+From Plan, open category details to review balance, goal settings, and related
+configuration.
+
+![OpenBudget iOS category detail](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-22-step7/category-detail-screen.png)
+
+## 5. Use inline envelope editing
+
+Tap an envelope row in Plan for quick edits without leaving the budget context.
+
+![OpenBudget iOS inline envelope editor](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-22-step7/plan-inline-editor-screen.png)

--- a/docs/how-to-use-openbudget-transaction-review.md
+++ b/docs/how-to-use-openbudget-transaction-review.md
@@ -1,0 +1,26 @@
+# Transaction Review Flow (iOS)
+
+Use this flow to keep your budget accurate by approving and categorizing
+incoming transactions.
+
+## 1. Open transaction review
+
+When OpenBudget detects uncategorized transactions, review them from the Plan
+screen prompt.
+
+![OpenBudget iOS transaction review](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-ios-guide/review-transactions-screen.png)
+
+## 2. Approve and categorize entries
+
+Select a transaction, verify payee/category/amount, then approve it.
+
+## 3. Confirm clean state
+
+After everything is processed, OpenBudget shows the empty review state.
+
+![OpenBudget iOS transaction review complete](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-ios-guide/review-transactions-empty-screen.png)
+
+## 4. Return to Plan
+
+Use **Done** to return to the monthly planning view and continue assigning
+money.

--- a/docs/how-to-use-openbudget.md
+++ b/docs/how-to-use-openbudget.md
@@ -1,0 +1,18 @@
+# OpenBudget iOS Guide
+
+This section is the iOS user guide for OpenBudget. Use the pages below based on
+what you are trying to do.
+
+## Guide pages
+
+- [Plan and priorities flow](./how-to-use-openbudget-plan-and-priorities.md)
+- [Transaction review flow](./how-to-use-openbudget-transaction-review.md)
+- [Recent moves and envelope details flow](./how-to-use-openbudget-recent-moves-and-envelopes.md)
+
+## Recommended daily flow
+
+1. Open the Plan screen and check **Ready to Assign**.
+2. Assign money to key categories.
+3. Review and approve new transactions.
+4. Check Spotlight priorities.
+5. Use recent moves and envelope detail screens to validate category activity.


### PR DESCRIPTION
## Summary
This PR expands the iOS product documentation from a single-page guide into a multi-page flow guide with additional usage paths and screenshot-backed steps.

## What changed
- Added a new docs index page:
  - `docs/how-to-use-openbudget.md`
- Added dedicated flow pages:
  - `docs/how-to-use-openbudget-plan-and-priorities.md`
  - `docs/how-to-use-openbudget-transaction-review.md`
  - `docs/how-to-use-openbudget-recent-moves-and-envelopes.md`

## Why
The previous guide covered only a narrow path. This update documents additional real user flows so onboarding and daily use are clearer:
- monthly planning and priorities
- transaction review/approval
- recent moves auditing and envelope/category drill-down

## Screenshots
All screenshots are hosted in Backblaze and referenced by URL in markdown. No screenshot assets were added to the repository.

## Validation
- `devenv shell -- dprint fmt docs/how-to-use-openbudget.md docs/how-to-use-openbudget-plan-and-priorities.md docs/how-to-use-openbudget-transaction-review.md docs/how-to-use-openbudget-recent-moves-and-envelopes.md`
- `devenv shell -- dprint check docs/how-to-use-openbudget.md docs/how-to-use-openbudget-plan-and-priorities.md docs/how-to-use-openbudget-transaction-review.md docs/how-to-use-openbudget-recent-moves-and-envelopes.md`
- `devenv shell -- lint:all`
