### PR TITLE
fix(accounts): keep add account search submit in filtering mode

### DIFF
--- a/docs/openbudget-screenflows.md
+++ b/docs/openbudget-screenflows.md
@@ -19,6 +19,7 @@ Last updated: 2026-02-25
 - Accounts
   - Add account wizard, institution search/filtering, unlinked account validation, account detail actions, reconcile, loan overview/activity, edit/close
   - Desktop/tablet Add Accounts search parity (search labeling, two-column institution grid, unlinked CTA alignment)
+  - Search submit stays in Add Accounts filtering mode (no accidental jump into unlinked flow)
 - Transactions
   - Add expense/income/transfer, filtering, edit and action sheets, review queue approval flow
 - Reflect and reports
@@ -44,3 +45,4 @@ Last updated: 2026-02-25
 - Add Accounts bank search: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr136/add-accounts-search-screen.png
 - Add Account type selection: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr137/add-account-type-selection.png
 - Add Accounts desktop bank search: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr140/add-accounts-search-desktop-screen.png
+- Add Accounts search-submit results state: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr141/add-accounts-search-submit-results.png

--- a/openbudget_app/integration_test/account_flow_test.dart
+++ b/openbudget_app/integration_test/account_flow_test.dart
@@ -272,6 +272,31 @@ void main() {
     );
   });
 
+  patrolWidgetTest('submitting search query keeps user in bank search mode', (
+    $,
+  ) async {
+    final tester = $.tester;
+    await tester.pumpWidget(_buildApp(accounts: const []));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Add Account'));
+    await _pumpToAddAccountSearch(tester);
+
+    await tester.enterText(find.byType(TextField).first, 'citi');
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search for your bank'), findsOneWidget);
+    expect(find.text('Search Results'), findsOneWidget);
+    expect(find.text('Citi'), findsOneWidget);
+    expect(find.text('Add Unlinked Account'), findsNothing);
+    expect(find.textContaining('Linked connections for "citi"'), findsNothing);
+    await captureIntegrationScreenshot(
+      tester,
+      'add-accounts-search-submit-results',
+    );
+  });
+
   patrolWidgetTest(
     'desktop add accounts flow shows search controls and options',
     ($) async {

--- a/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
+++ b/openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart
@@ -223,7 +223,6 @@ class AddAccountScreen extends HookConsumerWidget {
             _AddAccountStep.searchBank => _BankSearchStep(
               searchController: searchController,
               searchQuery: searchController.text,
-              onSearchSubmitted: startLinkedBankFlow,
               onInstitutionTap: startLinkedBankFlow,
               onAddUnlinked: () => step.value = _AddAccountStep.unlinkedAccount,
             ),
@@ -381,14 +380,12 @@ class _BankSearchStep extends StatelessWidget {
   const _BankSearchStep({
     required this.searchController,
     required this.searchQuery,
-    required this.onSearchSubmitted,
     required this.onInstitutionTap,
     required this.onAddUnlinked,
   });
 
   final TextEditingController searchController;
   final String searchQuery;
-  final Future<void> Function(String value) onSearchSubmitted;
   final Future<void> Function(String institution) onInstitutionTap;
   final VoidCallback onAddUnlinked;
 
@@ -441,7 +438,7 @@ class _BankSearchStep extends StatelessWidget {
         const SizedBox(height: SpacingTokens.xs),
         TextField(
           controller: searchController,
-          onSubmitted: onSearchSubmitted,
+          onSubmitted: (_) => FocusScope.of(context).unfocus(),
           textInputAction: TextInputAction.search,
           decoration: const InputDecoration(
             hintText: 'Search by institution name or web address (URL)',

--- a/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/add_account_screen_test.dart
@@ -136,6 +136,22 @@ void main() {
     expect(find.text('Chase'), findsOneWidget);
   });
 
+  testWidgets('search submit keeps user on the bank search step', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject());
+    await _pumpToBankSearch(tester);
+
+    await tester.enterText(find.byType(TextField).first, 'citi');
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search for your bank'), findsOneWidget);
+    expect(find.text('Search Results'), findsOneWidget);
+    expect(find.text('Add Unlinked Account'), findsNothing);
+    expect(find.textContaining('Linked connections for "citi"'), findsNothing);
+  });
+
   testWidgets('account type picker can be opened from unlinked form', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- prevent Add Accounts search submit (`TextInputAction.search`) from navigating away to unlinked account mode
- keep submit action focused on filtering workflow while preserving institution-tile tap behavior for linked-connection fallback
- add widget + Patrol regressions to lock this behavior
- update `docs/openbudget-screenflows.md` with the new flow checkpoint and runtime artifact link

## Screenshots
![Add Accounts search submit results](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr141/add-accounts-search-submit-results.png)

## Verification
- `devenv shell -- dart format openbudget_app/lib/src/features/accounts/screens/add_account_screen.dart openbudget_app/test/features/accounts/screens/add_account_screen_test.dart openbudget_app/integration_test/account_flow_test.dart`
- `devenv shell -- flutter test openbudget_app/test/features/accounts/screens/add_account_screen_test.dart`
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-25-pr141 PATROL_TEST_GLOB=integration_test/account_flow_test.dart tools/run_patrol_integration_tests.sh`
- `devenv shell -- dart analyze openbudget_app`
