### PR TITLE
feat(settings): persist appearance preferences across launches

### DIFF
--- a/docs/ynab-ui-migration-todo.md
+++ b/docs/ynab-ui-migration-todo.md
@@ -1,6 +1,6 @@
 # OpenBudget UI Migration Tracker (from `~/Downloads/ynab-ui`)
 
-Last updated: 2026-02-24 (Reports dark-mode surface parity)
+Last updated: 2026-02-24 (Appearance preferences persistence + app-icon flow polish)
 
 ## Scope
 
@@ -10,7 +10,7 @@ Last updated: 2026-02-24 (Reports dark-mode surface parity)
 
 ## Progress Snapshot
 
-- Overall migration progress: **~99.8%**
+- Overall migration progress: **~99.85%**
 - Core plan/settings/auth/navigation flows: **implemented**
 - Advanced accounts/transactions flows: **implemented**
 - Reports/appearance polish flows: **in progress**
@@ -23,10 +23,13 @@ Last updated: 2026-02-24 (Reports dark-mode surface parity)
 - 2026-02-24: Patrol flow updated to assert preset range rendering in integration coverage (`openbudget_app/integration_test/reports_flow_test.dart`).
 - 2026-02-24: Patrol flow expanded to assert deterministic preset month-pivot ranges (`December 2025–February 2026` then `November 2025–January 2026`) and aggregated totals.
 - 2026-02-24: Patrol flow expanded to assert dark-mode scaffold background parity for Spending Breakdown.
+- 2026-02-24: Appearance preference notifiers now persist theme/app-icon/privacy formatting state to local UI preferences and hydrate on launch.
+- 2026-02-24: Settings -> App Icon screen updated to use theme-aware surface/background tokens for dark-mode parity.
 - 2026-02-24: PR screenshot artifacts policy active: every migration PR must include at least one runtime screenshot link in PR body/comments.
 - 2026-02-24: PR #127 artifact screenshot (Preset mode): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr127/reports-preset-mode.png
 - 2026-02-24: PR #129 artifact screenshot (Preset range + month anchor): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr129/reports-preset-range-month-anchor.png
 - 2026-02-24: PR #130 artifact screenshot (Dark-mode spending breakdown): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr130/reports-dark-mode-runtime.png
+- 2026-02-24: PR #131 artifact screenshot (Dark-mode app icon settings): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr131/settings-app-icon-dark.png
 
 ## Completed Flows
 
@@ -157,6 +160,7 @@ Last updated: 2026-02-24 (Reports dark-mode surface parity)
 - [x] Integration coverage for opening custom target editor and validating Save button enablement
 - [x] Integration coverage for Reflect dashboard -> Spending Breakdown + Net Worth flows
 - [x] Integration coverage for dark-mode report surfaces (Reflect -> Spending Breakdown)
+- [x] Unit coverage for persisted appearance preference hydration/write behavior
 - [x] Integration CI enforces per-file timeout for stuck integration files with explicit timeout errors
 - [ ] Expand integration tests for remaining pending batches above
 

--- a/openbudget_app/integration_test/settings_flow_test.dart
+++ b/openbudget_app/integration_test/settings_flow_test.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_detail_provider.dart';
 import 'package:openbudget_app/src/features/settings/providers/display_options_provider.dart';
+import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
 import 'package:openbudget_app/src/features/settings/screens/account_settings_screen.dart';
 import 'package:openbudget_app/src/features/settings/screens/app_icon_screen.dart';
 import 'package:openbudget_app/src/features/settings/screens/currency_settings_screen.dart';
