### PR TITLE
ci(integration): speed up patrol runs with shared pub resolution

### DIFF
--- a/docs/openbudget-screenflows.md
+++ b/docs/openbudget-screenflows.md
@@ -32,6 +32,7 @@ Last updated: 2026-02-25
 - CI hardening for integration reliability:
   - Per-file timeout enforcement
   - Failure-marker detection to prevent false-green runs
+  - Shared dependency resolution + `--no-pub` Patrol file execution to reduce redundant setup time
   - Repaint fallback screenshot capture on `flutter-tester`
 - Branding regression guard:
   - `/openbudget_app/test/branding/no_ynab_branding_test.dart`

--- a/tools/run_patrol_integration_tests.sh
+++ b/tools/run_patrol_integration_tests.sh
@@ -24,6 +24,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
 	timeout_cmd="gtimeout"
 fi
 
+echo "::group::Resolving Flutter dependencies"
+flutter pub get
+echo "::endgroup::"
+
 echo "Discovered ${#tests[@]} Patrol integration test file(s)."
 
 failed=0
@@ -44,10 +48,10 @@ for f in "${tests[@]}"; do
 	set +e
 	if [ -n "$timeout_cmd" ]; then
 		"$timeout_cmd" "${timeout_seconds}s" \
-			flutter test "$f" -d flutter-tester 2>&1 | tee "$output_file"
+			flutter test --no-pub "$f" -d flutter-tester 2>&1 | tee "$output_file"
 		status=${PIPESTATUS[0]}
 	else
-		flutter test "$f" -d flutter-tester 2>&1 | tee "$output_file"
+		flutter test --no-pub "$f" -d flutter-tester 2>&1 | tee "$output_file"
 		status=${PIPESTATUS[0]}
 	fi
 	set -e


### PR DESCRIPTION
## Summary
- optimize `tools/run_patrol_integration_tests.sh` to resolve Flutter dependencies once before file execution
- run each Patrol test file with `flutter test --no-pub` to avoid repeated per-file pub resolution overhead
- document this integration runner optimization in `docs/openbudget-screenflows.md`

## Verification
- `bash -n tools/run_patrol_integration_tests.sh`
- `devenv shell -- dprint fmt --allow-no-files docs/openbudget-screenflows.md`
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-25-pr139 PATROL_TEST_GLOB=integration_test/app_test.dart tools/run_patrol_integration_tests.sh`
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-25-full-patrol tools/run_patrol_integration_tests.sh` (14/14 files passed in local verification)

## Screenshots
- Runtime artifact: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr139/reports-spending-breakdown-preset.png
