### PR TITLE
feat(accounts): add staged loading parity for add account flow

### DIFF
--- a/docs/ynab-ui-migration-todo.md
+++ b/docs/ynab-ui-migration-todo.md
@@ -1,6 +1,6 @@
 # OpenBudget UI Migration Tracker (from `~/Downloads/ynab-ui`)
 
-Last updated: 2026-02-24 (Recent Moves visual polish)
+Last updated: 2026-02-24 (Add Accounts staged loading parity)
 
 ## Scope
 
@@ -29,6 +29,7 @@ Last updated: 2026-02-24 (Recent Moves visual polish)
 - 2026-02-24: Added dedicated Patrol integration coverage for app icon dark-mode preview asset + style persistence (`integration_test/app_icon_flow_test.dart`).
 - 2026-02-24: Patrol screenshot capture now falls back to render-tree capture when `IntegrationTestWidgetsFlutterBinding.takeScreenshot` is unavailable (e.g., `flutter-tester`), writing PNG artifacts instead of skipping.
 - 2026-02-24: Recent Moves list rows now use improved day-heading typography (relative label + date split) and divider-backed spacing for closer parity.
+- 2026-02-24: Add Accounts flow now includes staged loading states (`Loading...` then `Loading institutions...`) with OpenBudget-branded logo treatment before bank search.
 - 2026-02-24: PR screenshot artifacts policy active: every migration PR must include at least one runtime screenshot link in PR body/comments.
 - 2026-02-24: PR #127 artifact screenshot (Preset mode): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr127/reports-preset-mode.png
 - 2026-02-24: PR #129 artifact screenshot (Preset range + month anchor): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr129/reports-preset-range-month-anchor.png

--- a/openbudget_app/integration_test/account_flow_test.dart
+++ b/openbudget_app/integration_test/account_flow_test.dart
@@ -21,6 +21,8 @@ import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_client/openbudget_client.dart';
 import 'package:patrol/patrol.dart';
 
+import 'helpers/screenshot_capture.dart';
+
 const _budgetId = 'test-budget-id';
 final _budgetUuid = UuidValue.fromString(
   '00000000-0000-0000-0000-000000000010',
@@ -213,11 +215,20 @@ void main() {
 
     expect(find.text('No Accounts Yet'), findsOneWidget);
     await tester.tap(find.text('Add Account'));
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+    expect(find.text('Loading institutions...'), findsOneWidget);
+    await captureIntegrationScreenshot(
+      tester,
+      'add-accounts-loading-institutions-screen',
+    );
+    await tester.pump(const Duration(milliseconds: 1000));
     await tester.pumpAndSettle();
 
     expect(find.text('Add Accounts'), findsOneWidget);
     expect(find.text('Search for your bank'), findsOneWidget);
     expect(find.text('Add an Unlinked Account'), findsOneWidget);
+    await captureIntegrationScreenshot(tester, 'add-accounts-search-screen');
 
     await tester.tap(find.text('Add an Unlinked Account'));
     await tester.pumpAndSettle();
@@ -240,7 +251,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Add Account'));
-    await tester.pumpAndSettle();
+    await _pumpToAddAccountSearch(tester);
 
     await tester.tap(find.text('Chase'));
     await tester.pump(const Duration(milliseconds: 900));
@@ -261,7 +272,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Add Account'));
-      await tester.pumpAndSettle();
+      await _pumpToAddAccountSearch(tester);
       await tester.tap(find.text('Add an Unlinked Account'));
       await tester.pumpAndSettle();
 
@@ -295,7 +306,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Add Account'));
-      await tester.pumpAndSettle();
+      await _pumpToAddAccountSearch(tester);
       await tester.tap(find.text('Add an Unlinked Account'));
       await tester.pumpAndSettle();
 
@@ -614,4 +625,9 @@ void main() {
     expect(find.text('Payment from Daily'), findsOneWidget);
     expect(find.text('Payments'), findsOneWidget);
   });
+}
+
+Future<void> _pumpToAddAccountSearch(WidgetTester tester) async {
+  await tester.pump(const Duration(milliseconds: 1500));
+  await tester.pumpAndSettle();
 }

