### PR TITLE
feat(accounts): align account type list with text-row parity

### DIFF
--- a/docs/ynab-ui-migration-todo.md
+++ b/docs/ynab-ui-migration-todo.md
@@ -1,6 +1,6 @@
 # OpenBudget UI Migration Tracker (from `~/Downloads/ynab-ui`)
 
-Last updated: 2026-02-24 (Add Accounts bank-search filtering polish)
+Last updated: 2026-02-24 (Account-type list visual parity)
 
 ## Scope
 
@@ -31,6 +31,7 @@ Last updated: 2026-02-24 (Add Accounts bank-search filtering polish)
 - 2026-02-24: Recent Moves list rows now use improved day-heading typography (relative label + date split) and divider-backed spacing for closer parity.
 - 2026-02-24: Add Accounts flow now includes staged loading states (`Loading...` then `Loading institutions...`) with OpenBudget-branded logo treatment before bank search.
 - 2026-02-24: Add Accounts bank search now supports live filtering, empty-state messaging, and richer institution tile styling for parity with the reference flow.
+- 2026-02-24: Add Accounts -> Select Account Type now uses text-focused list rows (without leading icons) for closer visual parity.
 - 2026-02-24: PR screenshot artifacts policy active: every migration PR must include at least one runtime screenshot link in PR body/comments.
 - 2026-02-24: PR #127 artifact screenshot (Preset mode): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr127/reports-preset-mode.png
 - 2026-02-24: PR #129 artifact screenshot (Preset range + month anchor): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr129/reports-preset-range-month-anchor.png

--- a/openbudget_app/integration_test/account_flow_test.dart
+++ b/openbudget_app/integration_test/account_flow_test.dart
@@ -298,6 +298,7 @@ void main() {
 
       await tester.tap(find.text('Select account type...'));
       await tester.pumpAndSettle();
+      await captureIntegrationScreenshot(tester, 'add-account-type-selection');
       await tester.tap(find.text('Checking'));
       await tester.pumpAndSettle();
 

--- a/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
@@ -728,7 +728,6 @@ class _AccountTypeStep extends StatelessWidget {
           for (final option in section.options) ...[
             ListTile(
               onTap: () => onSelected(option),
-              leading: Icon(option.icon),
               title: Text(option.label),
               trailing: option.key == selectedTypeKey
                   ? const Icon(
@@ -837,7 +836,6 @@ class _AccountTypeOption {
   const _AccountTypeOption({
     required this.key,
     required this.label,
-    required this.icon,
     required this.serverType,
     required this.onBudgetDefault,
     required this.isDebt,
@@ -845,7 +843,6 @@ class _AccountTypeOption {
 
   final String key;
   final String label;
-  final IconData icon;
   final String serverType;
   final bool onBudgetDefault;
   final bool isDebt;
@@ -874,7 +871,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'checking',
           label: l10n.accountTypeChecking,
-          icon: Icons.account_balance_rounded,
           serverType: 'checking',
           onBudgetDefault: true,
           isDebt: false,
@@ -882,7 +878,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'savings',
           label: l10n.accountTypeSavings,
-          icon: Icons.savings_rounded,
           serverType: 'savings',
           onBudgetDefault: true,
           isDebt: false,
@@ -890,7 +885,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'cash',
           label: l10n.accountTypeCash,
-          icon: Icons.payments_rounded,
           serverType: 'cash',
           onBudgetDefault: true,
           isDebt: false,
@@ -904,7 +898,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'creditCard',
           label: l10n.accountTypeCreditCard,
-          icon: Icons.credit_card_rounded,
           serverType: 'creditCard',
           onBudgetDefault: true,
           isDebt: true,
@@ -912,7 +905,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         const _AccountTypeOption(
           key: 'lineOfCredit',
           label: 'Line of Credit',
-          icon: Icons.credit_score_rounded,
           serverType: 'other',
           onBudgetDefault: true,
           isDebt: true,
@@ -926,7 +918,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'mortgage',
           label: 'Mortgage',
-          icon: Icons.home_work_outlined,
           serverType: 'other',
           onBudgetDefault: false,
           isDebt: true,
@@ -934,7 +925,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'autoLoan',
           label: 'Auto Loan',
-          icon: Icons.directions_car_outlined,
           serverType: 'other',
           onBudgetDefault: false,
           isDebt: true,
@@ -942,7 +932,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'studentLoan',
           label: 'Student Loan',
-          icon: Icons.school_outlined,
           serverType: 'other',
           onBudgetDefault: false,
           isDebt: true,
@@ -950,7 +939,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'personalLoan',
           label: 'Personal Loan',
-          icon: Icons.person_outline_rounded,
           serverType: 'other',
           onBudgetDefault: false,
           isDebt: true,
@@ -958,7 +946,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'medicalDebt',
           label: 'Medical Debt',
-          icon: Icons.health_and_safety_outlined,
           serverType: 'other',
           onBudgetDefault: false,
           isDebt: true,
@@ -966,7 +953,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'otherDebt',
           label: 'Other Debt',
-          icon: Icons.receipt_long_outlined,
           serverType: 'other',
           onBudgetDefault: false,
           isDebt: true,
@@ -981,7 +967,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'asset',
           label: 'Asset (e.g. Investment)',
-          icon: Icons.trending_up_rounded,
           serverType: 'investment',
           onBudgetDefault: false,
           isDebt: false,
@@ -989,7 +974,6 @@ List<_AccountTypeSection> _accountTypeSections(AppLocalizations l10n) {
         _AccountTypeOption(
           key: 'liability',
           label: 'Liability',
-          icon: Icons.warning_amber_rounded,
           serverType: 'other',
           onBudgetDefault: false,
           isDebt: true,

--- a/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
@@ -147,6 +147,8 @@ void main() {
     expect(find.text('Cash Accounts'), findsOneWidget);
     expect(find.text('Credit Accounts'), findsOneWidget);
     expect(find.text('Mortgages and Loans'), findsOneWidget);
+    expect(find.byIcon(Icons.account_balance_rounded), findsNothing);
+    expect(find.byIcon(Icons.savings_rounded), findsNothing);
   });
 
   testWidgets('next stays disabled until type and balance are provided', (


### PR DESCRIPTION
## Summary
- align Add Accounts -> Select Account Type option rows with text-first visual parity (remove leading icons)
- keep sectioned account-type taxonomy and selected-row check state behavior
- add Patrol runtime screenshot capture for account-type selection and keep migration tracker in sync

## Verification
- `devenv shell -- dart format openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- dprint fmt --allow-no-files docs/ynab-ui-migration-todo.md`
- `devenv shell -- flutter analyze openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- flutter test openbudget_app/test/features/accounts/screens/add_account_screen_test.dart`
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-24-pr137 PATROL_TEST_GLOB=integration_test/account_flow_test.dart tools/run_patrol_integration_tests.sh`

## Screenshots
- Account Type selection (runtime): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr137/add-account-type-selection.png
