### PR TITLE
feat(plan): polish recent moves list spacing and headings

### DIFF
--- a/docs/ynab-ui-migration-todo.md
+++ b/docs/ynab-ui-migration-todo.md
@@ -1,6 +1,6 @@
 # OpenBudget UI Migration Tracker (from `~/Downloads/ynab-ui`)
 
-Last updated: 2026-02-24 (Patrol screenshot fallback on flutter-tester)
+Last updated: 2026-02-24 (Recent Moves visual polish)
 
 ## Scope
 
@@ -28,6 +28,7 @@ Last updated: 2026-02-24 (Patrol screenshot fallback on flutter-tester)
 - 2026-02-24: App icon previews now resolve by current theme brightness (`light`/`dark`) across Settings -> App Icon and Login branding mark.
 - 2026-02-24: Added dedicated Patrol integration coverage for app icon dark-mode preview asset + style persistence (`integration_test/app_icon_flow_test.dart`).
 - 2026-02-24: Patrol screenshot capture now falls back to render-tree capture when `IntegrationTestWidgetsFlutterBinding.takeScreenshot` is unavailable (e.g., `flutter-tester`), writing PNG artifacts instead of skipping.
+- 2026-02-24: Recent Moves list rows now use improved day-heading typography (relative label + date split) and divider-backed spacing for closer parity.
 - 2026-02-24: PR screenshot artifacts policy active: every migration PR must include at least one runtime screenshot link in PR body/comments.
 - 2026-02-24: PR #127 artifact screenshot (Preset mode): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr127/reports-preset-mode.png
 - 2026-02-24: PR #129 artifact screenshot (Preset range + month anchor): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr129/reports-preset-range-month-anchor.png
@@ -106,7 +107,7 @@ Last updated: 2026-02-24 (Patrol screenshot fallback on flutter-tester)
   - [x] Destination chip navigation
   - [x] Source chip navigation
   - [x] Undo integration from plan menu
-  - [ ] Additional visual parity polish for row spacing/typography
+  - [x] Additional visual parity polish for row spacing/typography
 - [x] Plan menu behavior polish for mobile transitions
 
 ## Pending Flows (Next Batches)

--- a/openbudget_app/lib/src/features/budget/screens/recent_moves_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/recent_moves_screen.dart
@@ -516,38 +516,81 @@ class _RecentMovesList extends HookWidget {
               SpacingTokens.md,
               SpacingTokens.xs,
             ),
-            child: Text(
-              _dayHeading(l10n, day),
-              style: Theme.of(
-                context,
-              ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
-            ),
+            child: _buildDayHeading(context, l10n, day),
           ),
-          for (final event in grouped[day]!)
+          for (
+            var eventIndex = 0;
+            eventIndex < grouped[day]!.length;
+            eventIndex++
+          )
             _RecentMoveRow(
-              event: event,
+              event: grouped[day]![eventIndex],
               envelopeNames: envelopeNames,
               currencyCode: currencyCode,
               hideAmounts: hideAmounts,
               onEnvelopeTap: onEnvelopeTap,
+              showDivider: eventIndex < grouped[day]!.length - 1,
             ),
         ],
       ],
     );
   }
 