--- a/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
@@ -15,6 +15,7 @@ import 'package:openbudget_ui/openbudget_ui.dart';
 
 enum _AddAccountStep {
   loading,
+  loadingInstitutions,
   searchBank,
   unlinkedAccount,
   accountType,
@@ -70,6 +71,16 @@ class AddAccountScreen extends HookConsumerWidget {
 
     useEffect(() {
       if (step.value != _AddAccountStep.loading) return null;
+      final timer = Timer(const Duration(milliseconds: 450), () {
+        if (context.mounted) {
+          step.value = _AddAccountStep.loadingInstitutions;
+        }
+      });
+      return timer.cancel;
+    }, [step.value]);
+
+    useEffect(() {
+      if (step.value != _AddAccountStep.loadingInstitutions) return null;
       final timer = Timer(const Duration(milliseconds: 900), () {
         if (context.mounted) {
           step.value = _AddAccountStep.searchBank;
@@ -151,13 +162,17 @@ class AddAccountScreen extends HookConsumerWidget {
         surfaceTintColor: Colors.transparent,
         scrolledUnderElevation: 0,
         automaticallyImplyLeading: false,
-        leading: step.value == _AddAccountStep.searchBank
+        leading:
+            step.value == _AddAccountStep.loading ||
+                step.value == _AddAccountStep.loadingInstitutions ||
+                step.value == _AddAccountStep.searchBank
             ? null
             : IconButton(
                 icon: const Icon(Icons.arrow_back_ios_new_rounded),
                 onPressed: () {
                   switch (step.value) {
                     case _AddAccountStep.loading:
+                    case _AddAccountStep.loadingInstitutions:
                       break;
                     case _AddAccountStep.searchBank:
                       break;
@@ -172,7 +187,8 @@ class AddAccountScreen extends HookConsumerWidget {
               ),
         title: Text(
           switch (step.value) {
-            _AddAccountStep.loading => 'Add Accounts',
+            _AddAccountStep.loading => '',
+            _AddAccountStep.loadingInstitutions => 'Add Accounts',
             _AddAccountStep.searchBank => 'Add Accounts',
             _AddAccountStep.unlinkedAccount => 'Add Unlinked Account',
             _AddAccountStep.accountType => 'Select Account Type',
@@ -195,7 +211,14 @@ class AddAccountScreen extends HookConsumerWidget {
       body: Stack(
         children: [
           switch (step.value) {
-            _AddAccountStep.loading => const _LoadingStep(),
+            _AddAccountStep.loading => const _LoadingStep(
+              title: 'Loading...',
+              includeSpinner: false,
+            ),
+            _AddAccountStep.loadingInstitutions => const _LoadingStep(
+              title: 'Loading institutions...',
+              includeSpinner: true,
+            ),
             _AddAccountStep.searchBank => _BankSearchStep(
               searchController: searchController,
               onSearchSubmitted: startLinkedBankFlow,
@@ -260,6 +283,7 @@ class AddAccountScreen extends HookConsumerWidget {
       ),
       bottomNavigationBar: switch (step.value) {
         _AddAccountStep.loading => null,
+        _AddAccountStep.loadingInstitutions => null,
         _AddAccountStep.unlinkedAccount => SafeArea(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(
@@ -290,25 +314,41 @@ class AddAccountScreen extends HookConsumerWidget {
 }
 
 class _LoadingStep extends StatelessWidget {
-  const _LoadingStep();
+  const _LoadingStep({required this.title, required this.includeSpinner});
+
+  final String title;
+  final bool includeSpinner;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final logoAsset = theme.brightness == Brightness.dark
+        ? 'assets/branding/logos/ob_primary_dark_512.png'
+        : 'assets/branding/logos/ob_primary_light_512.png';
+
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: SpacingTokens.xl),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              Icons.account_balance_rounded,
-              size: 72,
-              color: theme.colorScheme.primary,
+            ClipRRect(
+              borderRadius: BorderRadius.circular(RadiusTokens.lg),
+              child: Image.asset(
+                logoAsset,
+                width: 84,
+                height: 84,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) => Icon(
+                  Icons.account_balance_rounded,
+                  size: 84,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
             ),
             const SizedBox(height: SpacingTokens.md),
             Text(
-              'Loading institutions...',
+              title,
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.w700,
               ),
@@ -320,12 +360,14 @@ class _LoadingStep extends StatelessWidget {
                 color: OpenBudgetPalette.mutedText,
               ),
             ),
-            const SizedBox(height: SpacingTokens.lg),
-            const SizedBox(
-              height: 28,
-              width: 28,
-              child: CircularProgressIndicator(strokeWidth: 3),
-            ),
+            if (includeSpinner) ...[
+              const SizedBox(height: SpacingTokens.lg),
+              const SizedBox(
+                height: 28,
+                width: 28,
+                child: CircularProgressIndicator(strokeWidth: 3),
+              ),
+            ],
           ],
         ),
       ),

--- a/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
@@ -63,7 +63,7 @@ void main() {
 
   testWidgets('renders bank search entry step', (tester) async {
     await tester.pumpWidget(buildSubject());
-    await tester.pumpAndSettle();
+    await _pumpToBankSearch(tester);
 
     expect(find.text('Add Accounts'), findsOneWidget);
     expect(find.text('Search for your bank'), findsOneWidget);
@@ -71,11 +71,30 @@ void main() {
     expect(find.text('Add an Unlinked Account'), findsOneWidget);
   });
 
+  testWidgets('shows staged loading states before bank search', (tester) async {
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+
+    expect(find.text('Loading...'), findsOneWidget);
+    expect(find.text('Search for your bank'), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+
+    expect(find.text('Add Accounts'), findsOneWidget);
+    expect(find.text('Loading institutions...'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 1000));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search for your bank'), findsOneWidget);
+  });
+
   testWidgets('renders currency selector in unlinked account step', (
     tester,
   ) async {
     await tester.pumpWidget(buildSubject(currencyCode: 'EUR'));
-    await tester.pumpAndSettle();
+    await _pumpToBankSearch(tester);
 
     await tester.tap(find.text('Add an Unlinked Account'));
     await tester.pumpAndSettle();
@@ -90,7 +109,7 @@ void main() {
     tester,
   ) async {
     await tester.pumpWidget(buildSubject());
-    await tester.pumpAndSettle();
+    await _pumpToBankSearch(tester);
 
     await tester.tap(find.text('Add an Unlinked Account'));
     await tester.pumpAndSettle();
@@ -108,7 +127,7 @@ void main() {
     tester,
   ) async {
     await tester.pumpWidget(buildSubject());
-    await tester.pumpAndSettle();
+    await _pumpToBankSearch(tester);
 
     await tester.tap(find.text('Add an Unlinked Account'));
     await tester.pumpAndSettle();
@@ -133,4 +152,9 @@ void main() {
     nextButton = tester.widget(find.widgetWithText(FilledButton, 'Next'));
     expect(nextButton.onPressed, isNotNull);
   });
+}
+
+Future<void> _pumpToBankSearch(WidgetTester tester) async {
+  await tester.pump(const Duration(milliseconds: 1500));
+  await tester.pumpAndSettle();
 }


### PR DESCRIPTION
## Summary
- add staged Add Accounts loading flow parity (`Loading...` -> `Loading institutions...` -> bank search)
- use OpenBudget branded loading logo assets with safe fallback icon in tests
- update widget + Patrol integration coverage to wait for staged loading and assert expected transitions
- update the YNAB migration tracker with this completed parity checkpoint

## Verification
- `devenv shell -- dart format openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- dprint fmt --allow-no-files docs/ynab-ui-migration-todo.md`
- `devenv shell -- flutter analyze openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- flutter test openbudget_app/test/features/accounts/screens/add_account_screen_test.dart`
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-24-pr135 PATROL_TEST_GLOB=integration_test/account_flow_test.dart tools/run_patrol_integration_tests.sh`

## Screenshots
- Loading institutions (runtime): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr135/add-accounts-loading-institutions-screen.png
- Bank search (runtime): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr135/add-accounts-search-screen.png
