### PR TITLE
test(integration): add screenshot fallback capture for flutter-tester

### DIFF
--- a/docs/ynab-ui-migration-todo.md
+++ b/docs/ynab-ui-migration-todo.md
@@ -1,6 +1,6 @@
 # OpenBudget UI Migration Tracker (from `~/Downloads/ynab-ui`)
 
-Last updated: 2026-02-24 (App-icon dark-mode parity + Patrol coverage)
+Last updated: 2026-02-24 (Patrol screenshot fallback on flutter-tester)
 
 ## Scope
 
@@ -10,7 +10,7 @@ Last updated: 2026-02-24 (App-icon dark-mode parity + Patrol coverage)
 
 ## Progress Snapshot
 
-- Overall migration progress: **~99.85%**
+- Overall migration progress: **~99.9%**
 - Core plan/settings/auth/navigation flows: **implemented**
 - Advanced accounts/transactions flows: **implemented**
 - Reports/appearance polish flows: **implemented**
@@ -27,11 +27,13 @@ Last updated: 2026-02-24 (App-icon dark-mode parity + Patrol coverage)
 - 2026-02-24: Settings -> App Icon screen updated to use theme-aware surface/background tokens for dark-mode parity.
 - 2026-02-24: App icon previews now resolve by current theme brightness (`light`/`dark`) across Settings -> App Icon and Login branding mark.
 - 2026-02-24: Added dedicated Patrol integration coverage for app icon dark-mode preview asset + style persistence (`integration_test/app_icon_flow_test.dart`).
+- 2026-02-24: Patrol screenshot capture now falls back to render-tree capture when `IntegrationTestWidgetsFlutterBinding.takeScreenshot` is unavailable (e.g., `flutter-tester`), writing PNG artifacts instead of skipping.
 - 2026-02-24: PR screenshot artifacts policy active: every migration PR must include at least one runtime screenshot link in PR body/comments.
 - 2026-02-24: PR #127 artifact screenshot (Preset mode): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr127/reports-preset-mode.png
 - 2026-02-24: PR #129 artifact screenshot (Preset range + month anchor): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr129/reports-preset-range-month-anchor.png
 - 2026-02-24: PR #130 artifact screenshot (Dark-mode spending breakdown): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr130/reports-dark-mode-runtime.png
 - 2026-02-24: PR #131 artifact screenshot (Dark-mode app icon settings): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr131/settings-app-icon-dark.png
+- 2026-02-24: PR #132 artifact screenshot (App icon dark-preview parity): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr132/settings-app-icon-dark-parity.png
 
 ## Completed Flows
 
@@ -99,7 +101,7 @@ Last updated: 2026-02-24 (App-icon dark-mode parity + Patrol coverage)
 
 ## In Progress
 
-- [ ] Screenshot capture pipeline stabilization across integration runtimes (`flutter-tester` cannot capture screenshots via plugin)
+- [x] Screenshot capture pipeline stabilization across integration runtimes (`flutter-tester` cannot capture screenshots via plugin)
 - [ ] Recent Moves interaction polish:
   - [x] Destination chip navigation
   - [x] Source chip navigation
@@ -165,6 +167,7 @@ Last updated: 2026-02-24 (App-icon dark-mode parity + Patrol coverage)
 - [x] Unit coverage for persisted appearance preference hydration/write behavior
 - [x] Integration coverage for app-icon dark-mode preview + selection persistence
 - [x] Integration CI enforces per-file timeout for stuck integration files with explicit timeout errors
+- [x] Integration screenshot capture persists runtime PNG artifacts on `flutter-tester` via repaint fallback
 - [ ] Expand integration tests for remaining pending batches above
 
 ## Deletion Criteria