-  String _dayHeading(AppLocalizations l10n, DateTime day) {
+  Widget _buildDayHeading(
+    BuildContext context,
+    AppLocalizations l10n,
+    DateTime day,
+  ) {
+    final theme = Theme.of(context);
+    final heading = _dayHeading(l10n, day);
+    if (heading.relativeLabel == null) {
+      return Text(
+        heading.dateLabel,
+        style: theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w700,
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          heading.relativeLabel!,
+          style: theme.textTheme.bodyLarge?.copyWith(
+            fontWeight: FontWeight.w500,
+            color: OpenBudgetPalette.mutedTextFor(theme),
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          heading.dateLabel,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+
+  _DayHeadingData _dayHeading(AppLocalizations l10n, DateTime day) {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
     final yesterday = today.subtract(const Duration(days: 1));
 
     if (day == today) {
-      return '${l10n.transactionDateToday}\n${_formatDate(l10n, day)}';
+      return _DayHeadingData(
+        relativeLabel: l10n.transactionDateToday,
+        dateLabel: _formatDate(l10n, day),
+      );
     }
     if (day == yesterday) {
-      return '${l10n.transactionDateYesterday}\n${_formatDate(l10n, day)}';
+      return _DayHeadingData(
+        relativeLabel: l10n.transactionDateYesterday,
+        dateLabel: _formatDate(l10n, day),
+      );
     }
-    return _formatDate(l10n, day);
+    return _DayHeadingData(dateLabel: _formatDate(l10n, day));
   }
 
   String _formatDate(AppLocalizations l10n, DateTime day) {
@@ -578,6 +621,7 @@ class _RecentMoveRow extends HookWidget {
     required this.currencyCode,
     required this.hideAmounts,
     required this.onEnvelopeTap,
+    required this.showDivider,
   });
 
   final RecentMoveEvent event;
@@ -585,6 +629,7 @@ class _RecentMoveRow extends HookWidget {
   final CurrencyCode currencyCode;
   final bool hideAmounts;
   final ValueChanged<String> onEnvelopeTap;
+  final bool showDivider;
 
   @override
   Widget build(BuildContext context) {
@@ -601,45 +646,53 @@ class _RecentMoveRow extends HookWidget {
         ? envelopeNames[sourceEnvelopeId] ?? l10n.recentMovesUnnamedEnvelope
         : l10n.recentMovesReadyToAssign;
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        SpacingTokens.md,
-        SpacingTokens.xs,
-        SpacingTokens.md,
-        SpacingTokens.xs,
-      ),
-      child: Row(
+    return ColoredBox(
+      color: OpenBudgetPalette.surfaceFor(theme),
+      child: Column(
         children: [
-          _MoveChip(
-            label: fromName,
-            accent: sourceEnvelopeId != null,
-            onTap: sourceEnvelopeId != null
-                ? () => onEnvelopeTap(sourceEnvelopeId)
-                : null,
-          ),
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: SpacingTokens.xs),
-            child: Icon(
-              Icons.arrow_forward_rounded,
-              size: 16,
-              color: OpenBudgetPalette.mutedText,
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              SpacingTokens.md,
+              SpacingTokens.sm,
+              SpacingTokens.md,
+              SpacingTokens.sm,
+            ),
+            child: Row(
+              children: [
+                _MoveChip(
+                  label: fromName,
+                  accent: sourceEnvelopeId != null,
+                  onTap: sourceEnvelopeId != null
+                      ? () => onEnvelopeTap(sourceEnvelopeId)
+                      : null,
+                ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: SpacingTokens.xs),
+                  child: Icon(
+                    Icons.arrow_forward_rounded,
+                    size: 16,
+                    color: OpenBudgetPalette.mutedText,
+                  ),
+                ),
+                _MoveChip(
+                  label: toName,
+                  accent: true,
+                  onTap: () => onEnvelopeTap(event.toEnvelopeId),
+                ),
+                const SizedBox(width: SpacingTokens.sm),
+                Expanded(
+                  child: Text(
+                    amountText,
+                    textAlign: TextAlign.right,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
-          _MoveChip(
-            label: toName,
-            accent: true,
-            onTap: () => onEnvelopeTap(event.toEnvelopeId),
-          ),
-          const SizedBox(width: SpacingTokens.sm),
-          Expanded(
-            child: Text(
-              amountText,
-              textAlign: TextAlign.right,
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-          ),
+          if (showDivider) const Divider(height: 1),
         ],
       ),
     );
@@ -755,16 +808,17 @@ class _MoveChip extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final accentFill = theme.brightness == Brightness.dark
+        ? OpenBudgetPalette.accentBlue.withAlpha(38)
+        : OpenBudgetPalette.accentBlue.withAlpha(24);
     final chip = Container(
-      constraints: const BoxConstraints(maxWidth: 140),
+      constraints: const BoxConstraints(maxWidth: 152),
       padding: const EdgeInsets.symmetric(
         horizontal: SpacingTokens.sm,
-        vertical: 6,
+        vertical: 7,
       ),
       decoration: BoxDecoration(
-        color: accent
-            ? OpenBudgetPalette.accentBlue.withAlpha(30)
-            : OpenBudgetPalette.surfaceMuted,
+        color: accent ? accentFill : OpenBudgetPalette.surfaceMutedFor(theme),
         borderRadius: BorderRadius.circular(RadiusTokens.sm),
       ),
       child: Text(
@@ -785,6 +839,14 @@ class _MoveChip extends HookWidget {
       child: chip,
     );
   }
+}
+
+@immutable
+class _DayHeadingData {
+  const _DayHeadingData({required this.dateLabel, this.relativeLabel});
+
+  final String dateLabel;
+  final String? relativeLabel;
 }
 
 class _EmptyMovesState extends HookWidget {

--- a/openbudget_app/test/features/budget/screens/recent_moves_screen_test.dart
+++ b/openbudget_app/test/features/budget/screens/recent_moves_screen_test.dart
@@ -138,6 +138,8 @@ void main() {
       await _dismissCoachmarkIfVisible(tester);
 
       expect(find.text('Recent Moves'), findsWidgets);
+      expect(find.text('Today'), findsOneWidget);
+      expect(find.textContaining(DateTime.now().year.toString()), findsWidgets);
       expect(find.text('All'), findsOneWidget);
       expect(find.text('Moved'), findsOneWidget);
       expect(find.text('Assigned'), findsOneWidget);


### PR DESCRIPTION
## Summary
- polish Recent Moves list heading typography to split relative day label and date for better readability
- add divider-backed spacing between move rows for closer mobile parity
- fine-tune move chip sizing/fill across light/dark themes
- update migration tracker to mark Recent Moves visual polish complete

## Screenshot Artifact
- https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr134/recent-moves-screen.png

## Verification
- devenv shell -- dart format openbudget_app/lib/src/features/budget/screens/recent_moves_screen.dart openbudget_app/test/features/budget/screens/recent_moves_screen_test.dart
- devenv shell -- dprint fmt --allow-no-files
- devenv shell -- flutter analyze openbudget_app/lib/src/features/budget/screens/recent_moves_screen.dart openbudget_app/test/features/budget/screens/recent_moves_screen_test.dart
- devenv shell -- flutter test openbudget_app/test/features/budget/screens/recent_moves_screen_test.dart
- devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=$PWD/.screenshots/2026-02-24-pr134 PATROL_TEST_GLOB=integration_test/plan_screens_flow_test.dart ./tools/run_patrol_integration_tests.sh
