### PR TITLE
chore: initialize plan artifacts and sync agent context workflow

### DIFF
--- a/.changeset/agent-context-plan-artifacts.md
+++ b/.changeset/agent-context-plan-artifacts.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improve planning workflow documentation and harden agent-context regeneration to avoid duplicate or placeholder entries while keeping shared agent role guidance synchronized.

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ local.properties
 
 **/node_modules/
 .serena/
+.ant-colony/

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -197,7 +197,7 @@ parse_plan_data() {
 		log_info "Found framework: $NEW_FRAMEWORK"
 	fi
 
-	if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
+	if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != N/A* ]]; then
 		log_info "Found database: $NEW_DB"
 	fi
 
@@ -375,21 +375,36 @@ update_existing_agent_file() {
 	local tech_stack=$(format_technology_stack "$NEW_LANG" "$NEW_FRAMEWORK")
 	local new_tech_entries=()
 	local new_change_entry=""
+	local tech_stack_entry=""
+	local db_entry=""
 
-	# Prepare new technology entries
-	if [[ -n "$tech_stack" ]] && ! grep -q "$tech_stack" "$target_file"; then
-		new_tech_entries+=("- $tech_stack ($CURRENT_BRANCH)")
+	# Prepare new technology entries (exact bullet-line dedupe)
+	if [[ -n "$tech_stack" ]]; then
+		tech_stack_entry="- $tech_stack ($CURRENT_BRANCH)"
+		if ! grep -Fqx -- "$tech_stack_entry" "$target_file" 2>/dev/null; then
+			new_tech_entries+=("$tech_stack_entry")
+		fi
 	fi
 
-	if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]] && ! grep -q "$NEW_DB" "$target_file"; then
-		new_tech_entries+=("- $NEW_DB ($CURRENT_BRANCH)")
+	if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != N/A* ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
+		db_entry="- $NEW_DB ($CURRENT_BRANCH)"
+		if ! grep -Fqx -- "$db_entry" "$target_file" 2>/dev/null; then
+			new_tech_entries+=("$db_entry")
+		fi
 	fi
 
 	# Prepare new change entry
 	if [[ -n "$tech_stack" ]]; then
 		new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
-	elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
+	elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != N/A* ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
 		new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
+	fi
+
+	# Dedupe: if this exact recent-change entry already exists anywhere in the file,
+	# do not prepend it again.
+	local should_add_change_entry=true
+	if [[ -n "$new_change_entry" ]] && grep -Fqx -- "$new_change_entry" "$target_file" 2>/dev/null; then
+		should_add_change_entry=false
 	fi
 
 	# Check if sections exist in the file