--- a/openbudget_app/integration_test/helpers/screenshot_capture.dart
+++ b/openbudget_app/integration_test/helpers/screenshot_capture.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+Future<void> captureIntegrationScreenshot(
+  WidgetTester tester,
+  String name,
+) async {
+  final bytes =
+      await _captureViaIntegrationBinding(tester, name) ??
+      await _captureViaRenderView(tester) ??
+      await _captureViaRepaintBoundary(tester);
+
+  if (bytes == null || bytes.isEmpty) {
+    // ignore: avoid_print, reason: keeps CI/test logs explicit when capture cannot run.
+    print(
+      'Skipping screenshot capture for $name: no supported capture backend',
+    );
+    return;
+  }
+
+  final screenshotRootFromEnv = Platform
+      .environment['OPENBUDGET_SCREENSHOT_DIR']
+      ?.trim();
+  final screenshotRoot =
+      screenshotRootFromEnv == null || screenshotRootFromEnv.isEmpty
+      ? '${Directory.systemTemp.path}/openbudget_screenshots/runtime'
+      : screenshotRootFromEnv;
+  final screenshotDir = Directory(screenshotRoot);
+  if (!screenshotDir.existsSync()) {
+    screenshotDir.createSync(recursive: true);
+  }
+
+  final screenshotPath = '${screenshotDir.path}/$name.png';
+  File(screenshotPath).writeAsBytesSync(bytes);
+  // ignore: avoid_print, reason: exposes generated artifact path in CI/test logs.
+  print('Saved screenshot: $screenshotPath');
+}
+
+Future<Uint8List?> _captureViaIntegrationBinding(
+  WidgetTester tester,
+  String name,
+) async {
+  final binding = tester.binding;
+  if (binding is! IntegrationTestWidgetsFlutterBinding) {
+    return null;
+  }
+
+  try {
+    final bytes = await binding.takeScreenshot(name);
+    return Uint8List.fromList(bytes);
+  } catch (error) {
+    if (error is MissingPluginException || error is UnimplementedError) {
+      // ignore: avoid_print, reason: plugin is unavailable in flutter-tester; we fall back below.
+      print('Screenshot plugin unavailable for $name; using repaint fallback');
+      return null;
+    }
+    rethrow;
+  }
+}
+
+Future<Uint8List?> _captureViaRepaintBoundary(WidgetTester tester) async {
+  await tester.pump();
+
+  final boundaries = find
+      .byType(RepaintBoundary, skipOffstage: false)
+      .evaluate()
+      .map((element) => element.renderObject)
+      .whereType<RenderRepaintBoundary>();
+
+  RenderRepaintBoundary? largestBoundary;
+  var largestArea = 0.0;
+
+  for (final boundary in boundaries) {
+    if (!boundary.hasSize) {
+      continue;
+    }
+    final size = boundary.size;
+    if (size.isEmpty || !size.isFinite) {
+      continue;
+    }
+    final area = size.width * size.height;
+    if (area > largestArea) {
+      largestArea = area;
+      largestBoundary = boundary;
+    }
+  }
+
+  if (largestBoundary == null) {
+    return null;
+  }
+
+  final pixelRatio = tester.view.devicePixelRatio > 0
+      ? tester.view.devicePixelRatio
+      : 1.0;
+  final image = await largestBoundary.toImage(pixelRatio: pixelRatio);
+  final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+  if (bytes == null) {
+    return null;
+  }
+
+  return bytes.buffer.asUint8List();
+}
+
+Future<Uint8List?> _captureViaRenderView(WidgetTester tester) async {
+  await tester.pump();
+
+  final renderViews = tester.binding.renderViews;
+  if (renderViews.isEmpty) {
+    return null;
+  }
+
+  final renderView = renderViews.first;
+  final layer = renderView.debugLayer;
+  if (layer is! OffsetLayer) {
+    return null;
+  }
+
+  final pixelRatio = tester.view.devicePixelRatio > 0
+      ? tester.view.devicePixelRatio
+      : 1.0;
+  final image = await layer.toImage(
+    renderView.paintBounds,
+    pixelRatio: pixelRatio,
+  );
+  final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+  if (bytes == null) {
+    return null;
+  }
+  return bytes.buffer.asUint8List();
+}

--- a/openbudget_app/integration_test/plan_screens_flow_test.dart
+++ b/openbudget_app/integration_test/plan_screens_flow_test.dart
@@ -1,15 +1,11 @@
-import 'dart:io';
-
 // Serverpod's UuidValue.fromString is marked experimental.
 // ignore_for_file: experimental_member_use
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:integration_test/integration_test.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_goals_provider.dart';
 import 'package:openbudget_app/src/features/budget/providers/budget_summary_provider.dart';
@@ -23,6 +19,8 @@ import 'package:openbudget_app/src/features/recurring/providers/recurring_auto_p
 import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:patrol/patrol.dart';
+
+import 'helpers/screenshot_capture.dart';
 
 const _budgetId = '00000000-0000-0000-0000-000000000901';
 const _categoryId = '00000000-0000-0000-0000-000000000902';
@@ -380,7 +378,7 @@ void main() {
           amountCents: 3000,
         );
     await tester.pumpAndSettle();
-    await _captureScreenshot(tester, 'plan-screen');
+    await captureIntegrationScreenshot(tester, 'plan-screen');
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Finish Onboarding'));
     await tester.pumpAndSettle();
