### PR TITLE
feat(accounts): polish add-account bank search results

### DIFF
--- a/docs/ynab-ui-migration-todo.md
+++ b/docs/ynab-ui-migration-todo.md
@@ -1,6 +1,6 @@
 # OpenBudget UI Migration Tracker (from `~/Downloads/ynab-ui`)
 
-Last updated: 2026-02-24 (Add Accounts staged loading parity)
+Last updated: 2026-02-24 (Add Accounts bank-search filtering polish)
 
 ## Scope
 
@@ -30,6 +30,7 @@ Last updated: 2026-02-24 (Add Accounts staged loading parity)
 - 2026-02-24: Patrol screenshot capture now falls back to render-tree capture when `IntegrationTestWidgetsFlutterBinding.takeScreenshot` is unavailable (e.g., `flutter-tester`), writing PNG artifacts instead of skipping.
 - 2026-02-24: Recent Moves list rows now use improved day-heading typography (relative label + date split) and divider-backed spacing for closer parity.
 - 2026-02-24: Add Accounts flow now includes staged loading states (`Loading...` then `Loading institutions...`) with OpenBudget-branded logo treatment before bank search.
+- 2026-02-24: Add Accounts bank search now supports live filtering, empty-state messaging, and richer institution tile styling for parity with the reference flow.
 - 2026-02-24: PR screenshot artifacts policy active: every migration PR must include at least one runtime screenshot link in PR body/comments.
 - 2026-02-24: PR #127 artifact screenshot (Preset mode): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr127/reports-preset-mode.png
 - 2026-02-24: PR #129 artifact screenshot (Preset range + month anchor): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr129/reports-preset-range-month-anchor.png
@@ -147,6 +148,7 @@ Last updated: 2026-02-24 (Add Accounts staged loading parity)
 - [x] Integration coverage for onboarding account CTA routing
 - [x] Integration coverage for plan month switching
 - [x] Integration coverage for add-account wizard/search flow
+- [x] Integration coverage for add-account live-search filtering results
 - [x] Integration coverage for unlinked account type selection validation
 - [x] Integration coverage for account detail overflow actions and uncleared filtering
 - [x] Integration coverage for account detail edit form presentation

--- a/openbudget_app/integration_test/account_flow_test.dart
+++ b/openbudget_app/integration_test/account_flow_test.dart
@@ -227,10 +227,11 @@ void main() {
 
     expect(find.text('Add Accounts'), findsOneWidget);
     expect(find.text('Search for your bank'), findsOneWidget);
+    await _ensureAddUnlinkedVisible(tester);
     expect(find.text('Add an Unlinked Account'), findsOneWidget);
     await captureIntegrationScreenshot(tester, 'add-accounts-search-screen');
 
-    await tester.tap(find.text('Add an Unlinked Account'));
+    await _tapAddUnlinkedAccount(tester);
     await tester.pumpAndSettle();
 
     expect(find.text('Currency'), findsOneWidget);
@@ -253,13 +254,20 @@ void main() {
     await tester.tap(find.text('Add Account'));
     await _pumpToAddAccountSearch(tester);
 
-    await tester.tap(find.text('Chase'));
+    await tester.enterText(find.byType(TextField).first, 'citi');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search Results'), findsOneWidget);
+    expect(find.text('Citi'), findsOneWidget);
+    expect(find.text('Chase'), findsNothing);
+
+    await tester.tap(find.text('Citi'));
     await tester.pump(const Duration(milliseconds: 900));
     await tester.pumpAndSettle();
 
     expect(find.text('Add Unlinked Account'), findsOneWidget);
     expect(
-      find.textContaining('Linked connections for "Chase" are coming soon'),
+      find.textContaining('Linked connections for "Citi" are coming soon'),
       findsOneWidget,
     );
   });
