### PR TITLE
feat(app): support More tab with quick actions

### DIFF
--- a/.changeset/more-tab-quick-actions.md
+++ b/.changeset/more-tab-quick-actions.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add support for the More bottom-tab button by opening a quick-actions sheet when re-tapping the More tab, with shortcuts to Settings, Recurring Transactions, and Payees.

--- a/openbudget_app/lib/src/features/budget/screens/budget_shell_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_shell_screen.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/budget/widgets/add_transaction_sheet.dart';
+import 'package:openbudget_app/src/routing/route_names.dart';
 
 class BudgetShellScreen extends HookWidget {
   const BudgetShellScreen({
@@ -22,7 +25,7 @@ class BudgetShellScreen extends HookWidget {
       body: navigationShell,
       bottomNavigationBar: NavigationBar(
         selectedIndex: _adjustedIndex(navigationShell.currentIndex),
-        onDestinationSelected: (index) => _onTap(context, index),
+        onDestinationSelected: (index) => unawaited(_onTap(context, index)),
         destinations: [
           NavigationDestination(
             icon: const Icon(Icons.savings_outlined),
@@ -64,13 +67,18 @@ class BudgetShellScreen extends HookWidget {
     return shellIndex + 1;
   }
 
-  void _onTap(BuildContext context, int index) {
+  Future<void> _onTap(BuildContext context, int index) async {
     if (index == 2) {
       // "+" tab — show add transaction sheet
-      showModalBottomSheet<void>(
+      await showModalBottomSheet<void>(
         context: context,
         builder: (_) => AddTransactionSheet(budgetId: budgetId),
       );
+      return;
+    }
+
+    if (index == 4 && navigationShell.currentIndex == 3) {
+      await _showMoreQuickActions(context);
       return;
     }
 
@@ -81,4 +89,48 @@ class BudgetShellScreen extends HookWidget {
       initialLocation: branchIndex == navigationShell.currentIndex,
     );
   }
+
+  Future<void> _showMoreQuickActions(BuildContext context) async {
+    final l10n = AppLocalizations.of(context);
+    final action = await showModalBottomSheet<_MoreQuickAction>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.settings_outlined),
+              title: Text(l10n.moreSettings),
+              onTap: () => Navigator.of(context).pop(_MoreQuickAction.settings),
+            ),
+            ListTile(
+              leading: const Icon(Icons.repeat_rounded),
+              title: Text(l10n.moreRecurring),
+              onTap: () =>
+                  Navigator.of(context).pop(_MoreQuickAction.recurring),
+            ),
+            ListTile(
+              leading: const Icon(Icons.people_outline_rounded),
+              title: Text(l10n.morePayees),
+              onTap: () => Navigator.of(context).pop(_MoreQuickAction.payees),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (!context.mounted || action == null) return;
+
+    switch (action) {
+      case _MoreQuickAction.settings:
+        context.goNamed(settingsRoute, pathParameters: {'id': budgetId});
+      case _MoreQuickAction.recurring:
+        context.goNamed(recurringListRoute, pathParameters: {'id': budgetId});
+      case _MoreQuickAction.payees:
+        context.goNamed(payeeListRoute, pathParameters: {'id': budgetId});
+    }
+  }
 }
+
+enum _MoreQuickAction { settings, recurring, payees }

--- a/openbudget_app/test/features/budget/screens/budget_shell_screen_test.dart
+++ b/openbudget_app/test/features/budget/screens/budget_shell_screen_test.dart
@@ -145,5 +145,22 @@ void main() {
 
       expect(find.text('More Tab'), findsOneWidget);
     });
+
+    testWidgets('re-tapping More tab opens quick actions sheet', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('More'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('More'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.text('Recurring Transactions'), findsOneWidget);
+      expect(find.text('Payees'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- add support for the More bottom-tab button re-tap behavior
- when the More tab is already selected, re-tapping it now opens a quick-actions sheet
- add shortcuts in that sheet for Settings, Recurring Transactions, and Payees
- add widget test coverage for the new quick-actions sheet behavior

## Validation
- `devenv shell -- bash -lc 'cd openbudget_app && flutter test test/features/budget/screens/budget_shell_screen_test.dart'`
