### PR TITLE
fix(ui): replace HookWidget with StatelessWidget for hookless widgets

### DIFF
--- a/openbudget_ui/lib/src/widgets/ob_button.dart
+++ b/openbudget_ui/lib/src/widgets/ob_button.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// A themed filled button for primary actions.
-class ObFilledButton extends HookWidget {
+class ObFilledButton extends StatelessWidget {
   const ObFilledButton({
     required this.onPressed,
     required this.child,
@@ -30,7 +29,7 @@ class ObFilledButton extends HookWidget {
 }
 
 /// A themed outlined button for secondary actions.
-class ObOutlinedButton extends HookWidget {
+class ObOutlinedButton extends StatelessWidget {
   const ObOutlinedButton({
     required this.onPressed,
     required this.child,
@@ -47,7 +46,7 @@ class ObOutlinedButton extends HookWidget {
 }
 
 /// A themed text button for tertiary actions.
-class ObTextButton extends HookWidget {
+class ObTextButton extends StatelessWidget {
   const ObTextButton({required this.onPressed, required this.child, super.key});
 
   final VoidCallback? onPressed;

--- a/openbudget_ui/lib/src/widgets/ob_card.dart
+++ b/openbudget_ui/lib/src/widgets/ob_card.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// A themed card widget with consistent styling.
-class ObCard extends HookWidget {
+class ObCard extends StatelessWidget {
   const ObCard({required this.child, this.padding, super.key});
 
   final Widget child;

--- a/openbudget_ui/lib/src/widgets/ob_dropdown.dart
+++ b/openbudget_ui/lib/src/widgets/ob_dropdown.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// A themed dropdown field with consistent styling.
-class ObDropdown<T> extends HookWidget {
+class ObDropdown<T> extends StatelessWidget {
   const ObDropdown({
     required this.value,
     required this.items,

--- a/openbudget_ui/lib/src/widgets/ob_text_field.dart
+++ b/openbudget_ui/lib/src/widgets/ob_text_field.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// A themed text field with consistent styling.
-class ObTextField extends HookWidget {
+class ObTextField extends StatelessWidget {
   const ObTextField({
     this.controller,
     this.hintText,


### PR DESCRIPTION
## Summary

- Changed `ObFilledButton`, `ObOutlinedButton`, `ObTextButton`, `ObCard`, `ObDropdown`, and `ObTextField` from extending `HookWidget` to `StatelessWidget` since none of them use any hooks
- Removed unused `package:flutter_hooks/flutter_hooks.dart` imports from all four widget files
- `dart analyze openbudget_ui` passes cleanly

## Test plan

- [x] `dart analyze openbudget_ui` reports no issues
- [ ] Existing widget tests continue to pass (`melos run test`)

Closes #203