@@ -273,7 +281,7 @@ void main() {
 
       await tester.tap(find.text('Add Account'));
       await _pumpToAddAccountSearch(tester);
-      await tester.tap(find.text('Add an Unlinked Account'));
+      await _tapAddUnlinkedAccount(tester);
       await tester.pumpAndSettle();
 
       var nextButton = tester.widget<FilledButton>(
@@ -307,7 +315,7 @@ void main() {
 
       await tester.tap(find.text('Add Account'));
       await _pumpToAddAccountSearch(tester);
-      await tester.tap(find.text('Add an Unlinked Account'));
+      await _tapAddUnlinkedAccount(tester);
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField).at(0), 'Daily');
@@ -629,5 +637,23 @@ void main() {
 
 Future<void> _pumpToAddAccountSearch(WidgetTester tester) async {
   await tester.pump(const Duration(milliseconds: 1500));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tapAddUnlinkedAccount(WidgetTester tester) async {
+  await _ensureAddUnlinkedVisible(tester);
+  await tester.tap(find.text('Add an Unlinked Account'));
+}
+
+Future<void> _ensureAddUnlinkedVisible(WidgetTester tester) async {
+  final finder = find.text('Add an Unlinked Account');
+  if (finder.evaluate().isEmpty) {
+    await tester.scrollUntilVisible(
+      finder,
+      200,
+      scrollable: find.byType(Scrollable).first,
+    );
+  }
+  await tester.ensureVisible(finder);
   await tester.pumpAndSettle();
 }

--- a/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
@@ -68,6 +68,7 @@ class AddAccountScreen extends HookConsumerWidget {
 
     useListenable(nameController);
     useListenable(balanceController);
+    useListenable(searchController);
 
     useEffect(() {
       if (step.value != _AddAccountStep.loading) return null;
@@ -221,6 +222,7 @@ class AddAccountScreen extends HookConsumerWidget {
             ),
             _AddAccountStep.searchBank => _BankSearchStep(
               searchController: searchController,
+              searchQuery: searchController.text,
               onSearchSubmitted: startLinkedBankFlow,
               onInstitutionTap: startLinkedBankFlow,
               onAddUnlinked: () => step.value = _AddAccountStep.unlinkedAccount,
@@ -378,28 +380,57 @@ class _LoadingStep extends StatelessWidget {
 class _BankSearchStep extends StatelessWidget {
   const _BankSearchStep({
     required this.searchController,
+    required this.searchQuery,
     required this.onSearchSubmitted,
     required this.onInstitutionTap,
     required this.onAddUnlinked,
   });
 
   final TextEditingController searchController;
+  final String searchQuery;
   final Future<void> Function(String value) onSearchSubmitted;
   final Future<void> Function(String institution) onInstitutionTap;
   final VoidCallback onAddUnlinked;
 
   @override
   Widget build(BuildContext context) {
-    const popularInstitutions = [
-      'Chase',
-      'Capital One',
-      'American Express',
-      'Bank of America',
-      'Citi',
-      'Discover',
-      'Wells Fargo',
-      'Apple Card',
+    const institutions = [
+      _InstitutionOption(name: 'Chase', backgroundColor: Color(0xFF1262AE)),
+      _InstitutionOption(
+        name: 'Capital One',
+        backgroundColor: Color(0xFF0A557D),
+      ),
+      _InstitutionOption(
+        name: 'American Express',
+        backgroundColor: Color(0xFF1876C8),
+      ),
+      _InstitutionOption(
+        name: 'Bank of America',
+        backgroundColor: Color(0xFFD22841),
+      ),
+      _InstitutionOption(name: 'Citi', backgroundColor: Color(0xFF044684)),
+      _InstitutionOption(name: 'Discover', backgroundColor: Color(0xFF383B54)),
+      _InstitutionOption(
+        name: 'Wells Fargo',
+        backgroundColor: Color(0xFFBD2134),
+      ),
+      _InstitutionOption(
+        name: 'Apple Card',
+        backgroundColor: Color(0xFF111111),
+      ),
     ];
+    final normalizedQuery = searchQuery.trim().toLowerCase();
+    final filteredInstitutions = normalizedQuery.isEmpty
+        ? institutions
+        : institutions
+              .where(
+                (institution) =>
+                    institution.name.toLowerCase().contains(normalizedQuery),
+              )
+              .toList(growable: false);
+    final sectionTitle = normalizedQuery.isEmpty
+        ? 'Popular Options'
+        : 'Search Results';
 
     return ListView(
       padding: const EdgeInsets.fromLTRB(
@@ -433,23 +464,39 @@ class _BankSearchStep extends StatelessWidget {
         ),
         const SizedBox(height: SpacingTokens.md),
         Text(
-          'Popular Options',
+          sectionTitle,
           style: Theme.of(
             context,
           ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
         ),
         const SizedBox(height: SpacingTokens.sm),
-        Wrap(
-          spacing: SpacingTokens.sm,
-          runSpacing: SpacingTokens.sm,
-          children: [
-            for (final institution in popularInstitutions)
-              _InstitutionTile(
-                name: institution,
-                onTap: () => onInstitutionTap(institution),
+        if (filteredInstitutions.isEmpty)
+          Container(
+            padding: const EdgeInsets.all(SpacingTokens.md),
+            decoration: BoxDecoration(
+              color: OpenBudgetPalette.surface,
+              border: Border.all(color: OpenBudgetPalette.divider),
+              borderRadius: BorderRadius.circular(RadiusTokens.md),
+            ),
+            child: Text(
+              'No institutions found. Try another name or add an unlinked account.',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: OpenBudgetPalette.mutedText,
               ),
-          ],
-        ),
+            ),
+          )
+        else
+          Wrap(
+            spacing: SpacingTokens.sm,
+            runSpacing: SpacingTokens.sm,
+            children: [
+              for (final institution in filteredInstitutions)
+                _InstitutionTile(
+                  option: institution,
+                  onTap: () => onInstitutionTap(institution.name),
+                ),
+            ],
+          ),
         const SizedBox(height: SpacingTokens.md),
         Row(
           children: [
@@ -477,9 +524,9 @@ class _BankSearchStep extends StatelessWidget {
 }
 
 class _InstitutionTile extends StatelessWidget {
-  const _InstitutionTile({required this.name, required this.onTap});
+  const _InstitutionTile({required this.option, required this.onTap});
 
-  final String name;
+  final _InstitutionOption option;
   final VoidCallback onTap;
 
   @override
@@ -491,24 +538,40 @@ class _InstitutionTile extends StatelessWidget {
         onTap: onTap,
         borderRadius: BorderRadius.circular(RadiusTokens.md),
         child: Container(
-          height: 56,
-          alignment: Alignment.center,
+          height: 82,
+          padding: const EdgeInsets.all(SpacingTokens.sm),
           decoration: BoxDecoration(
             color: OpenBudgetPalette.surface,
             border: Border.all(color: OpenBudgetPalette.divider),
             borderRadius: BorderRadius.circular(RadiusTokens.md),
           ),
-          child: Text(
-            name,
-            style: Theme.of(
-              context,
-            ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
-            textAlign: TextAlign.center,
+          child: Container(
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: option.backgroundColor,
+              borderRadius: BorderRadius.circular(RadiusTokens.sm),
+            ),
+            child: Text(
+              option.name,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+              ),
+              textAlign: TextAlign.center,
+            ),
           ),
         ),
       ),
     );
   }
+}
+
+@immutable
+class _InstitutionOption {
+  const _InstitutionOption({required this.name, required this.backgroundColor});
+
+  final String name;
+  final Color backgroundColor;
 }
 
 class _UnlinkedAccountStep extends StatelessWidget {

--- a/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
@@ -68,6 +68,8 @@ void main() {
     expect(find.text('Add Accounts'), findsOneWidget);
     expect(find.text('Search for your bank'), findsOneWidget);
     expect(find.text('Popular Options'), findsOneWidget);
+
+    await _scrollToAddUnlinked(tester);
     expect(find.text('Add an Unlinked Account'), findsOneWidget);
   });
 
@@ -96,7 +98,7 @@ void main() {
     await tester.pumpWidget(buildSubject(currencyCode: 'EUR'));
     await _pumpToBankSearch(tester);
 
-    await tester.tap(find.text('Add an Unlinked Account'));
+    await _tapAddUnlinked(tester);
     await tester.pumpAndSettle();
 
     expect(find.text('Add Unlinked Account'), findsOneWidget);
@@ -105,13 +107,37 @@ void main() {
     expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
   });
 
+  testWidgets('filters institutions by search query', (tester) async {
+    await tester.pumpWidget(buildSubject());
+    await _pumpToBankSearch(tester);
+
+    final searchField = find.byType(TextField).first;
+    await tester.enterText(searchField, 'citi');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search Results'), findsOneWidget);
+    expect(find.text('Citi'), findsOneWidget);
+    expect(find.text('Chase'), findsNothing);
+
+    await tester.enterText(searchField, 'zzz');
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No institutions found'), findsOneWidget);
+
+    await tester.enterText(searchField, '');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Popular Options'), findsOneWidget);
+    expect(find.text('Chase'), findsOneWidget);
+  });
+
   testWidgets('account type picker can be opened from unlinked form', (
     tester,
   ) async {
     await tester.pumpWidget(buildSubject());
     await _pumpToBankSearch(tester);
 
-    await tester.tap(find.text('Add an Unlinked Account'));
+    await _tapAddUnlinked(tester);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Select account type...'));
@@ -129,7 +155,7 @@ void main() {
     await tester.pumpWidget(buildSubject());
     await _pumpToBankSearch(tester);
 
-    await tester.tap(find.text('Add an Unlinked Account'));
+    await _tapAddUnlinked(tester);
     await tester.pumpAndSettle();
 
     var nextButton = tester.widget<FilledButton>(
@@ -156,5 +182,23 @@ void main() {
 
 Future<void> _pumpToBankSearch(WidgetTester tester) async {
   await tester.pump(const Duration(milliseconds: 1500));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tapAddUnlinked(WidgetTester tester) async {
+  await _scrollToAddUnlinked(tester);
+  await tester.tap(find.text('Add an Unlinked Account'));
+}
+
+Future<void> _scrollToAddUnlinked(WidgetTester tester) async {
+  final finder = find.text('Add an Unlinked Account');
+  if (finder.evaluate().isEmpty) {
+    await tester.scrollUntilVisible(
+      finder,
+      200,
+      scrollable: find.byType(Scrollable).first,
+    );
+  }
+  await tester.ensureVisible(finder);
   await tester.pumpAndSettle();
 }


### PR DESCRIPTION
## Summary
- add live institution filtering to Add Accounts bank search (`Popular Options` -> `Search Results`)
- add a no-results empty state and richer institution card presentation for closer reference parity
- harden add-account widget/integration tests with scroll-to-CTA helpers for viewport-stable tapping
- update migration tracker checkpoints and validation coverage notes

## Verification
- `devenv shell -- dart format openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- dprint fmt --allow-no-files docs/ynab-ui-migration-todo.md`
- `devenv shell -- flutter analyze openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- flutter test openbudget_app/test/features/accounts/screens/add_account_screen_test.dart`
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-24-pr136 PATROL_TEST_GLOB=integration_test/account_flow_test.dart tools/run_patrol_integration_tests.sh`

## Screenshots
- Add Accounts bank search (runtime): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr136/add-accounts-search-screen.png
