### PR TITLE
fix(app): preserve android back navigation stack

### DIFF
--- a/.changeset/android-back-navigation-stack.md
+++ b/.changeset/android-back-navigation-stack.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Preserve navigation history for Android hardware back presses in the budget shell by tracking tab history and stepping back through previously visited tabs before allowing route pop. Also switch key Home navigations to pushed routes so back returns users to prior screens instead of exiting.

--- a/openbudget_app/lib/src/features/budget/screens/budget_shell_screen.dart
+++ b/openbudget_app/lib/src/features/budget/screens/budget_shell_screen.dart
@@ -20,39 +20,49 @@ class BudgetShellScreen extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final tabHistory = useState<List<int>>(<int>[navigationShell.currentIndex]);
 
-    return Scaffold(
-      body: navigationShell,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _adjustedIndex(navigationShell.currentIndex),
-        onDestinationSelected: (index) => unawaited(_onTap(context, index)),
-        destinations: [
-          NavigationDestination(
-            icon: const Icon(Icons.savings_outlined),
-            selectedIcon: const Icon(Icons.savings_rounded),
-            label: l10n.tabPlan,
-          ),
-          NavigationDestination(
-            icon: const Icon(Icons.account_balance_outlined),
-            selectedIcon: const Icon(Icons.account_balance_rounded),
-            label: l10n.tabAccounts,
-          ),
-          NavigationDestination(
-            icon: const Icon(Icons.add_circle_outline_rounded),
-            selectedIcon: const Icon(Icons.add_circle_rounded),
-            label: l10n.tabAdd,
-          ),
-          NavigationDestination(
-            icon: const Icon(Icons.bar_chart_outlined),
-            selectedIcon: const Icon(Icons.bar_chart_rounded),
-            label: l10n.tabReflect,
-          ),
-          NavigationDestination(
-            icon: const Icon(Icons.more_horiz_rounded),
-            selectedIcon: const Icon(Icons.more_horiz_rounded),
-            label: l10n.tabMore,
-          ),
-        ],
+    useEffect(() {
+      _recordTabVisit(tabHistory, navigationShell.currentIndex);
+      return null;
+    }, [navigationShell.currentIndex]);
+
+    return BackButtonListener(
+      onBackButtonPressed: () => _onBackButtonPressed(context, tabHistory),
+      child: Scaffold(
+        body: navigationShell,
+        bottomNavigationBar: NavigationBar(
+          selectedIndex: _adjustedIndex(navigationShell.currentIndex),
+          onDestinationSelected: (index) =>
+              unawaited(_onTap(context, index, tabHistory)),
+          destinations: [
+            NavigationDestination(
+              icon: const Icon(Icons.savings_outlined),
+              selectedIcon: const Icon(Icons.savings_rounded),
+              label: l10n.tabPlan,
+            ),
+            NavigationDestination(
+              icon: const Icon(Icons.account_balance_outlined),
+              selectedIcon: const Icon(Icons.account_balance_rounded),
+              label: l10n.tabAccounts,
+            ),
+            NavigationDestination(
+              icon: const Icon(Icons.add_circle_outline_rounded),
+              selectedIcon: const Icon(Icons.add_circle_rounded),
+              label: l10n.tabAdd,
+            ),
+            NavigationDestination(
+              icon: const Icon(Icons.bar_chart_outlined),
+              selectedIcon: const Icon(Icons.bar_chart_rounded),
+              label: l10n.tabReflect,
+            ),
+            NavigationDestination(
+              icon: const Icon(Icons.more_horiz_rounded),
+              selectedIcon: const Icon(Icons.more_horiz_rounded),
+              label: l10n.tabMore,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -67,7 +77,11 @@ class BudgetShellScreen extends HookWidget {
     return shellIndex + 1;
   }
 
-  Future<void> _onTap(BuildContext context, int index) async {
+  Future<void> _onTap(
+    BuildContext context,
+    int index,
+    ValueNotifier<List<int>> tabHistory,
+  ) async {
     if (index == 2) {
       // "+" tab — show add transaction sheet
       final action = await showModalBottomSheet<AddTransactionAction>(
@@ -78,9 +92,15 @@ class BudgetShellScreen extends HookWidget {
       if (!context.mounted || action == null) return;
       switch (action) {
         case AddTransactionAction.income:
-          context.goNamed(addIncomeRoute, pathParameters: {'id': budgetId});
+          await context.pushNamed(
+            addIncomeRoute,
+            pathParameters: {'id': budgetId},
+          );
         case AddTransactionAction.expense:
-          context.goNamed(addExpenseRoute, pathParameters: {'id': budgetId});
+          await context.pushNamed(
+            addExpenseRoute,
+            pathParameters: {'id': budgetId},
+          );
         case AddTransactionAction.transfer:
           await context.pushNamed(
             createTransferRoute,
@@ -97,9 +117,39 @@ class BudgetShellScreen extends HookWidget {
 
     // Map visual tab index back to shell branch index
     final branchIndex = index > 2 ? index - 1 : index;
+    if (branchIndex != navigationShell.currentIndex) {
+      _recordTabVisit(tabHistory, branchIndex);
+    }
     // Always navigate to the branch root to avoid stale shell state causing
     // apparent no-op tab taps (especially on first visit to a branch).
     navigationShell.goBranch(branchIndex, initialLocation: true);
+  }
+
+  Future<bool> _onBackButtonPressed(
+    BuildContext context,
+    ValueNotifier<List<int>> tabHistory,
+  ) async {
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) return false;
+
+    final history = List<int>.from(tabHistory.value);
+    if (history.length <= 1) return false;
+
+    history.removeLast();
+    final previousBranch = history.last;
+    tabHistory.value = history;
+    navigationShell.goBranch(previousBranch, initialLocation: true);
+    return true;
+  }
+
+  void _recordTabVisit(ValueNotifier<List<int>> tabHistory, int branchIndex) {
+    final history = List<int>.from(tabHistory.value);
+    if (history.isNotEmpty && history.last == branchIndex) return;
+
+    history
+      ..remove(branchIndex)
+      ..add(branchIndex);
+    tabHistory.value = history;
   }
 
   Future<void> _showMoreQuickActions(BuildContext context) async {
@@ -136,11 +186,20 @@ class BudgetShellScreen extends HookWidget {
 
     switch (action) {
       case _MoreQuickAction.settings:
-        context.goNamed(settingsRoute, pathParameters: {'id': budgetId});
+        await context.pushNamed(
+          settingsRoute,
+          pathParameters: {'id': budgetId},
+        );
       case _MoreQuickAction.recurring:
-        context.goNamed(recurringListRoute, pathParameters: {'id': budgetId});
+        await context.pushNamed(
+          recurringListRoute,
+          pathParameters: {'id': budgetId},
+        );
       case _MoreQuickAction.payees:
-        context.goNamed(payeeListRoute, pathParameters: {'id': budgetId});
+        await context.pushNamed(
+          payeeListRoute,
+          pathParameters: {'id': budgetId},
+        );
     }
   }
 }

--- a/openbudget_app/lib/src/features/home/screens/home_screen.dart
+++ b/openbudget_app/lib/src/features/home/screens/home_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -85,7 +87,8 @@ class HomeScreen extends HookConsumerWidget {
                     ),
                     const SizedBox(height: SpacingTokens.lg),
                     FilledButton.icon(
-                      onPressed: () => context.goNamed(createBudgetRoute),
+                      onPressed: () =>
+                          unawaited(context.pushNamed(createBudgetRoute)),
                       icon: const Icon(Icons.add),
                       label: Text(l10n.homeCreateBudget),
                     ),
@@ -115,7 +118,12 @@ class HomeScreen extends HookConsumerWidget {
                     onTap: () {
                       final id = budget.id?.toString();
                       if (id == null || id.isEmpty) return;
-                      context.goNamed(planRoute, pathParameters: {'id': id});
+                      unawaited(
+                        context.pushNamed(
+                          planRoute,
+                          pathParameters: {'id': id},
+                        ),
+                      );
                     },
                     onLongPress: () => _confirmDeleteBudget(
                       context,
@@ -132,7 +140,8 @@ class HomeScreen extends HookConsumerWidget {
       floatingActionButton: budgets.maybeWhen(
         data: (list) => list.isNotEmpty
             ? FloatingActionButton(
-                onPressed: () => context.goNamed(createBudgetRoute),
+                onPressed: () =>
+                    unawaited(context.pushNamed(createBudgetRoute)),
                 child: const Icon(Icons.add),
               )
             : null,

--- a/openbudget_app/test/features/budget/screens/budget_shell_screen_test.dart
+++ b/openbudget_app/test/features/budget/screens/budget_shell_screen_test.dart
@@ -136,6 +136,27 @@ void main() {
       expect(find.text('Reflect Tab'), findsOneWidget);
     });
 
+    testWidgets('android back navigates through tab history', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Accounts'));
+      await tester.pumpAndSettle();
+      expect(find.text('Accounts Tab'), findsOneWidget);
+
+      await tester.tap(find.text('Reflect'));
+      await tester.pumpAndSettle();
+      expect(find.text('Reflect Tab'), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(find.text('Accounts Tab'), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(find.text('Plan Tab'), findsOneWidget);
+    });
+
     testWidgets('tapping More tab navigates to more', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
On Android, pressing the hardware back button from budget tabs could exit the current flow instead of stepping back through recently visited tabs and previous screens.

## User Impact
Users navigating across `Plan`, `Accounts`, `Reflect`, and `More` could lose context when pressing back, because the app did not preserve tab navigation history in the shell. In addition, some key navigations from Home used replacement navigation, making back behavior feel like an app exit.

## Root Cause
- `BudgetShellScreen` did not track tab visit history or intercept Android hardware back events to move to the prior tab.
- Key entry navigation from Home used `goNamed` (replace), which discards prior route stack.

## Fix
- Added lightweight tab history tracking in `BudgetShellScreen`.
- Added Android hardware back handling via `BackButtonListener`:
  - If tab history exists, back now switches to the previously visited tab.
  - If no tab history remains, back falls through to normal router behavior.
- Updated Home navigation actions (`create budget`, `open budget`) to `pushNamed` so route history is preserved.
- Kept the change scoped to navigation behavior only.

## Validation
- `flutter analyze` (openbudget_app): passed
- `flutter test test/features/budget/screens/budget_shell_screen_test.dart`: passed
- Added a widget test that simulates hardware back (`handlePopRoute`) and verifies tab-history back traversal.
