### PR TITLE
feat(app): wire add-transaction sheet actions

### DIFF
--- a/.changeset/add-transaction-sheet-actions.md
+++ b/.changeset/add-transaction-sheet-actions.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Wire add-transaction sheet actions through host navigation
+
+Updates the add-transaction bottom sheet to return a selected action and lets host screens perform navigation for Add Income, Add Expense, and Transfer flows.

--- a/openbudget_app/lib/src/features/budget/screens/budget_shell_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_shell_screen.dart
@@ -70,10 +70,22 @@ class BudgetShellScreen extends HookWidget {
   Future<void> _onTap(BuildContext context, int index) async {
     if (index == 2) {
       // "+" tab — show add transaction sheet
-      await showModalBottomSheet<void>(
+      final action = await showModalBottomSheet<AddTransactionAction>(
         context: context,
         builder: (_) => AddTransactionSheet(budgetId: budgetId),
       );
+      if (!context.mounted || action == null) return;
+      switch (action) {
+        case AddTransactionAction.income:
+          context.goNamed(addIncomeRoute, pathParameters: {'id': budgetId});
+        case AddTransactionAction.expense:
+          context.goNamed(addExpenseRoute, pathParameters: {'id': budgetId});
+        case AddTransactionAction.transfer:
+          context.goNamed(
+            createTransferRoute,
+            pathParameters: {'id': budgetId},
+          );
+      }
       return;
     }
 

--- a/openbudget_app/lib/src/features/budget/widgets/add_transaction_sheet.dart
+++ b/openbudget_app/lib/src/features/budget/widgets/add_transaction_sheet.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
-import 'package:openbudget_app/src/routing/route_names.dart';
 import 'package:openbudget_app/src/theme/openbudget_palette.dart';
 import 'package:openbudget_ui/openbudget_ui.dart';
+
+enum AddTransactionAction { income, expense, transfer }
 
 class AddTransactionSheet extends HookWidget {
   const AddTransactionSheet({required this.budgetId, super.key});
@@ -46,11 +46,7 @@ class AddTransactionSheet extends HookWidget {
               label: l10n.addTransactionIncome,
               color: OpenBudgetPalette.fgSuccessFor(theme),
               onTap: () {
-                Navigator.of(context).pop();
-                context.goNamed(
-                  addIncomeRoute,
-                  pathParameters: {'id': budgetId},
-                );
+                Navigator.of(context).pop(AddTransactionAction.income);
               },
             ),
             const SizedBox(height: SpacingTokens.sm),
@@ -59,11 +55,7 @@ class AddTransactionSheet extends HookWidget {
               label: l10n.addTransactionExpense,
               color: OpenBudgetPalette.fgErrorFor(theme),
               onTap: () {
-                Navigator.of(context).pop();
-                context.goNamed(
-                  addExpenseRoute,
-                  pathParameters: {'id': budgetId},
-                );
+                Navigator.of(context).pop(AddTransactionAction.expense);
               },
             ),
             const SizedBox(height: SpacingTokens.sm),
@@ -72,11 +64,7 @@ class AddTransactionSheet extends HookWidget {
               label: l10n.addTransactionTransfer,
               color: OpenBudgetPalette.bgBrandFor(theme),
               onTap: () {
-                Navigator.of(context).pop();
-                context.goNamed(
-                  createTransferRoute,
-                  pathParameters: {'id': budgetId},
-                );
+                Navigator.of(context).pop(AddTransactionAction.transfer);
               },
             ),
             const SizedBox(height: SpacingTokens.md),

--- a/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
+++ b/openbudget_app/lib/src/features/transactions/screens/transaction_list_screen.dart
@@ -433,11 +433,28 @@ class TransactionListScreen extends HookConsumerWidget {
         },
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => showModalBottomSheet<void>(
-          context: context,
-          isScrollControlled: true,
-          builder: (_) => AddTransactionSheet(budgetId: budgetId),
-        ),
+        onPressed: () async {
+          final action = await showModalBottomSheet<AddTransactionAction>(
+            context: context,
+            isScrollControlled: true,
+            builder: (_) => AddTransactionSheet(budgetId: budgetId),
+          );
+          if (!context.mounted || action == null) return;
+          switch (action) {
+            case AddTransactionAction.income:
+              context.goNamed(addIncomeRoute, pathParameters: {'id': budgetId});
+            case AddTransactionAction.expense:
+              context.goNamed(
+                addExpenseRoute,
+                pathParameters: {'id': budgetId},
+              );
+            case AddTransactionAction.transfer:
+              context.goNamed(
+                createTransferRoute,
+                pathParameters: {'id': budgetId},
+              );
+          }
+        },
         child: const Icon(Icons.add),
       ),
       bottomNavigationBar: selectionMode.value && selectedIds.value.isNotEmpty

--- a/openbudget_app/test/features/budget/widgets/add_transaction_sheet_test.dart
+++ b/openbudget_app/test/features/budget/widgets/add_transaction_sheet_test.dart
@@ -36,11 +36,33 @@ void main() {
           builder: (context, state) => Scaffold(
             body: Center(
               child: FilledButton(
-                onPressed: () => showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  builder: (_) => const AddTransactionSheet(budgetId: budgetId),
-                ),
+                onPressed: () async {
+                  final action =
+                      await showModalBottomSheet<AddTransactionAction>(
+                        context: context,
+                        isScrollControlled: true,
+                        builder: (_) =>
+                            const AddTransactionSheet(budgetId: budgetId),
+                      );
+                  if (!context.mounted || action == null) return;
+                  switch (action) {
+                    case AddTransactionAction.income:
+                      context.goNamed(
+                        addIncomeRoute,
+                        pathParameters: {'id': budgetId},
+                      );
+                    case AddTransactionAction.expense:
+                      context.goNamed(
+                        addExpenseRoute,
+                        pathParameters: {'id': budgetId},
+                      );
+                    case AddTransactionAction.transfer:
+                      context.goNamed(
+                        createTransferRoute,
+                        pathParameters: {'id': budgetId},
+                      );
+                  }
+                },
                 child: const Text('Open Add Sheet'),
               ),
             ),


### PR DESCRIPTION
## Summary
- make `AddTransactionSheet` return an explicit action (`income`, `expense`, `transfer`) instead of navigating directly
- handle navigation in host screens (`BudgetShellScreen` and `TransactionListScreen`) after the sheet closes
- update sheet widget tests to validate the host-driven navigation flow

## Validation
- `cd openbudget_app && flutter test test/features/budget/widgets/add_transaction_sheet_test.dart`
- `cd openbudget_app && dart analyze lib/src/features/budget/widgets/add_transaction_sheet.dart lib/src/features/budget/screens/budget_shell_screen.dart lib/src/features/transactions/screens/transaction_list_screen.dart test/features/budget/widgets/add_transaction_sheet_test.dart`
