### PR TITLE
test(reports): cover spending breakdown preset recalculation

### DIFF
--- a/docs/openbudget-screenflows.md
+++ b/docs/openbudget-screenflows.md
@@ -24,6 +24,7 @@ Last updated: 2026-02-25
   - Add expense/income/transfer, filtering, edit and action sheets, review queue approval flow
 - Reflect and reports
   - Spending Breakdown (month and preset ranges), Net Worth detail, dark-mode parity
+  - Spending Breakdown preset selector regression coverage (3/6/12 range recalculation)
 - Recent Moves
   - Tabs, coach dialog, empty and populated states, source/destination drilldowns
 
@@ -46,3 +47,4 @@ Last updated: 2026-02-25
 - Add Account type selection: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-pr137/add-account-type-selection.png
 - Add Accounts desktop bank search: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr140/add-accounts-search-desktop-screen.png
 - Add Accounts search-submit results state: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr141/add-accounts-search-submit-results.png
+- Spending Breakdown last-six-months preset: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr142/reports-spending-breakdown-last-six-months.png

--- a/openbudget_app/integration_test/reports_flow_test.dart
+++ b/openbudget_app/integration_test/reports_flow_test.dart
@@ -239,6 +239,41 @@ void main() {
     },
   );
 
+  patrolWidgetTest(
+    'spending breakdown updates totals when preset range changes',
+    ($) async {
+      final tester = $.tester;
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Spending Breakdown').first);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Preset'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Last 3 Months'), findsWidgets);
+      expect(find.text('December 2025–February 2026'), findsOneWidget);
+      expect(find.textContaining(r'$6,660.00'), findsOneWidget);
+
+      await tester.tap(find.byType(DropdownButton<int>).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Last 6 Months').last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('September 2025–February 2026'), findsOneWidget);
+      expect(find.textContaining(r'$8,180.00'), findsOneWidget);
+      expect(find.textContaining(r'$4,400.00'), findsOneWidget);
+      expect(find.textContaining(r'$2,800.00'), findsOneWidget);
+      expect(find.textContaining(r'$980.00'), findsOneWidget);
+
+      await captureIntegrationScreenshot(
+        tester,
+        'reports-spending-breakdown-last-six-months',
+      );
+    },
+  );
+
   patrolWidgetTest('reflect dashboard navigates to net worth detail', (
     $,
   ) async {


### PR DESCRIPTION
## Summary
- add Patrol regression for Spending Breakdown preset-range selection changes
- verify 3-month to 6-month range recalculation updates total spent, range label, and category totals
- capture runtime artifact for the Last 6 Months preset state
- update `docs/openbudget-screenflows.md` with this reports checkpoint and screenshot link

## Screenshots
![Spending Breakdown - Last 6 Months](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr142/reports-spending-breakdown-last-six-months.png)

## Verification
- `devenv shell -- env OPENBUDGET_SCREENSHOT_DIR=.screenshots/2026-02-25-pr142 PATROL_TEST_GLOB=integration_test/reports_flow_test.dart tools/run_patrol_integration_tests.sh`
- `devenv shell -- dart analyze openbudget_app`