@@ -408,9 +423,13 @@ update_existing_agent_file() {
 	local in_tech_section=false
 	local in_changes_section=false
 	local tech_entries_added=false
-	local changes_entries_added=false
 	local existing_changes_count=0
-	local file_ended=false
+	local existing_changes_limit=3
+	local seen_change_entries=""
+
+	if [[ "$should_add_change_entry" == true ]] && [[ -n "$new_change_entry" ]]; then
+		existing_changes_limit=2
+	fi
 
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		# Handle Active Technologies section
@@ -435,25 +454,38 @@ update_existing_agent_file() {
 			fi
 			echo "$line" >>"$temp_file"
 			continue
+		elif [[ $in_tech_section == true ]] && { [[ "$line" == "- N/A"* ]] || [[ "$line" == *"[if applicable"* ]]; }; then
+			# Drop stale placeholder / N/A technology entries from previous generations.
+			continue
 		fi
 
 		# Handle Recent Changes section
 		if [[ "$line" == "## Recent Changes" ]]; then
 			echo "$line" >>"$temp_file"
-			# Add new change entry right after the heading
-			if [[ -n "$new_change_entry" ]]; then
+			# Add new change entry right after the heading (unless deduped)
+			if [[ "$should_add_change_entry" == true ]] && [[ -n "$new_change_entry" ]]; then
 				echo "$new_change_entry" >>"$temp_file"
+				seen_change_entries="${new_change_entry}"$'\n'
 			fi
 			in_changes_section=true
-			changes_entries_added=true
 			continue
 		elif [[ $in_changes_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
 			echo "$line" >>"$temp_file"
 			in_changes_section=false
 			continue
 		elif [[ $in_changes_section == true ]] && [[ "$line" == "- "* ]]; then
-			# Keep only first 2 existing changes
-			if [[ $existing_changes_count -lt 2 ]]; then
+			# Drop stale placeholders from previous generations.
+			if [[ "$line" == *"[if applicable"* ]]; then
+				continue
+			fi
+
+			# Keep unique entries only, capped to preserve the last 3 changes total.
+			if printf '%s\n' "$seen_change_entries" | grep -Fqx -- "$line" 2>/dev/null; then
+				continue
+			fi
+
+			seen_change_entries="${seen_change_entries}${line}"$'\n'
+			if [[ $existing_changes_count -lt $existing_changes_limit ]]; then
 				echo "$line" >>"$temp_file"
 				((existing_changes_count++))
 			fi
@@ -482,11 +514,10 @@ update_existing_agent_file() {
 		tech_entries_added=true
 	fi
 
-	if [[ $has_recent_changes -eq 0 ]] && [[ -n "$new_change_entry" ]]; then
+	if [[ $has_recent_changes -eq 0 ]] && [[ "$should_add_change_entry" == true ]] && [[ -n "$new_change_entry" ]]; then
 		echo "" >>"$temp_file"
 		echo "## Recent Changes" >>"$temp_file"
 		echo "$new_change_entry" >>"$temp_file"
-		changes_entries_added=true
 	fi
 
 	# Move temp file to target atomically
@@ -644,86 +675,99 @@ update_specific_agent() {
 
 update_all_existing_agents() {
 	local found_agent=false
+	local processed_targets=""
+
+	target_already_processed() {
+		local target_file="$1"
+		if [[ -z "$processed_targets" ]]; then
+			return 1
+		fi
+		printf '%s\n' "$processed_targets" | grep -Fqx -- "$target_file"
+	}
+
+	mark_target_processed() {
+		local target_file="$1"
+		processed_targets="${processed_targets}${target_file}"$'\n'
+	}
+
+	# Update target only once even if multiple agent aliases map to same file
+	update_agent_file_once() {
+		local target_file="$1"
+		local agent_name="$2"
+
+		if target_already_processed "$target_file"; then
+			log_info "Skipping duplicate target for $agent_name: $target_file"
+			return 0
+		fi
+
+		update_agent_file "$target_file" "$agent_name"
+		mark_target_processed "$target_file"
+		found_agent=true
+	}
 
 	# Check each possible agent file and update if it exists
 	if [[ -f "$CLAUDE_FILE" ]]; then
-		update_agent_file "$CLAUDE_FILE" "Claude Code"
-		found_agent=true
+		update_agent_file_once "$CLAUDE_FILE" "Claude Code"
 	fi
 
 	if [[ -f "$GEMINI_FILE" ]]; then
-		update_agent_file "$GEMINI_FILE" "Gemini CLI"
-		found_agent=true
+		update_agent_file_once "$GEMINI_FILE" "Gemini CLI"
 	fi
 
 	if [[ -f "$COPILOT_FILE" ]]; then
-		update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-		found_agent=true
+		update_agent_file_once "$COPILOT_FILE" "GitHub Copilot"
 	fi
 
 	if [[ -f "$CURSOR_FILE" ]]; then
-		update_agent_file "$CURSOR_FILE" "Cursor IDE"
-		found_agent=true
+		update_agent_file_once "$CURSOR_FILE" "Cursor IDE"
 	fi
 
 	if [[ -f "$QWEN_FILE" ]]; then
-		update_agent_file "$QWEN_FILE" "Qwen Code"
-		found_agent=true
+		update_agent_file_once "$QWEN_FILE" "Qwen Code"
 	fi
 
 	if [[ -f "$AGENTS_FILE" ]]; then
-		update_agent_file "$AGENTS_FILE" "Codex/opencode"
-		found_agent=true
+		update_agent_file_once "$AGENTS_FILE" "Codex/opencode"
 	fi
 
 	if [[ -f "$WINDSURF_FILE" ]]; then
-		update_agent_file "$WINDSURF_FILE" "Windsurf"
-		found_agent=true
+		update_agent_file_once "$WINDSURF_FILE" "Windsurf"
 	fi
 
 	if [[ -f "$KILOCODE_FILE" ]]; then
-		update_agent_file "$KILOCODE_FILE" "Kilo Code"
-		found_agent=true
+		update_agent_file_once "$KILOCODE_FILE" "Kilo Code"
 	fi
 
 	if [[ -f "$AUGGIE_FILE" ]]; then
-		update_agent_file "$AUGGIE_FILE" "Auggie CLI"
-		found_agent=true
+		update_agent_file_once "$AUGGIE_FILE" "Auggie CLI"
 	fi
 
 	if [[ -f "$ROO_FILE" ]]; then
-		update_agent_file "$ROO_FILE" "Roo Code"
-		found_agent=true
+		update_agent_file_once "$ROO_FILE" "Roo Code"
 	fi
 
 	if [[ -f "$CODEBUDDY_FILE" ]]; then
-		update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-		found_agent=true
+		update_agent_file_once "$CODEBUDDY_FILE" "CodeBuddy CLI"
 	fi
 
 	if [[ -f "$SHAI_FILE" ]]; then
-		update_agent_file "$SHAI_FILE" "SHAI"
-		found_agent=true
+		update_agent_file_once "$SHAI_FILE" "SHAI"
 	fi
 
 	if [[ -f "$QODER_FILE" ]]; then
-		update_agent_file "$QODER_FILE" "Qoder CLI"
-		found_agent=true
+		update_agent_file_once "$QODER_FILE" "Qoder CLI"
 	fi
 
 	if [[ -f "$Q_FILE" ]]; then
-		update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
-		found_agent=true
+		update_agent_file_once "$Q_FILE" "Amazon Q Developer CLI"
 	fi
 
 	if [[ -f "$AGY_FILE" ]]; then
-		update_agent_file "$AGY_FILE" "Antigravity"
-		found_agent=true
+		update_agent_file_once "$AGY_FILE" "Antigravity"
 	fi
 
 	if [[ -f "$BOB_FILE" ]]; then
-		update_agent_file "$BOB_FILE" "IBM Bob"
-		found_agent=true
+		update_agent_file_once "$BOB_FILE" "IBM Bob"
 	fi
 
 	# If no agent files exist, create a default Claude file
@@ -744,7 +788,7 @@ print_summary() {
 		echo "  - Added framework: $NEW_FRAMEWORK"
 	fi
 
-	if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
+	if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != N/A* ]]; then
 		echo "  - Added database: $NEW_DB"
 	fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# OpenBudget Agent Instructions
+
+This file provides role guidance for the OpenBudget ant colony workflow.
+
+## Roles
+
+### scout
+
+- Discover relevant repository context and constraints.
+- Report findings and recommended tasks.
+- Avoid changing implementation files unless explicitly assigned.
+
+### worker
+
+- Execute assigned implementation tasks autonomously.
+- Keep changes scoped to assigned files.
+- Verify changes (build/tests/lint as applicable).
+- Declare follow-up sub-tasks when additional work is required.
+
+### drone
+
+- Handle automation and maintenance tasks (generation, syncing, updates).
+- Regenerate derived context files and keep tooling metadata current.
+
+### soldier
+
+- Handle high-risk fixes, urgent blockers, and conflict resolution.
+- Stabilize failing verification pipelines when standard workflow is blocked.
+
+### designer
+
+- Own UX and interaction design direction across features.
+- Define user journeys, flows, information architecture, and visual intent.
+- Provide design constraints and acceptance criteria for implementation tasks.
+- Coordinate with worker and scout roles to ensure plan outputs include design requirements.
+
+## Notes
+
+- This file is treated as shared agent context.
+- Keep role definitions concise and action-oriented.
+
+## Recent Changes
+
+- 001-initialize-plan-artifacts: Added Bash (POSIX shell scripting with Bash 3.2+ compatibility) + Git, grep, sed, awk, mktemp
+
+## Active Technologies
+
+- Bash (POSIX shell scripting with Bash 3.2+ compatibility) + Git, grep, sed, awk, mktemp (001-initialize-plan-artifacts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,3 +213,11 @@ See `.specify/memory/constitution.md` for the full project constitution (v1.0.0)
 - **Patrol** — E2E integration testing
 - **dprint** — non-Dart formatting
 - **Knope** — changeset-based version management and release automation
+
+## Recent Changes
+
+- 001-initialize-plan-artifacts: Added Bash (POSIX shell scripting with Bash 3.2+ compatibility) + Git, grep, sed, awk, mktemp
+
+## Active Technologies
+
+- Bash (POSIX shell scripting with Bash 3.2+ compatibility) + Git, grep, sed, awk, mktemp (001-initialize-plan-artifacts)

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -4,6 +4,13 @@ inputs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
   ifiokjr-nixpkgs:
     url: github:ifiokjr/nixpkgs
+  git-hooks:
+    url: github:cachix/git-hooks.nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  pre-commit-hooks:
+    follows: git-hooks
 # If you're using non-OSS software, you can set allowUnfree to true.
 allowUnfree: true
 

--- a/docs/how-to-use-openbudget-plan-and-priorities.md
+++ b/docs/how-to-use-openbudget-plan-and-priorities.md
@@ -29,6 +29,31 @@ undo actions, and fast navigation into recent moves.
 
 ![OpenBudget iOS plan actions menu](https://f002.backblazeb2.com/file/openbudget/screenshots/2026-02-24-ios-guide/plan-menu.png)
 
+## Maintainer workflow: planning next steps with agent context
+
+When continuing implementation work from a feature plan, use the current
+SpecKit command flow and always refresh shared agent context before generating
+tasks.
+
+1. Start from a feature branch/spec context, then run
+   `.claude/commands/speckit.plan.md` workflow (`/speckit.plan`).
+2. During Phase 1 design, run
+   `.specify/scripts/bash/update-agent-context.sh claude`.
+3. Confirm the regeneration updated shared guidance artifacts:
+   - `AGENTS.md` (shared role guidance for codex/opencode/amp/q/bob flows)
+   - `.agent/rules/specify-rules.md`
+   - `.cursor/rules/specify-rules.mdc`
+   - `.windsurf/rules/specify-rules.md`
+   - `.kilocode/rules/specify-rules.md`
+   - `.augment/rules/specify-rules.md`
+   - `.roo/rules/specify-rules.md`
+4. Continue with `.claude/commands/speckit.tasks.md` (`/speckit.tasks`) to
+   generate dependency-ordered implementation tasks from the updated plan
+   artifacts.
+
+This keeps “next steps in the plan” aligned with the latest rules and
+multi-agent context.
+
 <!-- {=iosGuideCompanionWorkflows} -->
 
 ## Continue with another guide flow

--- a/specs/001-initialize-plan-artifacts/plan.md
+++ b/specs/001-initialize-plan-artifacts/plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan: Initialize plan artifacts and regenerate agent context
+
+**Branch**: `001-initialize-plan-artifacts` | **Date**: 2026-03-08 | **Spec**: `specs/001-initialize-plan-artifacts/spec.md`
+**Input**: Feature specification from `/specs/001-initialize-plan-artifacts/spec.md`
+
+## Summary
+
+Initialize plan artifacts for the feature branch and regenerate agent context files from a valid feature-plan context so instruction files stay synchronized with repository workflow.
+
+## Technical Context
+
+**Language/Version**: Bash (POSIX shell scripting with Bash 3.2+ compatibility)\
+**Primary Dependencies**: Git, grep, sed, awk, mktemp\
+**Storage**: N/A (markdown files in repository)\
+**Testing**: Manual script execution + shellcheck (where available)\
+**Target Platform**: macOS/Linux developer shell environment
+**Project Type**: single (tooling/documentation automation)\
+**Performance Goals**: Complete context regeneration in <5s for current repo size\
+**Constraints**: Must be idempotent and preserve manual additions in agent files\
+**Scale/Scope**: One feature spec/plan pair with updates to root agent instruction files
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+Current changes are documentation/tooling-only and align with existing constitution expectations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-initialize-plan-artifacts/
+├── plan.md
+├── spec.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+.specify/
+└── scripts/
+    └── bash/
+        ├── setup-plan.sh
+        └── update-agent-context.sh
+
+AGENTS.md
+CLAUDE.md
+specs/
+└── 001-initialize-plan-artifacts/
+    ├── spec.md
+    └── plan.md
+```
+
+**Structure Decision**: Single repository tooling/documentation structure centered on `.specify/scripts/bash` plus root-level agent context markdown files.
+
+## Complexity Tracking
+
+No constitution violations identified.

--- a/specs/001-initialize-plan-artifacts/spec.md
+++ b/specs/001-initialize-plan-artifacts/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Initialize plan artifacts and regenerate agent context
+
+**Feature Branch**: `001-initialize-plan-artifacts`\
+**Created**: 2026-03-08\
+**Status**: Draft\
+**Input**: User description: "continue with the next steps in the plan make sure you have a designer and all rules are up to date in the agents file"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Regenerate agent context from a valid feature plan (Priority: P1)
+
+As a maintainer, I can run the plan workflow and refresh shared agent context files from the active feature plan so agent rules and roles stay synchronized.
+
+**Why this priority**: This is required to keep operational guidance accurate before generating implementation tasks.
+
+**Independent Test**: Run `.specify/scripts/bash/update-agent-context.sh` from the feature branch and verify `CLAUDE.md` and `AGENTS.md` contain up-to-date context.
+
+**Acceptance Scenarios**:
+
+1. **Given** a feature branch with `specs/<feature>/plan.md`, **When** the update script runs, **Then** agent context files are updated successfully.
+2. **Given** missing plan context, **When** the update script runs, **Then** it fails with a clear actionable error.
+
+---
+
+### User Story 2 - Keep agent updates idempotent (Priority: P2)
+
+As a maintainer, I can rerun context generation without creating duplicate Recent Changes or Active Technologies entries.
+
+**Why this priority**: Repeated runs are common during planning and should not degrade context quality.
+
+**Independent Test**: Run the update script multiple times and confirm no duplicate entries are added.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent file that already contains the current branch change line, **When** the script reruns, **Then** no duplicate line is added.
+2. **Given** stale placeholder entries from older runs, **When** the script updates the file, **Then** placeholder rows are not retained.
+
+---
+
+### User Story 3 - Support shared target files across agent aliases (Priority: P3)
+
+As a maintainer, I can update all existing agent files in one command without processing the same physical file multiple times.
+
+**Why this priority**: Several agent aliases map to `AGENTS.md`; duplicate processing causes repeated writes and noisy history.
+
+**Independent Test**: Run update with no agent argument and verify each target file is updated once.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple aliases map to one target file, **When** update-all runs, **Then** duplicate targets are skipped with an informational log.
+
+## Edge Cases
+
+- Plan metadata contains `N/A` variants (for example `N/A (...)`) for storage.
+- Existing context files include placeholder bullets (for example `[if applicable, ...]`).
+- Agent aliases map to identical paths (`codex`, `opencode`, `amp`, `q`, `bob`).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST require a valid feature branch/plan context before updating agent files.
+- **FR-002**: System MUST parse implementation plan metadata (language, dependencies, storage, project type).
+- **FR-003**: System MUST update existing agent files without duplicating current-branch Recent Changes lines.
+- **FR-004**: System MUST update Active Technologies using exact line-level dedupe to avoid false positives from substring matches.
+- **FR-005**: System MUST skip stale placeholder/N/A entries when refreshing context sections.
+- **FR-006**: System MUST ensure the shared `AGENTS.md` includes a `designer` role definition.
+- **FR-007**: System MUST avoid updating the same target file multiple times during update-all mode.
+- **FR-008**: Documentation MUST define the maintainer workflow for running plan + context refresh before task generation.
+
+### Key Entities _(include if feature involves data)_
+
+- **Feature Plan Metadata**: Extracted fields from `plan.md` (`Language/Version`, `Primary Dependencies`, `Storage`, `Project Type`).
+- **Agent Context File**: Markdown instructions file containing roles, recent changes, and active technologies.
+- **Agent Target Mapping**: Mapping from logical agent type (`claude`, `codex`, `q`, etc.) to physical file path.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Running `.specify/scripts/bash/update-agent-context.sh` on the feature branch exits successfully and updates context files.
+- **SC-002**: Running the same command twice in succession produces no additional duplicate entries in `Recent Changes`.
+- **SC-003**: `AGENTS.md` contains a `designer` role and no placeholder `[if applicable, ...]` change entries.
+- **SC-004**: Update-all mode logs duplicate-target skips for aliases that resolve to the same path and writes each target once.

--- a/specs/001-initialize-plan-artifacts/tasks.md
+++ b/specs/001-initialize-plan-artifacts/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Initialize plan artifacts and regenerate agent context
+
+**Input**: Design documents from `/specs/001-initialize-plan-artifacts/`
+**Prerequisites**: `plan.md`, `spec.md`
+
+## Phase 1: Setup
+
+- [x] T001 Create feature-plan artifacts in `specs/001-initialize-plan-artifacts/`.
+- [x] T002 Add shared `AGENTS.md` and include role guidance with a `designer` role.
+- [x] T003 Update `docs/how-to-use-openbudget-plan-and-priorities.md` with maintainer plan/context workflow.
+
+## Phase 2: Core implementation
+
+- [x] T004 Update `.specify/scripts/bash/update-agent-context.sh` to dedupe repeated `Recent Changes` entries.
+- [x] T005 Update `.specify/scripts/bash/update-agent-context.sh` to dedupe `Active Technologies` by exact bullet line.
+- [x] T006 Ensure update-all mode processes each target file once even when multiple aliases map to the same file.
+- [x] T007 Filter stale placeholder entries (for example `[if applicable, ...]`) from generated context sections.
+
+## Phase 3: Validation
+
+- [x] T008 Run `bash -n .specify/scripts/bash/update-agent-context.sh`.
+- [x] T009 Run `.specify/scripts/bash/update-agent-context.sh` (update-all mode) from the feature branch.
+- [x] T010 Run `dprint check` for updated markdown files.
+
+## Notes
+
+- This task file reflects work completed while continuing “next steps in the plan” on branch `001-initialize-plan-artifacts`.


### PR DESCRIPTION
## Summary
- add shared `AGENTS.md` with explicit multi-agent roles including `designer`
- harden `.specify/scripts/bash/update-agent-context.sh` for idempotent updates (dedupe recent changes, exact active-tech dedupe, placeholder cleanup, shared-target de-duplication)
- update `CLAUDE.md` and maintainer planning workflow docs for plan/context regeneration
- add feature-plan artifacts in `specs/001-initialize-plan-artifacts/` (`plan.md`, `spec.md`, `tasks.md`)

## Validation
- `bash -n .specify/scripts/bash/update-agent-context.sh`
- `.specify/scripts/bash/update-agent-context.sh` (update-all mode)
- `dprint check AGENTS.md CLAUDE.md docs/how-to-use-openbudget-plan-and-priorities.md specs/001-initialize-plan-artifacts/plan.md specs/001-initialize-plan-artifacts/spec.md specs/001-initialize-plan-artifacts/tasks.md`

## Notes
- update-all mode now updates shared targets once and logs duplicate target skips for alias collisions (for example `codex`/`q`/`bob` -> `AGENTS.md`).