@@ -389,7 +387,7 @@ void main() {
     await tester.tap(find.text('Review 1 transaction'));
     await tester.pumpAndSettle();
     expect(find.text('1 New Transaction'), findsOneWidget);
-    await _captureScreenshot(tester, 'review-transactions-screen');
+    await captureIntegrationScreenshot(tester, 'review-transactions-screen');
     await tester.pump(const Duration(seconds: 1));
 
     await tester.tap(find.text('Landlord'));
@@ -399,15 +397,21 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('No Transactions'), findsOneWidget);
     expect(find.text("You're All Done!"), findsOneWidget);
-    await _captureScreenshot(tester, 'review-transactions-empty-screen');
+    await captureIntegrationScreenshot(
+      tester,
+      'review-transactions-empty-screen',
+    );
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Done'));
     await tester.pumpAndSettle();
-    await _captureScreenshot(tester, 'plan-screen-onboarding-dismissed');
+    await captureIntegrationScreenshot(
+      tester,
+      'plan-screen-onboarding-dismissed',
+    );
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Spotlight'));
     await tester.pumpAndSettle();
-    await _captureScreenshot(tester, 'spotlight-screen');
+    await captureIntegrationScreenshot(tester, 'spotlight-screen');
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Categories'));
     await tester.pumpAndSettle();
@@ -416,7 +420,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.more_horiz_rounded));
     await tester.pumpAndSettle();
     expect(find.text('Hide Amounts'), findsOneWidget);
-    await _captureScreenshot(tester, 'plan-menu');
+    await captureIntegrationScreenshot(tester, 'plan-menu');
     await tester.pump(const Duration(seconds: 1));
 
     await _tapPopupMenuItem(tester, 'Undo');
