### PR TITLE
test: add desktop recent moves Patrol coverage

### DIFF
--- a/docs/openbudget-migration-progress.md
+++ b/docs/openbudget-migration-progress.md
@@ -23,6 +23,7 @@ This checklist tracks progress for migrating and polishing app flows using the `
 - [x] Add Accounts desktop unlinked-account form/success parity coverage
 - [x] Transaction review + action sheet flow parity
 - [x] Recent Moves tabs, coach dialog, and drilldown parity
+- [x] Recent Moves desktop tab-switch regression coverage
 - [x] Reflect dashboard + Spending Breakdown + Net Worth parity
 - [x] Spending Breakdown preset range recalculation regression coverage
 - [x] Spending Breakdown desktop preset-range parity regression coverage

--- a/docs/openbudget-screenflows.md
+++ b/docs/openbudget-screenflows.md
@@ -32,6 +32,7 @@ Progress checklist: `docs/openbudget-migration-progress.md`
   - Desktop Spending Breakdown preset parity coverage for six-month range totals
 - Recent Moves
   - Tabs, coach dialog, empty and populated states, source/destination drilldowns
+  - Desktop modal/tab-switch parity coverage for All and Moved tabs
 
 ## Verification Gates
 
@@ -59,3 +60,5 @@ Progress checklist: `docs/openbudget-migration-progress.md`
 - Accounts desktop edit account form: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr145/accounts-edit-account-desktop-screen.png
 - Add Unlinked Account desktop form: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr148/add-unlinked-account-desktop-form-screen.png
 - Add Unlinked Account desktop success: https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr148/add-unlinked-account-desktop-success-screen.png
+- Recent Moves desktop (All tab): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr149/recent-moves-desktop-screen.png
+- Recent Moves desktop (Moved tab): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr149/recent-moves-desktop-moved-screen.png

--- a/openbudget_app/integration_test/plan_screens_flow_test.dart
+++ b/openbudget_app/integration_test/plan_screens_flow_test.dart
@@ -589,6 +589,103 @@ void main() {
     expect(find.text('Cover 1 overspent category'), findsOneWidget);
   });
 
+  patrolWidgetTest('desktop recent moves flow opens and switches tabs', (
+    $,
+  ) async {
+    final tester = $.tester;
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.binding.setSurfaceSize(const Size(1024, 768));
+
+    final container = ProviderContainer(
+      overrides: [
+        budgetMonthlySummaryProvider.overrideWith((ref, _) async {
+          return _makeSummary();
+        }),
+        budgetGoalsProvider.overrideWith((ref, _) async => {}),
+        creditCardPaymentsProvider.overrideWith((ref, _) async => const []),
+        monthlyTransactionsProvider.overrideWith(
+          (ref, _) async => _makeMonthlyTransactions(),
+        ),
+        recurringDueCountProvider.overrideWith((ref, _) async => 0),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final router = GoRouter(
+      initialLocation: '/budgets/$_budgetId/plan',
+      routes: [
+        GoRoute(
+          name: planRoute,
+          path: '/budgets/:id/plan',
+          builder: (context, state) =>
+              BudgetDetailScreen(budgetId: state.pathParameters['id']!),
+          routes: [
+            GoRoute(
+              name: recentMovesRoute,
+              path: 'recent-moves',
+              builder: (context, state) =>
+                  RecentMovesScreen(budgetId: state.pathParameters['id']!),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: ThemeData.light(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    container
+        .read(recentMovesProvider.notifier)
+        .recordAssigned(
+          budgetId: _budgetId,
+          envelopeId: _utilitiesEnvelopeId,
+          amountCents: 6000,
+        );
+    container
+        .read(recentMovesProvider.notifier)
+        .recordMove(
+          budgetId: _budgetId,
+          fromEnvelopeId: _storageEnvelopeId,
+          toEnvelopeId: _utilitiesEnvelopeId,
+          amountCents: 3000,
+        );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_horiz_rounded));
+    await tester.pumpAndSettle();
+    await _tapPopupMenuItem(tester, 'Recent Moves');
+    await _dismissCoachmarkIfVisible(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recent Moves'), findsOneWidget);
+    expect(find.text('All'), findsOneWidget);
+    expect(find.text('Moved'), findsOneWidget);
+    await captureIntegrationScreenshot(tester, 'recent-moves-desktop-screen');
+
+    await tester.tap(find.text('Moved'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Self storage'), findsOneWidget);
+    await captureIntegrationScreenshot(
+      tester,
+      'recent-moves-desktop-moved-screen',
+    );
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
+    expect(find.text('Categories'), findsOneWidget);
+  });
+
   patrolWidgetTest('reorder mode moves categories and exits cleanly', (
     $,
   ) async {


### PR DESCRIPTION
## Summary
- add a desktop Patrol regression for Recent Moves modal flow from Plan
- verify All/Moved tab switching and return to plan on desktop viewport
- capture desktop runtime screenshots for Recent Moves tabs
- update migration progress and screenflow docs with these checkpoints

## Screenshots
- Recent Moves desktop (All tab): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr149/recent-moves-desktop-screen.png
- Recent Moves desktop (Moved tab): https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-25-pr149/recent-moves-desktop-moved-screen.png

## Testing
- `OPENBUDGET_SCREENSHOT_DIR=/Users/ifiokjr/Developer/projects/openbudget/openbudget/.screenshots/pr149 PATROL_TEST_GLOB='integration_test/plan_screens_flow_test.dart' devenv shell -- ./tools/run_patrol_integration_tests.sh`
- `devenv shell -- flutter analyze openbudget_app/integration_test/plan_screens_flow_test.dart`
