### PR TITLE
chore: add .dockerignore for server builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Repo metadata and tooling
+.git/
+.github/
+.claude/
+.specify/
+.changeset/
+.fvm/
+
+# Packages not needed for the server build
+openbudget_app/
+openbudget_ui/
+openbudget_test_utils/
+openbudget_scripts/
+openbudget_lints/
+openbudget_wired/
+
+# Server test directory
+openbudget_server/test/
+
+# Infrastructure and docs
+infra/
+docs/
+tools/
+
+# Config files not needed in the image
+.envrc
+.fvmrc
+.gitignore
+.gitleaks.toml
+.swiftlint.yml
+analysis_options.yaml
+docker-compose.yaml
+dprint.json
+knope.toml
+mdt.toml
+package.json
+pnpm-lock.yaml
+pnpm-workspace.yaml
+devenv.lock
+devenv.nix
+devenv.yaml
+
+# Documentation
+*.md
+!openbudget_server/README.md
+
+# Misc
+*.log
+.DS_Store

--- a/infra/README.md
+++ b/infra/README.md
@@ -213,7 +213,7 @@ pipeline to build and deploy the Serverpod Docker image.
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <ecr-url>
 
 # Build and push
-docker build -t <ecr-url>:latest -f openbudget_server/Dockerfile openbudget_server/
+docker build -t <ecr-url>:latest -f openbudget_server/Dockerfile .
 docker push <ecr-url>:latest
 
 # Force new deployment
@@ -227,7 +227,7 @@ aws ecs update-service --cluster <cluster-name> --service <service-name> --force
 gcloud auth configure-docker <region>-docker.pkg.dev
 
 # Build and push
-docker build -t <registry-url>/serverpod:latest -f openbudget_server/Dockerfile openbudget_server/
+docker build -t <registry-url>/serverpod:latest -f openbudget_server/Dockerfile .
 docker push <registry-url>/serverpod:latest
 
 # Cloud Run auto-deploys on new image (if configured)

--- a/openbudget_server/Dockerfile
+++ b/openbudget_server/Dockerfile
@@ -1,9 +1,10 @@
-# Build stage
+# Build stage — context must be the repo root so path dependencies resolve
 FROM dart:3.8.0 AS build
-WORKDIR /app
+WORKDIR /workspace
 COPY . .
 
 # Install dependencies and compile the server executable
+WORKDIR /workspace/openbudget_server
 RUN dart pub get
 RUN dart compile exe bin/main.dart -o bin/server
 
@@ -20,15 +21,15 @@ ENV role=monolith
 COPY --from=build /runtime/ /
 
 # Copy compiled server executable
-COPY --from=build /app/bin/server server
+COPY --from=build /workspace/openbudget_server/bin/server server
 
 # Copy configuration files and resources
-COPY --from=build /app/config/ config/
-COPY --from=build /app/web/ web/
-COPY --from=build /app/migrations/ migrations/
+COPY --from=build /workspace/openbudget_server/config/ config/
+COPY --from=build /workspace/openbudget_server/web/ web/
+COPY --from=build /workspace/openbudget_server/migrations/ migrations/
 
 # This file is required to enable the endpoint log filter in Insights.
-COPY --from=build /app/lib/src/generated/protocol.yaml lib/src/generated/protocol.yaml
+COPY --from=build /workspace/openbudget_server/lib/src/generated/protocol.yaml lib/src/generated/protocol.yaml
 
 # Expose ports
 EXPOSE 8080


### PR DESCRIPTION
## Summary

- Add a root `.dockerignore` to exclude packages and files not needed for the server Docker build (app, UI, test utils, scripts, lints, infra, tooling configs, docs)
- Update `openbudget_server/Dockerfile` to use the repo root as build context, since the server has a path dependency on `../openbudget_core` that requires workspace-level resolution
- Fix `infra/README.md` docker build commands to pass `.` (repo root) as context instead of `openbudget_server/`

**Kept in context:** `openbudget_server/`, `openbudget_core/`, `openbudget_client/`, root `pubspec.yaml` and `pubspec.lock` (needed for Dart workspace resolution).

Closes #201

## Test plan

- [ ] Verify `docker build -f openbudget_server/Dockerfile .` succeeds from the repo root
- [ ] Confirm the built image starts correctly with `docker run`
- [ ] Check that `openbudget_core` path dependency resolves during `dart pub get` in the build stage