### PR TITLE
feat(settings): add dark-mode app icon preview parity

### DIFF
--- a/docs/ynab-ui-migration-todo.md
+++ b/docs/ynab-ui-migration-todo.md
@@ -1,6 +1,6 @@
 # OpenBudget UI Migration Tracker (from `~/Downloads/ynab-ui`)
 
-Last updated: 2026-02-24 (Appearance preferences persistence + app-icon flow polish)
+Last updated: 2026-02-24 (App-icon dark-mode parity + Patrol coverage)
 
 ## Scope
 
@@ -13,7 +13,7 @@ Last updated: 2026-02-24 (Appearance preferences persistence + app-icon flow pol
 - Overall migration progress: **~99.85%**
 - Core plan/settings/auth/navigation flows: **implemented**
 - Advanced accounts/transactions flows: **implemented**
-- Reports/appearance polish flows: **in progress**
+- Reports/appearance polish flows: **implemented**
 
 ## Screenflow Checkpoints
 
@@ -25,6 +25,8 @@ Last updated: 2026-02-24 (Appearance preferences persistence + app-icon flow pol
 - 2026-02-24: Patrol flow expanded to assert dark-mode scaffold background parity for Spending Breakdown.
 - 2026-02-24: Appearance preference notifiers now persist theme/app-icon/privacy formatting state to local UI preferences and hydrate on launch.
 - 2026-02-24: Settings -> App Icon screen updated to use theme-aware surface/background tokens for dark-mode parity.
+- 2026-02-24: App icon previews now resolve by current theme brightness (`light`/`dark`) across Settings -> App Icon and Login branding mark.
+- 2026-02-24: Added dedicated Patrol integration coverage for app icon dark-mode preview asset + style persistence (`integration_test/app_icon_flow_test.dart`).
 - 2026-02-24: PR screenshot artifacts policy active: every migration PR must include at least one runtime screenshot link in PR body/comments.
 - 2026-02-24: PR #127 artifact screenshot (Preset mode): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr127/reports-preset-mode.png
 - 2026-02-24: PR #129 artifact screenshot (Preset range + month anchor): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr129/reports-preset-range-month-anchor.png
@@ -131,7 +133,7 @@ Last updated: 2026-02-24 (Appearance preferences persistence + app-icon flow pol
   - [x] Multi-month/preset advanced analytics polish
 - [ ] Appearance/system flows
   - [x] Dark mode parity pass
-  - [ ] App icon switching parity pass
+  - [x] App icon switching parity pass
 
 ## Validation Status
 
@@ -161,6 +163,7 @@ Last updated: 2026-02-24 (Appearance preferences persistence + app-icon flow pol
 - [x] Integration coverage for Reflect dashboard -> Spending Breakdown + Net Worth flows
 - [x] Integration coverage for dark-mode report surfaces (Reflect -> Spending Breakdown)
 - [x] Unit coverage for persisted appearance preference hydration/write behavior
+- [x] Integration coverage for app-icon dark-mode preview + selection persistence
 - [x] Integration CI enforces per-file timeout for stuck integration files with explicit timeout errors
 - [ ] Expand integration tests for remaining pending batches above
 

--- a/openbudget_app/integration_test/app_icon_flow_test.dart
+++ b/openbudget_app/integration_test/app_icon_flow_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:openbudget_app/l10n/generated/app_localizations.dart';
+import 'package:openbudget_app/src/features/settings/providers/display_options_provider.dart';
+import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
+import 'package:openbudget_app/src/features/settings/screens/app_icon_screen.dart';
+import 'package:patrol/patrol.dart';
+
+void main() {
+  patrolWidgetTest(
+    'app icon screen uses dark icon previews and persists icon selection',
+    ($) async {
+      final tester = $.tester;
+      final store = InMemoryUiPreferencesStore();
+      final container = ProviderContainer(
+        overrides: [uiPreferencesStoreProvider.overrideWithValue(store)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: ThemeData.light(useMaterial3: true),
+            darkTheme: ThemeData.dark(useMaterial3: true),
+            themeMode: ThemeMode.dark,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const AppIconScreen(budgetId: 'test-budget-id'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final sproutTile = find.widgetWithText(ListTile, 'Sprout');
+      final sproutImage = tester.widget<Image>(
+        find.descendant(of: sproutTile, matching: find.byType(Image)).first,
+      );
+      final sproutAsset = sproutImage.image as AssetImage;
+      expect(
+        sproutAsset.assetName,
+        'assets/branding/logos/ob_v3_dark_preview.png',
+      );
+
+      await tester.tap(find.text('Arrow'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(appIconStyleProvider), AppIconStyle.v5);
+      expect(
+        store.readString(UiPreferenceKeys.appIconStyle),
+        AppIconStyle.v5.name,
+      );
+    },
+  );
+}

--- a/openbudget_app/lib/src/features/auth/screens/login_screen.dart
+++ b/openbudget_app/lib/src/features/auth/screens/login_screen.dart
@@ -238,11 +238,15 @@ class _OpenBudgetMark extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
     final appIconStyle = ref.watch(appIconStyleProvider);
     return SizedBox(
       height: 96,
       width: 96,
-      child: Image.asset(appIconStyle.previewAssetPath, fit: BoxFit.contain),
+      child: Image.asset(
+        appIconStyle.previewAssetPathFor(theme.brightness),
+        fit: BoxFit.contain,
+      ),
     );
   }
 }

--- a/openbudget_app/lib/src/features/settings/providers/display_options_provider.dart
+++ b/openbudget_app/lib/src/features/settings/providers/display_options_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
 
@@ -14,14 +15,35 @@ enum DateFormatStyle { monthDayYear, dayMonthYear, yearMonthDay }
 const hiddenAmountPlaceholder = '••••';
 
 extension AppIconStyleAssets on AppIconStyle {
-  String get previewAssetPath => switch (this) {
-    AppIconStyle.primary => 'assets/branding/logos/ob_primary_light_512.png',
-    AppIconStyle.v1 => 'assets/branding/logos/ob_v1_light_preview.png',
-    AppIconStyle.v2 => 'assets/branding/logos/ob_v2_light_preview.png',
-    AppIconStyle.v3 => 'assets/branding/logos/ob_v3_light_preview.png',
-    AppIconStyle.v4 => 'assets/branding/logos/ob_v4_light_preview.png',
-    AppIconStyle.v5 => 'assets/branding/logos/ob_v5_light_preview.png',
-  };
+  String get previewAssetPath => previewAssetPathFor(Brightness.light);
+
+  String previewAssetPathFor(Brightness brightness) =>
+      switch ((this, brightness)) {
+        (AppIconStyle.primary, Brightness.light) =>
+          'assets/branding/logos/ob_primary_light_512.png',
+        (AppIconStyle.primary, Brightness.dark) =>
+          'assets/branding/logos/ob_primary_dark_512.png',
+        (AppIconStyle.v1, Brightness.light) =>
+          'assets/branding/logos/ob_v1_light_preview.png',
+        (AppIconStyle.v1, Brightness.dark) =>
+          'assets/branding/logos/ob_v1_dark_preview.png',
+        (AppIconStyle.v2, Brightness.light) =>
+          'assets/branding/logos/ob_v2_light_preview.png',
+        (AppIconStyle.v2, Brightness.dark) =>
+          'assets/branding/logos/ob_v2_dark_preview.png',
+        (AppIconStyle.v3, Brightness.light) =>
+          'assets/branding/logos/ob_v3_light_preview.png',
+        (AppIconStyle.v3, Brightness.dark) =>
+          'assets/branding/logos/ob_v3_dark_preview.png',
+        (AppIconStyle.v4, Brightness.light) =>
+          'assets/branding/logos/ob_v4_light_preview.png',
+        (AppIconStyle.v4, Brightness.dark) =>
+          'assets/branding/logos/ob_v4_dark_preview.png',
+        (AppIconStyle.v5, Brightness.light) =>
+          'assets/branding/logos/ob_v5_light_preview.png',
+        (AppIconStyle.v5, Brightness.dark) =>
+          'assets/branding/logos/ob_v5_dark_preview.png',
+      };
 }
 
 final balanceStyleProvider =

--- a/openbudget_app/lib/src/features/settings/screens/app_icon_screen.dart
+++ b/openbudget_app/lib/src/features/settings/screens/app_icon_screen.dart
@@ -83,6 +83,9 @@ class AppIconScreen extends HookConsumerWidget {
                     (style) => _AppIconStyleTile(
                       style: style,
                       label: _styleLabel(l10n, style),
+                      previewAssetPath: style.previewAssetPathFor(
+                        theme.brightness,
+                      ),
                       selected: style == currentStyle,
                       onTap: () => ref
                           .read(appIconStyleProvider.notifier)
@@ -144,12 +147,14 @@ class _AppIconStyleTile extends HookWidget {
   const _AppIconStyleTile({
     required this.style,
     required this.label,
+    required this.previewAssetPath,
     required this.selected,
     required this.onTap,
   });
 
   final AppIconStyle style;
   final String label;
+  final String previewAssetPath;
   final bool selected;
   final VoidCallback onTap;
 
@@ -170,7 +175,7 @@ class _AppIconStyleTile extends HookWidget {
           border: Border.all(color: OpenBudgetPalette.dividerFor(theme)),
         ),
         clipBehavior: Clip.antiAlias,
-        child: Image.asset(style.previewAssetPath, fit: BoxFit.cover),
+        child: Image.asset(previewAssetPath, fit: BoxFit.cover),
       ),
     );
   }

--- a/openbudget_app/test/features/settings/screens/app_icon_screen_test.dart
+++ b/openbudget_app/test/features/settings/screens/app_icon_screen_test.dart
@@ -57,5 +57,32 @@ void main() {
 
       expect(container.read(appIconStyleProvider), AppIconStyle.v5);
     });
+
+    testWidgets('uses dark icon previews in dark mode', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: OpenBudgetTheme.light,
+            darkTheme: OpenBudgetTheme.dark,
+            themeMode: ThemeMode.dark,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const AppIconScreen(budgetId: 'test-budget-id'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final sproutTile = find.widgetWithText(ListTile, 'Sprout');
+      final sproutImage = tester.widget<Image>(
+        find.descendant(of: sproutTile, matching: find.byType(Image)).first,
+      );
+      final sproutAsset = sproutImage.image as AssetImage;
+
+      expect(
+        sproutAsset.assetName,
+        'assets/branding/logos/ob_v3_dark_preview.png',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- make `AppIconStyle` preview assets theme-aware (`light`/`dark`)
- apply theme-aware icon previews on `Settings -> App Icon` and login branding mark
- add Patrol coverage for dark-mode app icon preview asset + persisted style selection
- update migration tracker progress for completed app icon switching parity pass

## Screenshots
![app-icon-dark-parity](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr132/settings-app-icon-dark-parity.png)

## Validation
- `devenv shell -- dprint fmt --allow-no-files`
- `cd openbudget_app && fvm flutter analyze lib/src/features/settings/providers/display_options_provider.dart lib/src/features/settings/screens/app_icon_screen.dart lib/src/features/auth/screens/login_screen.dart test/features/settings/screens/app_icon_screen_test.dart integration_test/app_icon_flow_test.dart`
- `cd openbudget_app && fvm flutter test test/features/settings/screens/app_icon_screen_test.dart`
- `devenv shell -- env PATROL_TEST_GLOB=integration_test/app_icon_flow_test.dart ./tools/run_patrol_integration_tests.sh`
- `devenv shell -- ./tools/run_patrol_integration_tests.sh`
