### PR TITLE
fix(auth): remove login flash on cold app relaunch

### DIFF
--- a/.changeset/fix-auth-restore-login-flash.md
+++ b/.changeset/fix-auth-restore-login-flash.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Prevent a login-screen flash on cold app launch by introducing a dedicated auth-restore state and showing a bootstrap splash until initial auth restoration completes.

--- a/openbudget_app/lib/src/app_bootstrap.dart
+++ b/openbudget_app/lib/src/app_bootstrap.dart
@@ -3,6 +3,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/analytics/analytics_provider.dart';
 import 'package:openbudget_app/src/config/app_environment.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_provider.dart';
+import 'package:openbudget_app/src/features/auth/providers/auth_state.dart';
 import 'package:openbudget_app/src/features/settings/providers/ui_preferences_store.dart';
 import 'package:openbudget_app/src/logging/app_logging.dart';
 import 'package:openbudget_app/src/providers/theme_mode_provider.dart';
@@ -41,8 +43,22 @@ class OpenBudgetApp extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.watch(appRouterProvider);
     final themeMode = ref.watch(themeModeProvider);
+    final authState = ref.watch(authProvider);
+
+    if (authState is AuthRestoring) {
+      return MaterialApp(
+        title: AppEnvironment.appTitle,
+        theme: OpenBudgetTheme.light,
+        darkTheme: OpenBudgetTheme.dark,
+        themeMode: themeMode,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const _AuthBootstrapScreen(),
+      );
+    }
+
+    final router = ref.watch(appRouterProvider);
 
     return MaterialApp.router(
       title: AppEnvironment.appTitle,
@@ -53,5 +69,14 @@ class OpenBudgetApp extends HookConsumerWidget {
       supportedLocales: AppLocalizations.supportedLocales,
       routerConfig: router,
     );
+  }
+}
+
+class _AuthBootstrapScreen extends StatelessWidget {
+  const _AuthBootstrapScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: CircularProgressIndicator()));
   }
 }

--- a/openbudget_app/lib/src/features/auth/providers/auth_provider.dart
+++ b/openbudget_app/lib/src/features/auth/providers/auth_provider.dart
@@ -13,7 +13,7 @@ class AuthNotifier extends _$AuthNotifier {
   @override
   AuthState build() {
     _tryRestore();
-    return const AuthLoading();
+    return const AuthRestoring();
   }
 
   Future<void> _tryRestore() async {

--- a/openbudget_app/lib/src/features/auth/providers/auth_state.dart
+++ b/openbudget_app/lib/src/features/auth/providers/auth_state.dart
@@ -20,6 +20,10 @@ class Unauthenticated extends AuthState {
   const Unauthenticated();
 }
 
+class AuthRestoring extends AuthState {
+  const AuthRestoring();
+}
+
 class AuthLoading extends AuthState {
   const AuthLoading();
 }

--- a/openbudget_app/lib/src/routing/app_router.dart
+++ b/openbudget_app/lib/src/routing/app_router.dart
@@ -465,11 +465,13 @@ String? authRedirectForLocation({
   final isAuthRoute = location == loginPath || location == registerPath;
   final isStartupRoute = location == startupPath;
   final isAuthenticated = authState is Authenticated;
-  final isLoading = authState is AuthLoading;
+  final isRestoring = authState is AuthRestoring;
 
-  if (isLoading) {
+  if (isRestoring) {
     return isStartupRoute ? null : startupPath;
   }
+
+  if (authState is AuthLoading) return null;
 
   if (!isAuthenticated) {
     return isAuthRoute ? null : loginPath;

--- a/openbudget_app/test/routing/app_router_test.dart
+++ b/openbudget_app/test/routing/app_router_test.dart
@@ -5,27 +5,40 @@ import 'package:openbudget_app/src/routing/route_names.dart';
 
 void main() {
   group('authRedirectForLocation', () {
-    test('keeps loading users on startup route', () {
+    test('keeps restoring users on startup route', () {
       expect(
         authRedirectForLocation(
-          authState: const AuthLoading(),
+          authState: const AuthRestoring(),
           location: startupPath,
         ),
         isNull,
       );
     });
 
-    test('redirects loading users to startup route', () {
+    test('redirects restoring users to startup route', () {
       expect(
         authRedirectForLocation(
-          authState: const AuthLoading(),
+          authState: const AuthRestoring(),
           location: loginPath,
         ),
         startupPath,
       );
       expect(
-        authRedirectForLocation(authState: const AuthLoading(), location: '/'),
+        authRedirectForLocation(
+          authState: const AuthRestoring(),
+          location: '/',
+        ),
         startupPath,
+      );
+    });
+
+    test('does not force redirect during in-flow auth loading', () {
+      expect(
+        authRedirectForLocation(
+          authState: const AuthLoading(),
+          location: loginPath,
+        ),
+        isNull,
       );
     });
 


### PR DESCRIPTION
## Summary
- add an explicit `AuthRestoring` state for startup auth restoration
- gate `OpenBudgetApp` with a bootstrap splash while `AuthRestoring` is active
- keep `AuthLoading` for in-flow actions (login/register) so those flows are not forced through startup redirects
- update router redirect logic and tests to reflect the restore-vs-loading split

## Context
A cold relaunch could briefly render the login UI before redirecting home for signed-in users.
This change prevents any route UI (including login) from rendering until initial auth restoration has finished.

## Validation
- `devenv shell -- bash -lc 'cd openbudget_app && flutter test test/routing/app_router_test.dart'`