@@ -474,11 +478,11 @@ void main() {
     await tester.pumpAndSettle();
     await _tapPopupMenuItem(tester, 'Recent Moves');
     await _dismissCoachmarkIfVisible(tester);
-    await _captureScreenshot(tester, 'recent-moves-screen');
+    await captureIntegrationScreenshot(tester, 'recent-moves-screen');
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Moved'));
     await tester.pumpAndSettle();
-    await _captureScreenshot(tester, 'recent-moves-moved-screen');
+    await captureIntegrationScreenshot(tester, 'recent-moves-moved-screen');
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Self storage').first);
     await tester.pumpAndSettle();
@@ -489,7 +493,7 @@ void main() {
 
     await tester.tap(find.text('Utilities').first);
     await tester.pumpAndSettle();
-    await _captureScreenshot(tester, 'envelope-moves-screen');
+    await captureIntegrationScreenshot(tester, 'envelope-moves-screen');
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Done'));
     await tester.pumpAndSettle();
@@ -500,11 +504,11 @@ void main() {
 
     await tester.tap(find.text('Utilities'));
     await tester.pumpAndSettle();
-    await _captureScreenshot(tester, 'plan-inline-editor-screen');
+    await captureIntegrationScreenshot(tester, 'plan-inline-editor-screen');
     await tester.pump(const Duration(seconds: 1));
     await tester.tap(find.text('Details'));
     await tester.pumpAndSettle();
-    await _captureScreenshot(tester, 'category-detail-screen');
+    await captureIntegrationScreenshot(tester, 'category-detail-screen');
     await tester.pump(const Duration(seconds: 1));
     expect(find.text('Balance'), findsOneWidget);
     expect(find.text('Set Goal'), findsOneWidget);
@@ -653,41 +657,6 @@ void main() {
 
     expect(find.byIcon(Icons.swap_vert_rounded), findsOneWidget);
   });
-}
-
-Future<void> _captureScreenshot(WidgetTester tester, String name) async {
-  final binding = tester.binding;
-  if (binding is! IntegrationTestWidgetsFlutterBinding) {
-    // Logging here keeps the CI output explicit when screenshot capture is not
-    // supported by the active test binding.
-    // ignore: avoid_print
-    print('Skipping screenshot capture for $name: unsupported test binding');
-    return;
-  }
-
-  List<int> bytes;
-  try {
-    bytes = await binding.takeScreenshot(name);
-  } on MissingPluginException {
-    // Some test runtimes (for example flutter-tester) don't expose screenshot
-    // capture. Keep test assertions focused on behavior in those environments.
-    // ignore: avoid_print
-    print('Skipping screenshot capture for $name: plugin unavailable');
-    return;
-  }
-  if (bytes.isEmpty) return;
-
-  final screenshotDir = Directory(
-    '${Directory.systemTemp.path}/openbudget_screenshots/runtime',
-  );
-  if (!screenshotDir.existsSync()) {
-    screenshotDir.createSync(recursive: true);
-  }
-  final screenshotPath = '${screenshotDir.path}/$name.png';
-  File(screenshotPath).writeAsBytesSync(bytes);
-  // Expose location in test logs for host-side collection.
-  // ignore: avoid_print
-  print('Saved screenshot: $screenshotPath');
 }
 
 Future<void> _tapPopupMenuItem(WidgetTester tester, String label) async {

--- a/openbudget_app/integration_test/reports_flow_test.dart
+++ b/openbudget_app/integration_test/reports_flow_test.dart
@@ -1,14 +1,10 @@
 // Serverpod's UuidValue.fromString is marked experimental.
 // ignore_for_file: experimental_member_use
 
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:integration_test/integration_test.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/providers/age_of_money_provider.dart';
 import 'package:openbudget_app/src/features/reports/providers/net_worth_provider.dart';
@@ -22,6 +18,8 @@ import 'package:openbudget_client/openbudget_client.dart';
 import 'package:openbudget_core/openbudget_core.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
 import 'package:patrol/patrol.dart';
+
+import 'helpers/screenshot_capture.dart';
 
 const _budgetId = 'test-budget-id';
 final _budgetUuid = UuidValue.fromString(
@@ -234,7 +232,10 @@ void main() {
       expect(find.text('January 2026'), findsOneWidget);
       expect(find.text('November 2025–January 2026'), findsOneWidget);
       expect(find.textContaining(r'$5,960.00'), findsOneWidget);
-      await _captureScreenshot(tester, 'reports-spending-breakdown-preset');
+      await captureIntegrationScreenshot(
+        tester,
+        'reports-spending-breakdown-preset',
+      );
     },
   );
 
@@ -252,34 +253,4 @@ void main() {
     expect(find.text('Assets'), findsWidgets);
     expect(find.text('Liabilities'), findsWidgets);
   });
-}
-
-Future<void> _captureScreenshot(WidgetTester tester, String name) async {
-  final binding = tester.binding;
-  if (binding is! IntegrationTestWidgetsFlutterBinding) {
-    // ignore: avoid_print, reason: keeps CI logs explicit when screenshot capture is unavailable.
-    print('Skipping screenshot capture for $name: unsupported test binding');
-    return;
-  }
-
-  List<int> bytes;
-  try {
-    bytes = await binding.takeScreenshot(name);
-  } on MissingPluginException {
-    // ignore: avoid_print, reason: keeps CI logs explicit when screenshot plugin is unavailable.
-    print('Skipping screenshot capture for $name: plugin unavailable');
-    return;
-  }
-  if (bytes.isEmpty) return;
-
-  final screenshotDir = Directory(
-    '${Directory.systemTemp.path}/openbudget_screenshots/runtime',
-  );
-  if (!screenshotDir.existsSync()) {
-    screenshotDir.createSync(recursive: true);
-  }
-  final screenshotPath = '${screenshotDir.path}/$name.png';
-  File(screenshotPath).writeAsBytesSync(bytes);
-  // ignore: avoid_print, reason: exposes generated artifact path in CI/test logs.
-  print('Saved screenshot: $screenshotPath');
 }


### PR DESCRIPTION
## Summary
- add a shared integration screenshot helper that first tries the integration screenshot plugin
- add fallback PNG capture via render-view and repaint-boundary paths when plugin capture is unavailable (for example flutter-tester)
- refactor plan/reports integration tests to use the shared helper
- update migration tracker with screenshot-pipeline completion status

## Screenshot Artifact
- https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr133/reports-spending-breakdown-preset.png

## Verification
- devenv shell -- dart format openbudget_app/integration_test/helpers/screenshot_capture.dart openbudget_app/integration_test/plan_screens_flow_test.dart openbudget_app/integration_test/reports_flow_test.dart
- devenv shell -- dprint fmt --allow-no-files
- devenv shell -- flutter analyze openbudget_app/integration_test/helpers/screenshot_capture.dart openbudget_app/integration_test/plan_screens_flow_test.dart openbudget_app/integration_test/reports_flow_test.dart
- devenv shell -- OPENBUDGET_SCREENSHOT_DIR=$PWD/.screenshots/2026-02-24-pr133 PATROL_TEST_GLOB=integration_test/plan_screens_flow_test.dart ./tools/run_patrol_integration_tests.sh
- devenv shell -- OPENBUDGET_SCREENSHOT_DIR=$PWD/.screenshots/2026-02-24-pr133 PATROL_TEST_GLOB=integration_test/reports_flow_test.dart ./tools/run_patrol_integration_tests.sh
- devenv shell -- ./tools/run_patrol_integration_tests.sh
