### PR TITLE
feat(accounts): improve add accounts desktop search parity

### DIFF
--- a/docs/openbudget-screenflows.md
+++ b/docs/openbudget-screenflows.md
@@ -18,6 +18,7 @@ Last updated: 2026-02-25
   - Settings root, plan settings, currency, display options, app icon switching (light/dark aware)
 - Accounts
   - Add account wizard, institution search/filtering, unlinked account validation, account detail actions, reconcile, loan overview/activity, edit/close
+  - Desktop/tablet Add Accounts search parity (search labeling, two-column institution grid, unlinked CTA alignment)
 - Transactions
   - Add expense/income/transfer, filtering, edit and action sheets, review queue approval flow
 - Reflect and reports
@@ -42,3 +43,4 @@ Last updated: 2026-02-25
 - Add Accounts loading institutions: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr135/add-accounts-loading-institutions-screen.png
 - Add Accounts bank search: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr136/add-accounts-search-screen.png
 - Add Account type selection: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr137/add-account-type-selection.png
+- Add Accounts desktop bank search: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr140/add-accounts-search-desktop-screen.png

--- a/openbudget_app/integration_test/account_flow_test.dart
+++ b/openbudget_app/integration_test/account_flow_test.dart
@@ -273,6 +273,37 @@ void main() {
   });
 
   patrolWidgetTest(
+    'desktop add accounts flow shows search controls and options',
+    ($) async {
+      final tester = $.tester;
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(1024, 768));
+      await tester.pumpWidget(_buildApp(accounts: const []));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No Accounts Yet'), findsOneWidget);
+      await tester.tap(find.text('Add Account'));
+      await _pumpToAddAccountSearch(tester);
+
+      expect(find.text('Search for your bank'), findsOneWidget);
+      expect(find.text('Search by institution name'), findsOneWidget);
+      expect(
+        find.text('Search by institution name or web address (URL)'),
+        findsOneWidget,
+      );
+      expect(find.text('Popular Options'), findsOneWidget);
+      expect(find.text('Chase'), findsOneWidget);
+      expect(find.text('Capital One'), findsOneWidget);
+      await _ensureAddUnlinkedVisible(tester);
+      expect(find.text('Add an Unlinked Account'), findsOneWidget);
+      await captureIntegrationScreenshot(
+        tester,
+        'add-accounts-search-desktop-screen',
+      );
+    },
+  );
+
+  patrolWidgetTest(
     'unlinked account requires explicit type selection before next',
     ($) async {
       final tester = $.tester;

--- a/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
@@ -395,29 +395,14 @@ class _BankSearchStep extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const institutions = [
-      _InstitutionOption(name: 'Chase', backgroundColor: Color(0xFF1262AE)),
-      _InstitutionOption(
-        name: 'Capital One',
-        backgroundColor: Color(0xFF0A557D),
-      ),
-      _InstitutionOption(
-        name: 'American Express',
-        backgroundColor: Color(0xFF1876C8),
-      ),
-      _InstitutionOption(
-        name: 'Bank of America',
-        backgroundColor: Color(0xFFD22841),
-      ),
-      _InstitutionOption(name: 'Citi', backgroundColor: Color(0xFF044684)),
-      _InstitutionOption(name: 'Discover', backgroundColor: Color(0xFF383B54)),
-      _InstitutionOption(
-        name: 'Wells Fargo',
-        backgroundColor: Color(0xFFBD2134),
-      ),
-      _InstitutionOption(
-        name: 'Apple Card',
-        backgroundColor: Color(0xFF111111),
-      ),
+      _InstitutionOption(name: 'Chase'),
+      _InstitutionOption(name: 'Capital One'),
+      _InstitutionOption(name: 'American Express'),
+      _InstitutionOption(name: 'Bank of America'),
+      _InstitutionOption(name: 'Citi'),
+      _InstitutionOption(name: 'Discover'),
+      _InstitutionOption(name: 'Wells Fargo'),
+      _InstitutionOption(name: 'Apple Card'),
     ];
     final normalizedQuery = searchQuery.trim().toLowerCase();
     final filteredInstitutions = normalizedQuery.isEmpty
@@ -447,20 +432,20 @@ class _BankSearchStep extends StatelessWidget {
           ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
         ),
         const SizedBox(height: SpacingTokens.sm),
+        Text(
+          'Search by institution name',
+          style: Theme.of(
+            context,
+          ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w500),
+        ),
+        const SizedBox(height: SpacingTokens.xs),
         TextField(
           controller: searchController,
           onSubmitted: onSearchSubmitted,
           textInputAction: TextInputAction.search,
           decoration: const InputDecoration(
-            hintText: 'Search by institution name',
+            hintText: 'Search by institution name or web address (URL)',
           ),
-        ),
-        const SizedBox(height: SpacingTokens.xs),
-        Text(
-          'Search by institution name or web address (URL)',
-          style: Theme.of(
-            context,
-          ).textTheme.bodySmall?.copyWith(color: OpenBudgetPalette.mutedText),
         ),
         const SizedBox(height: SpacingTokens.md),
         Text(
@@ -538,27 +523,19 @@ class _InstitutionTile extends StatelessWidget {
         onTap: onTap,
         borderRadius: BorderRadius.circular(RadiusTokens.md),
         child: Container(
-          height: 82,
-          padding: const EdgeInsets.all(SpacingTokens.sm),
+          height: 84,
+          alignment: Alignment.center,
           decoration: BoxDecoration(
             color: OpenBudgetPalette.surface,
             border: Border.all(color: OpenBudgetPalette.divider),
             borderRadius: BorderRadius.circular(RadiusTokens.md),
           ),
-          child: Container(
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: option.backgroundColor,
-              borderRadius: BorderRadius.circular(RadiusTokens.sm),
-            ),
-            child: Text(
-              option.name,
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.w700,
-                color: Colors.white,
-              ),
-              textAlign: TextAlign.center,
-            ),
+          child: Text(
+            option.name,
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            textAlign: TextAlign.center,
           ),
         ),
       ),
@@ -568,10 +545,9 @@ class _InstitutionTile extends StatelessWidget {
 
 @immutable
 class _InstitutionOption {
-  const _InstitutionOption({required this.name, required this.backgroundColor});
+  const _InstitutionOption({required this.name});
 
   final String name;
-  final Color backgroundColor;
 }
 
 class _UnlinkedAccountStep extends StatelessWidget {

--- a/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
@@ -67,6 +67,11 @@ void main() {
 
     expect(find.text('Add Accounts'), findsOneWidget);
     expect(find.text('Search for your bank'), findsOneWidget);
+    expect(find.text('Search by institution name'), findsOneWidget);
+    expect(
+      find.text('Search by institution name or web address (URL)'),
+      findsOneWidget,
+    );
     expect(find.text('Popular Options'), findsOneWidget);
 
     await _scrollToAddUnlinked(tester);


### PR DESCRIPTION
## Summary
- restyle Add Accounts institution options to text-first tiles for desktop/tablet parity
- update search copy to match flow (`Search by institution name` + URL hint)
- add Patrol coverage for desktop viewport Add Accounts search flow and capture runtime artifact
- update `docs/openbudget-screenflows.md` with the new parity checkpoint and screenshot link

## Screenshots
![Add Accounts desktop search](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr140/add-accounts-search-desktop-screen.png)

## Verification
- `devenv shell -- dart format openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- flutter test openbudget_app/test/features/accounts/screens/add_account_screen_test.dart`
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-25-pr140 PATROL_TEST_GLOB=integration_test/account_flow_test.dart tools/run_patrol_integration_tests.sh`
- `devenv shell -- dart analyze openbudget_app`