@@ -32,9 +33,11 @@ void main() {
     'navigates settings -> plan settings -> currency -> display options',
     ($) async {
       final tester = $.tester;
+      final store = InMemoryUiPreferencesStore();
       final container = ProviderContainer(
         overrides: [
           budgetDetailProvider.overrideWith((ref, id) async => _makeBudget()),
+          uiPreferencesStoreProvider.overrideWithValue(store),
         ],
       );
       addTearDown(container.dispose);
@@ -127,6 +130,10 @@ void main() {
       await tester.tap(find.text('Arrow'));
       await tester.pumpAndSettle();
       expect(container.read(appIconStyleProvider), AppIconStyle.v5);
+      expect(
+        store.readString(UiPreferenceKeys.appIconStyle),
+        AppIconStyle.v5.name,
+      );
 
       await tester.tap(find.text('Done'));
       await tester.pumpAndSettle();
@@ -183,6 +190,13 @@ void main() {
       );
       expect(container.read(hideAmountsProvider), isTrue);
       expect(container.read(hideProgressBarsProvider), isTrue);
+      expect(store.readString(UiPreferenceKeys.themeMode), ThemeMode.dark.name);
+      expect(
+        store.readString(UiPreferenceKeys.balanceStyle),
+        BalanceStyle.differentiateWithoutColor.name,
+      );
+      expect(store.readBool(UiPreferenceKeys.hideAmounts), isTrue);
+      expect(store.readBool(UiPreferenceKeys.hideProgressBars), isTrue);
 
       await tester.tap(find.text('Done'));
       await tester.pumpAndSettle();

--- a/openbudget_app/ios/Podfile.lock
+++ b/openbudget_app/ios/Podfile.lock
@@ -13,6 +13,8 @@ PODS:
   - connectivity_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - flutter_native_splash (2.4.3):
+    - Flutter
   - flutter_secure_storage_darwin (10.0.0):
     - Flutter
     - FlutterMacOS
@@ -47,14 +49,19 @@ PODS:
     - GTMSessionFetcher/Core
   - integration_test (0.0.1):
     - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - patrol (0.0.1):
     - CocoaAsyncSocket (~> 7.6)
     - Flutter
     - FlutterMacOS
+  - PostHog (3.41.2)
+  - posthog_flutter (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - PostHog (< 4.0.0, >= 3.40.0)
   - PromisesObjC (2.4.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sign_in_with_apple (0.0.1):
     - Flutter
   - url_launcher_ios (0.0.1):
@@ -63,12 +70,14 @@ PODS:
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - Flutter (from `Flutter`)
+  - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - patrol (from `.symlinks/plugins/patrol/darwin`)
+  - posthog_flutter (from `.symlinks/plugins/posthog_flutter/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -81,6 +90,7 @@ SPEC REPOS:
     - GoogleUtilities
     - GTMAppAuth
     - GTMSessionFetcher
+    - PostHog
     - PromisesObjC
 
 EXTERNAL SOURCES:
@@ -88,6 +98,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/connectivity_plus/ios"
   Flutter:
     :path: Flutter
+  flutter_native_splash:
+    :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage_darwin:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   flutter_web_auth_2:
@@ -96,10 +108,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   patrol:
     :path: ".symlinks/plugins/patrol/darwin"
+  posthog_flutter:
+    :path: ".symlinks/plugins/posthog_flutter/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sign_in_with_apple:
     :path: ".symlinks/plugins/sign_in_with_apple/ios"
   url_launcher_ios:
@@ -111,19 +125,22 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
   flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
   flutter_web_auth_2: 4091f1645696258ddc57849f62bef2a848fc313c
-  google_sign_in_ios: 4bb0e529b167cadc6ac785b6ed943c0a0a4cc1c9
+  google_sign_in_ios: 7336a3372ea93ea56a21e126a0055ffca3723601
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   patrol: 5a504c6012be7a84369231475ede1fce6e777268
+  PostHog: 2a8daf098230d8e631adbc599b785bd966f7639f
+  posthog_flutter: 30917861666ce0ce3dc83d4f5aae5432ef93b8c0
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
   sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: 671fb9dc313b15dac337c595a3bd3450bb4ed23e
 

--- a/openbudget_app/lib/main.dart
+++ b/openbudget_app/lib/main.dart
@@ -2,16 +2,25 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/analytics/analytics_provider.dart';
+import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
 import 'package:openbudget_app/src/logging/app_logging.dart';
 import 'package:openbudget_app/src/providers/serverpod_client_provider.dart';
 import 'package:openbudget_app/src/providers/theme_mode_provider.dart';
 import 'package:openbudget_app/src/routing/app_router.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  final container = ProviderContainer();
+  final preferences = await SharedPreferences.getInstance();
+  final container = ProviderContainer(
+    overrides: [
+      uiPreferencesStoreProvider.overrideWithValue(
+        SharedPrefsUiPreferencesStore(preferences),
+      ),
+    ],
+  );
   initAppLogging(container.read(serverpodClientProvider));
 
   // Initialize PostHog analytics (no-ops in debug mode).

--- a/openbudget_app/lib/src/features/settings/providers/display_options_provider.dart
+++ b/openbudget_app/lib/src/features/settings/providers/display_options_provider.dart
@@ -1,4 +1,5 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
 
 enum BalanceStyle { standard, differentiateWithoutColor }
 
@@ -44,41 +45,65 @@ final hideProgressBarsProvider =
 
 class BalanceStyleNotifier extends Notifier<BalanceStyle> {
   @override
-  BalanceStyle build() => BalanceStyle.standard;
+  BalanceStyle build() {
+    final rawValue = ref
+        .watch(uiPreferencesStoreProvider)
+        .readString(UiPreferenceKeys.balanceStyle);
+    return enumFromName(BalanceStyle.values, rawValue, BalanceStyle.standard);
+  }
 
   // ignore: use_setters_to_change_properties, Keep explicit command-style API for consistency with other notifiers.
   void setBalanceStyle(BalanceStyle style) {
     state = style;
+    persistString(ref, key: UiPreferenceKeys.balanceStyle, value: style.name);
   }
 }
 
 class AppIconStyleNotifier extends Notifier<AppIconStyle> {
   @override
-  AppIconStyle build() => AppIconStyle.primary;
+  AppIconStyle build() {
+    final rawValue = ref
+        .watch(uiPreferencesStoreProvider)
+        .readString(UiPreferenceKeys.appIconStyle);
+    return enumFromName(AppIconStyle.values, rawValue, AppIconStyle.primary);
+  }
 
   // ignore: use_setters_to_change_properties, Keep explicit command-style API for consistency with other notifiers.
   void setAppIconStyle(AppIconStyle style) {
     state = style;
+    persistString(ref, key: UiPreferenceKeys.appIconStyle, value: style.name);
   }
 }
 
 class HideAmountsNotifier extends Notifier<bool> {
   @override
-  bool build() => false;
+  bool build() {
+    return ref
+            .watch(uiPreferencesStoreProvider)
+            .readBool(UiPreferenceKeys.hideAmounts) ??
+        false;
+  }
 
   // ignore: use_setters_to_change_properties, Keep explicit command-style API for consistency with other notifiers.
   void setHideAmounts({required bool value}) {
     state = value;
+    persistBool(ref, key: UiPreferenceKeys.hideAmounts, value: value);
   }
 }
 
 class HideProgressBarsNotifier extends Notifier<bool> {
   @override
-  bool build() => false;
+  bool build() {
+    return ref
+            .watch(uiPreferencesStoreProvider)
+            .readBool(UiPreferenceKeys.hideProgressBars) ??
+        false;
+  }
 
   // ignore: use_setters_to_change_properties, Keep explicit command-style API for consistency with other notifiers.
   void setHideProgressBars({required bool value}) {
     state = value;
+    persistBool(ref, key: UiPreferenceKeys.hideProgressBars, value: value);
   }
 }
 
@@ -89,11 +114,25 @@ final numberFormatStyleProvider =
 
 class NumberFormatStyleNotifier extends Notifier<NumberFormatStyle> {
   @override
-  NumberFormatStyle build() => NumberFormatStyle.standard;
+  NumberFormatStyle build() {
+    final rawValue = ref
+        .watch(uiPreferencesStoreProvider)
+        .readString(UiPreferenceKeys.numberFormatStyle);
+    return enumFromName(
+      NumberFormatStyle.values,
+      rawValue,
+      NumberFormatStyle.standard,
+    );
+  }
 
   // ignore: use_setters_to_change_properties, Keep explicit command-style API for consistency with other notifiers.
   void setNumberFormat(NumberFormatStyle style) {
     state = style;
+    persistString(
+      ref,
+      key: UiPreferenceKeys.numberFormatStyle,
+      value: style.name,
+    );
   }
 }
 
@@ -104,11 +143,25 @@ final currencyPlacementStyleProvider =
 
 class CurrencyPlacementStyleNotifier extends Notifier<CurrencyPlacementStyle> {
   @override
-  CurrencyPlacementStyle build() => CurrencyPlacementStyle.beforeAmount;
+  CurrencyPlacementStyle build() {
+    final rawValue = ref
+        .watch(uiPreferencesStoreProvider)
+        .readString(UiPreferenceKeys.currencyPlacementStyle);
+    return enumFromName(
+      CurrencyPlacementStyle.values,
+      rawValue,
+      CurrencyPlacementStyle.beforeAmount,
+    );
+  }
 
   // ignore: use_setters_to_change_properties, Keep explicit command-style API for consistency with other notifiers.
   void setCurrencyPlacement(CurrencyPlacementStyle style) {
     state = style;
+    persistString(
+      ref,
+      key: UiPreferenceKeys.currencyPlacementStyle,
+      value: style.name,
+    );
   }
 }
 
@@ -119,10 +172,24 @@ final dateFormatStyleProvider =
 
 class DateFormatStyleNotifier extends Notifier<DateFormatStyle> {
   @override
-  DateFormatStyle build() => DateFormatStyle.monthDayYear;
+  DateFormatStyle build() {
+    final rawValue = ref
+        .watch(uiPreferencesStoreProvider)
+        .readString(UiPreferenceKeys.dateFormatStyle);
+    return enumFromName(
+      DateFormatStyle.values,
+      rawValue,
+      DateFormatStyle.monthDayYear,
+    );
+  }
 
   // ignore: use_setters_to_change_properties, Keep explicit command-style API for consistency with other notifiers.
   void setDateFormat(DateFormatStyle style) {
     state = style;
+    persistString(
+      ref,
+      key: UiPreferenceKeys.dateFormatStyle,
+      value: style.name,
+    );
   }
 }

--- a/openbudget_app/lib/src/features/settings/providers/ui_preferences_store.dart
+++ b/openbudget_app/lib/src/features/settings/providers/ui_preferences_store.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+abstract final class UiPreferenceKeys {
+  static const themeMode = 'ui.themeMode';
+  static const appIconStyle = 'ui.appIconStyle';
+  static const balanceStyle = 'ui.balanceStyle';
+  static const hideAmounts = 'ui.hideAmounts';
+  static const hideProgressBars = 'ui.hideProgressBars';
+  static const numberFormatStyle = 'ui.numberFormatStyle';
+  static const currencyPlacementStyle = 'ui.currencyPlacementStyle';
+  static const dateFormatStyle = 'ui.dateFormatStyle';
+}
+
+abstract interface class UiPreferencesStore {
+  String? readString(String key);
+
+  bool? readBool(String key);
+
+  Future<void> writeString({required String key, required String value});
+
+  Future<void> writeBool({required String key, required bool value});
+}
+
+class SharedPrefsUiPreferencesStore implements UiPreferencesStore {
+  SharedPrefsUiPreferencesStore(this._preferences);
+
+  final SharedPreferences _preferences;
+
+  @override
+  String? readString(String key) => _preferences.getString(key);
+
+  @override
+  bool? readBool(String key) => _preferences.getBool(key);
+
+  @override
+  Future<void> writeString({required String key, required String value}) {
+    return _preferences.setString(key, value);
+  }
+
+  @override
+  Future<void> writeBool({required String key, required bool value}) {
+    return _preferences.setBool(key, value);
+  }
+}
+
+class InMemoryUiPreferencesStore implements UiPreferencesStore {
+  final _values = <String, Object>{};
+
+  @override
+  String? readString(String key) {
+    final value = _values[key];
+    return value is String ? value : null;
+  }
+
+  @override
+  bool? readBool(String key) {
+    final value = _values[key];
+    return value is bool ? value : null;
+  }
+
+  @override
+  Future<void> writeString({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> writeBool({required String key, required bool value}) async {
+    _values[key] = value;
+  }
+}
+
+final uiPreferencesStoreProvider = Provider<UiPreferencesStore>(
+  (ref) => InMemoryUiPreferencesStore(),
+);
+
+T enumFromName<T extends Enum>(Iterable<T> values, String? raw, T fallback) {
+  if (raw == null || raw.isEmpty) {
+    return fallback;
+  }
+
+  for (final value in values) {
+    if (value.name == raw) {
+      return value;
+    }
+  }
+
+  return fallback;
+}
+
+void persistString(Ref ref, {required String key, required String value}) {
+  unawaited(
+    ref.read(uiPreferencesStoreProvider).writeString(key: key, value: value),
+  );
+}
+
+void persistBool(Ref ref, {required String key, required bool value}) {
+  unawaited(
+    ref.read(uiPreferencesStoreProvider).writeBool(key: key, value: value),
+  );
+}

--- a/openbudget_app/lib/src/features/settings/screens/app_icon_screen.dart
+++ b/openbudget_app/lib/src/features/settings/screens/app_icon_screen.dart
@@ -20,9 +20,9 @@ class AppIconScreen extends HookConsumerWidget {
     final currentStyle = ref.watch(appIconStyleProvider);
 
     return Scaffold(
-      backgroundColor: OpenBudgetPalette.appBackground,
+      backgroundColor: OpenBudgetPalette.appBackgroundFor(theme),
       appBar: AppBar(
-        backgroundColor: OpenBudgetPalette.appBackground,
+        backgroundColor: OpenBudgetPalette.appBackgroundFor(theme),
         surfaceTintColor: Colors.transparent,
         centerTitle: true,
         leadingWidth: 120,
@@ -102,7 +102,7 @@ class AppIconScreen extends HookConsumerWidget {
           Text(
             l10n.settingsAppIconHint,
             style: theme.textTheme.bodySmall?.copyWith(
-              color: OpenBudgetPalette.mutedText,
+              color: OpenBudgetPalette.mutedTextFor(theme),
             ),
           ),
         ],
@@ -128,11 +128,12 @@ class _SettingsCard extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: OpenBudgetPalette.surface,
+        color: OpenBudgetPalette.surfaceFor(theme),
         borderRadius: BorderRadius.circular(RadiusTokens.md),
-        border: Border.all(color: OpenBudgetPalette.divider),
+        border: Border.all(color: OpenBudgetPalette.dividerFor(theme)),
       ),
       child: child,
     );
@@ -154,6 +155,7 @@ class _AppIconStyleTile extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return ListTile(
       onTap: onTap,
       leading: selected
@@ -165,7 +167,7 @@ class _AppIconStyleTile extends HookWidget {
         width: 34,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: OpenBudgetPalette.divider),
+          border: Border.all(color: OpenBudgetPalette.dividerFor(theme)),
         ),
         clipBehavior: Clip.antiAlias,
         child: Image.asset(style.previewAssetPath, fit: BoxFit.cover),

--- a/openbudget_app/lib/src/providers/theme_mode_provider.dart
+++ b/openbudget_app/lib/src/providers/theme_mode_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'theme_mode_provider.g.dart';
@@ -7,12 +8,16 @@ part 'theme_mode_provider.g.dart';
 class ThemeModeNotifier extends _$ThemeModeNotifier {
   @override
   ThemeMode build() {
-    return ThemeMode.system;
+    final rawValue = ref
+        .watch(uiPreferencesStoreProvider)
+        .readString(UiPreferenceKeys.themeMode);
+    return enumFromName(ThemeMode.values, rawValue, ThemeMode.system);
   }
 
   // Riverpod notifiers use methods, not setters, for state mutations.
   // ignore: use_setters_to_change_properties
   void setThemeMode(ThemeMode mode) {
     state = mode;
+    persistString(ref, key: UiPreferenceKeys.themeMode, value: mode.name);
   }
 }

--- a/openbudget_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/openbudget_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import flutter_web_auth_2
 import google_sign_in_ios
 import patrol
 import posthog_flutter
+import shared_preferences_foundation
 import sign_in_with_apple
 import url_launcher_macos
 import window_to_front
@@ -24,6 +25,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PatrolPlugin.register(with: registry.registrar(forPlugin: "PatrolPlugin"))
   PosthogFlutterPlugin.register(with: registry.registrar(forPlugin: "PosthogFlutterPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowToFrontPlugin.register(with: registry.registrar(forPlugin: "WindowToFrontPlugin"))

--- a/openbudget_app/pubspec.yaml
+++ b/openbudget_app/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   riverpod_annotation: 4.0.2
   serverpod_auth_idp_flutter: 3.3.1
   serverpod_flutter: 3.3.1
+  shared_preferences: 2.5.3
   shorebird_code_push: 2.0.5
 
 dev_dependencies:

--- a/openbudget_app/test/settings/preferences_persistence_test.dart
+++ b/openbudget_app/test/settings/preferences_persistence_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/src/features/settings/providers/display_options_provider.dart';
+import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
+import 'package:openbudget_app/src/providers/theme_mode_provider.dart';
+
+void main() {
+  group('preferences persistence', () {
+    test(
+      'theme mode hydrates from persisted value and writes updates',
+      () async {
+        final store = InMemoryUiPreferencesStore();
+        await store.writeString(
+          key: UiPreferenceKeys.themeMode,
+          value: ThemeMode.dark.name,
+        );
+
+        final container = ProviderContainer(
+          overrides: [uiPreferencesStoreProvider.overrideWithValue(store)],
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(themeModeProvider), ThemeMode.dark);
+
+        container
+            .read(themeModeProvider.notifier)
+            .setThemeMode(ThemeMode.light);
+        expect(
+          store.readString(UiPreferenceKeys.themeMode),
+          ThemeMode.light.name,
+        );
+      },
+    );
+
+    test(
+      'app icon style hydrates from persisted value and writes updates',
+      () async {
+        final store = InMemoryUiPreferencesStore();
+        await store.writeString(
+          key: UiPreferenceKeys.appIconStyle,
+          value: AppIconStyle.v3.name,
+        );
+
+        final container = ProviderContainer(
+          overrides: [uiPreferencesStoreProvider.overrideWithValue(store)],
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(appIconStyleProvider), AppIconStyle.v3);
+
+        container
+            .read(appIconStyleProvider.notifier)
+            .setAppIconStyle(AppIconStyle.v1);
+        expect(
+          store.readString(UiPreferenceKeys.appIconStyle),
+          AppIconStyle.v1.name,
+        );
+      },
+    );
+
+    test(
+      'display option toggles hydrate from persisted values and write updates',
+      () async {
+        final store = InMemoryUiPreferencesStore();
+        await store.writeBool(key: UiPreferenceKeys.hideAmounts, value: true);
+        await store.writeBool(
+          key: UiPreferenceKeys.hideProgressBars,
+          value: true,
+        );
+
+        final container = ProviderContainer(
+          overrides: [uiPreferencesStoreProvider.overrideWithValue(store)],
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(hideAmountsProvider), isTrue);
+        expect(container.read(hideProgressBarsProvider), isTrue);
+
+        container
+            .read(hideAmountsProvider.notifier)
+            .setHideAmounts(value: false);
+        container
+            .read(hideProgressBarsProvider.notifier)
+            .setHideProgressBars(value: false);
+
+        expect(store.readBool(UiPreferenceKeys.hideAmounts), isFalse);
+        expect(store.readBool(UiPreferenceKeys.hideProgressBars), isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add a UI preferences store abstraction with shared-preferences + in-memory implementations
- persist and hydrate appearance settings: theme mode, app icon style, balance style, hide amounts/progress bars, number/date/currency format options
- initialize persisted preferences in app bootstrap (`main.dart`) via `SharedPreferences`
- make `Settings -> App Icon` use theme-aware background/surface/divider tokens for dark-mode parity
- expand coverage with a new unit test file for preference hydration/writes and extend Patrol settings flow assertions for persisted values
- update migration tracker checkpoints/progress and add PR runtime screenshot artifact link

## Validation
- `fvm flutter analyze openbudget_app/lib/main.dart openbudget_app/lib/src/providers/theme_mode_provider.dart openbudget_app/lib/src/features/settings/providers/display_options_provider.dart openbudget_app/lib/src/features/settings/providers/ui_preferences_store.dart openbudget_app/lib/src/features/settings/screens/app_icon_screen.dart openbudget_app/integration_test/settings_flow_test.dart openbudget_app/test/settings/preferences_persistence_test.dart`
- `fvm flutter test openbudget_app/test/settings/preferences_persistence_test.dart`
- `devenv shell -- env PATROL_TEST_GLOB=integration_test/settings_flow_test.dart ./tools/run_patrol_integration_tests.sh`
- `devenv shell -- ./tools/run_patrol_integration_tests.sh` (13/13 files passing)
- `devenv shell -- dprint fmt --allow-no-files`

## Screenshot
![Dark-mode app icon settings](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr131/settings-app-icon-dark.png)
