### PR TITLE
fix(app): stabilize account and envelope screen tests

### DIFF
--- a/.changeset/test-baseline-regressions.md
+++ b/.changeset/test-baseline-regressions.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Stabilize account and envelope screen tests by avoiding viewport-sensitive assertions and prevent overflow in the envelope activity empty state when vertical space is constrained.

--- a/openbudget_app/lib/src/features/budget/screens/envelope_activity_sheet.dart
+++ b/openbudget_app/lib/src/features/budget/screens/envelope_activity_sheet.dart
@@ -197,24 +197,31 @@ class EnvelopeActivitySheet extends HookConsumerWidget {
                         );
 
                   if (transactions.isEmpty) {
-                    return Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            Icons.receipt_long_rounded,
-                            size: 40,
-                            color: colorScheme.outlineVariant,
+                    return LayoutBuilder(
+                      builder: (context, constraints) {
+                        final showIcon = constraints.maxHeight >= 72;
+                        return Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (showIcon) ...[
+                                Icon(
+                                  Icons.receipt_long_rounded,
+                                  size: 40,
+                                  color: colorScheme.outlineVariant,
+                                ),
+                                const SizedBox(height: SpacingTokens.sm),
+                              ],
+                              Text(
+                                l10n.envelopeNoActivity,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
                           ),
-                          const SizedBox(height: SpacingTokens.sm),
-                          Text(
-                            l10n.envelopeNoActivity,
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              color: colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        ],
-                      ),
+                        );
+                      },
                     );
                   }
 

--- a/openbudget_app/test/features/accounts/screens/account_detail_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/account_detail_screen_test.dart
@@ -478,6 +478,10 @@ void main() {
       expect(find.text('Payments'), findsOneWidget);
     });
     testWidgets('solana wallet dashboard renders with filters', (tester) async {
+      final binding = tester.binding;
+      await binding.setSurfaceSize(const Size(1200, 2200));
+      addTearDown(() => binding.setSurfaceSize(null));
+
       await tester.pumpWidget(_buildWalletSubject());
       await tester.pumpAndSettle();
 
@@ -492,6 +496,7 @@ void main() {
       await _scrollToText(tester, 'Transaction History');
       expect(find.text('Jupiter swap'), findsOneWidget);
       expect(find.text('Transfer to friend'), findsOneWidget);
+      expect(find.text('Transaction History'), findsOneWidget);
       expect(find.textContaining('P&L +'), findsWidgets);
       expect(find.text('Tax 2026'), findsWidgets);
       expect(find.textContaining('Basis'), findsWidgets);

--- a/openbudget_app/test/features/accounts/screens/account_list_screen_test.dart
+++ b/openbudget_app/test/features/accounts/screens/account_list_screen_test.dart
@@ -342,6 +342,12 @@ void main() {
 
       expect(find.text('Checking'), findsOneWidget);
       expect(find.text('Savings'), findsOneWidget);
+      await tester.scrollUntilVisible(
+        find.text('Credit Card'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
       expect(find.text('Credit Card'), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary
This PR stabilizes currently failing app tests on `main` that are blocking unrelated PRs.

## Problem
The shared `test` workflow is failing because of viewport-sensitive widget tests and a constrained empty-state layout:
- `envelope_activity_sheet_test`: render overflow in compact vertical space.
- `account_list_screen_test`: account type assertion depended on item visibility in a scrollable list.
- `account_detail_screen_test`: loan/wallet assertions relied on fragile scrolling assumptions.

## Fix
- Added a compact-height guard in `EnvelopeActivitySheet` empty-state rendering to avoid RenderFlex overflow.
- Updated account list test to scroll to the `Credit Card` label before asserting.
- Updated account detail tests to use robust visibility handling and deterministic surface size for wallet dashboard assertions.

## Validation
- `flutter analyze` (openbudget_app): passed
- `flutter test test/features/budget/screens/envelope_activity_sheet_test.dart`: passed
- `flutter test test/features/accounts/screens/account_list_screen_test.dart`: passed
- `flutter test test/features/accounts/screens/account_detail_screen_test.dart`: passed
