### PR TITLE
fix: regenerate Serverpod protocol for 3.4.6 upgrade

### DIFF
--- a/openbudget_app/pubspec.yaml
+++ b/openbudget_app/pubspec.yaml
@@ -32,8 +32,8 @@ dependencies:
   plaid_flutter: 5.0.5
   posthog_flutter: 5.14.0
   riverpod_annotation: 4.0.2
-  serverpod_auth_idp_flutter: 3.3.1
-  serverpod_flutter: 3.3.1
+  serverpod_auth_idp_flutter: 3.4.6
+  serverpod_flutter: 3.4.6
   shared_preferences: 2.5.3
   shorebird_code_push: 2.0.5
   simple_icons: 14.6.1

--- a/openbudget_client/lib/src/protocol/accounts/account.dart
+++ b/openbudget_client/lib/src/protocol/accounts/account.dart
@@ -74,9 +74,9 @@ abstract class Account implements _i1.SerializableModel {
           : _i1.UuidValueJsonExtension.fromJson(
               jsonSerialization['institutionId'],
             ),
-      onBudget: jsonSerialization['onBudget'] as bool,
+      onBudget: _i1.BoolJsonExtension.fromJson(jsonSerialization['onBudget']),
       sortOrder: jsonSerialization['sortOrder'] as int,
-      isClosed: jsonSerialization['isClosed'] as bool,
+      isClosed: _i1.BoolJsonExtension.fromJson(jsonSerialization['isClosed']),
       sourceType: jsonSerialization['sourceType'] as String?,
       externalAccountId: jsonSerialization['externalAccountId'] as String?,
       connectionId: jsonSerialization['connectionId'] == null

--- a/openbudget_client/lib/src/protocol/categories/category.dart
+++ b/openbudget_client/lib/src/protocol/categories/category.dart
@@ -43,7 +43,9 @@ abstract class Category implements _i1.SerializableModel {
         jsonSerialization['budgetId'],
       ),
       sortOrder: jsonSerialization['sortOrder'] as int,
-      isHidden: jsonSerialization['isHidden'] as bool?,
+      isHidden: jsonSerialization['isHidden'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isHidden']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),

--- a/openbudget_client/lib/src/protocol/client.dart
+++ b/openbudget_client/lib/src/protocol/client.dart
@@ -77,43 +77,57 @@ class EndpointAccount extends _i1.EndpointRef {
     required bool onBudget,
     required int sortOrder,
     _i1.UuidValue? institutionId,
-  }) => caller.callServerEndpoint<_i3.Account>('account', 'create', {
-    'name': name,
-    'accountType': accountType,
-    'balanceCents': balanceCents,
-    'currencyCode': currencyCode,
-    'budgetId': budgetId,
-    'onBudget': onBudget,
-    'sortOrder': sortOrder,
-    'institutionId': institutionId,
-  });
+  }) => caller.callServerEndpoint<_i3.Account>(
+    'account',
+    'create',
+    {
+      'name': name,
+      'accountType': accountType,
+      'balanceCents': balanceCents,
+      'currencyCode': currencyCode,
+      'budgetId': budgetId,
+      'onBudget': onBudget,
+      'sortOrder': sortOrder,
+      'institutionId': institutionId,
+    },
+  );
 
   /// Lists all accounts for a budget.
   _i2.Future<List<_i3.Account>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i3.Account>>('account', 'list', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<List<_i3.Account>>(
+        'account',
+        'list',
+        {'budgetId': budgetId},
+      );
 
   /// Lists creator-owned reusable accounts that can be added to another budget.
   _i2.Future<List<_i3.Account>> listMine({_i1.UuidValue? excludeBudgetId}) =>
-      caller.callServerEndpoint<List<_i3.Account>>('account', 'listMine', {
-        'excludeBudgetId': excludeBudgetId,
-      });
+      caller.callServerEndpoint<List<_i3.Account>>(
+        'account',
+        'listMine',
+        {'excludeBudgetId': excludeBudgetId},
+      );
 
   /// Adds one of the creator's existing accounts to another owned budget.
   _i2.Future<_i3.Account> addMineToBudget(
     _i1.UuidValue sourceAccountId,
     _i1.UuidValue budgetId,
-  ) => caller.callServerEndpoint<_i3.Account>('account', 'addMineToBudget', {
-    'sourceAccountId': sourceAccountId,
-    'budgetId': budgetId,
-  });
+  ) => caller.callServerEndpoint<_i3.Account>(
+    'account',
+    'addMineToBudget',
+    {
+      'sourceAccountId': sourceAccountId,
+      'budgetId': budgetId,
+    },
+  );
 
   /// Gets a single account by ID.
   _i2.Future<_i3.Account> get(_i1.UuidValue accountId) =>
-      caller.callServerEndpoint<_i3.Account>('account', 'get', {
-        'accountId': accountId,
-      });
+      caller.callServerEndpoint<_i3.Account>(
+        'account',
+        'get',
+        {'accountId': accountId},
+      );
 
   /// Updates an account by ID.
   _i2.Future<_i3.Account> update(
@@ -124,21 +138,27 @@ class EndpointAccount extends _i1.EndpointRef {
     bool? onBudget,
     int? sortOrder,
     bool? isClosed,
-  }) => caller.callServerEndpoint<_i3.Account>('account', 'update', {
-    'accountId': accountId,
-    'name': name,
-    'accountType': accountType,
-    'balanceCents': balanceCents,
-    'onBudget': onBudget,
-    'sortOrder': sortOrder,
-    'isClosed': isClosed,
-  });
+  }) => caller.callServerEndpoint<_i3.Account>(
+    'account',
+    'update',
+    {
+      'accountId': accountId,
+      'name': name,
+      'accountType': accountType,
+      'balanceCents': balanceCents,
+      'onBudget': onBudget,
+      'sortOrder': sortOrder,
+      'isClosed': isClosed,
+    },
+  );
 
   /// Deletes an account by ID.
   _i2.Future<_i3.Account> delete(_i1.UuidValue accountId) =>
-      caller.callServerEndpoint<_i3.Account>('account', 'delete', {
-        'accountId': accountId,
-      });
+      caller.callServerEndpoint<_i3.Account>(
+        'account',
+        'delete',
+        {'accountId': accountId},
+      );
 }
 
 /// By extending [AppleIdpBaseEndpoint], the Apple identity provider endpoint
@@ -166,17 +186,24 @@ class EndpointAppleIdp extends _i4.EndpointAppleIdpBase {
     required bool isNativeApplePlatformSignIn,
     String? firstName,
     String? lastName,
-  }) => caller.callServerEndpoint<_i5.AuthSuccess>('appleIdp', 'login', {
-    'identityToken': identityToken,
-    'authorizationCode': authorizationCode,
-    'isNativeApplePlatformSignIn': isNativeApplePlatformSignIn,
-    'firstName': firstName,
-    'lastName': lastName,
-  });
+  }) => caller.callServerEndpoint<_i5.AuthSuccess>(
+    'appleIdp',
+    'login',
+    {
+      'identityToken': identityToken,
+      'authorizationCode': authorizationCode,
+      'isNativeApplePlatformSignIn': isNativeApplePlatformSignIn,
+      'firstName': firstName,
+      'lastName': lastName,
+    },
+  );
 
   @override
-  _i2.Future<bool> hasAccount() =>
-      caller.callServerEndpoint<bool>('appleIdp', 'hasAccount', {});
+  _i2.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
+    'appleIdp',
+    'hasAccount',
+    {},
+  );
 }
 
 /// By extending [EmailIdpBaseEndpoint], the email identity provider endpoints
@@ -193,10 +220,14 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<_i5.AuthSuccess> login({
     required String email,
     required String password,
-  }) => caller.callServerEndpoint<_i5.AuthSuccess>('emailIdp', 'login', {
-    'email': email,
-    'password': password,
-  });
+  }) => caller.callServerEndpoint<_i5.AuthSuccess>(
+    'emailIdp',
+    'login',
+    {
+      'email': email,
+      'password': password,
+    },
+  );
 
   @override
   _i2.Future<_i1.UuidValue> startRegistration({required String email}) =>
@@ -210,11 +241,14 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<String> verifyRegistrationCode({
     required _i1.UuidValue accountRequestId,
     required String verificationCode,
-  }) =>
-      caller.callServerEndpoint<String>('emailIdp', 'verifyRegistrationCode', {
-        'accountRequestId': accountRequestId,
-        'verificationCode': verificationCode,
-      });
+  }) => caller.callServerEndpoint<String>(
+    'emailIdp',
+    'verifyRegistrationCode',
+    {
+      'accountRequestId': accountRequestId,
+      'verificationCode': verificationCode,
+    },
+  );
 
   @override
   _i2.Future<_i5.AuthSuccess> finishRegistration({
@@ -223,7 +257,10 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   }) => caller.callServerEndpoint<_i5.AuthSuccess>(
     'emailIdp',
     'finishRegistration',
-    {'registrationToken': registrationToken, 'password': password},
+    {
+      'registrationToken': registrationToken,
+      'password': password,
+    },
   );
 
   /// Requests a password reset for [email].
@@ -265,11 +302,14 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<String> verifyPasswordResetCode({
     required _i1.UuidValue passwordResetRequestId,
     required String verificationCode,
-  }) =>
-      caller.callServerEndpoint<String>('emailIdp', 'verifyPasswordResetCode', {
-        'passwordResetRequestId': passwordResetRequestId,
-        'verificationCode': verificationCode,
-      });
+  }) => caller.callServerEndpoint<String>(
+    'emailIdp',
+    'verifyPasswordResetCode',
+    {
+      'passwordResetRequestId': passwordResetRequestId,
+      'verificationCode': verificationCode,
+    },
+  );
 
   /// Completes a password reset request by setting a new password.
   ///
@@ -289,14 +329,21 @@ class EndpointEmailIdp extends _i4.EndpointEmailIdpBase {
   _i2.Future<void> finishPasswordReset({
     required String finishPasswordResetToken,
     required String newPassword,
-  }) => caller.callServerEndpoint<void>('emailIdp', 'finishPasswordReset', {
-    'finishPasswordResetToken': finishPasswordResetToken,
-    'newPassword': newPassword,
-  });
+  }) => caller.callServerEndpoint<void>(
+    'emailIdp',
+    'finishPasswordReset',
+    {
+      'finishPasswordResetToken': finishPasswordResetToken,
+      'newPassword': newPassword,
+    },
+  );
 
   @override
-  _i2.Future<bool> hasAccount() =>
-      caller.callServerEndpoint<bool>('emailIdp', 'hasAccount', {});
+  _i2.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
+    'emailIdp',
+    'hasAccount',
+    {},
+  );
 }
 
 /// By extending [GoogleIdpBaseEndpoint], the Google identity provider endpoint
@@ -317,14 +364,21 @@ class EndpointGoogleIdp extends _i4.EndpointGoogleIdpBase {
   _i2.Future<_i5.AuthSuccess> login({
     required String idToken,
     required String? accessToken,
-  }) => caller.callServerEndpoint<_i5.AuthSuccess>('googleIdp', 'login', {
-    'idToken': idToken,
-    'accessToken': accessToken,
-  });
+  }) => caller.callServerEndpoint<_i5.AuthSuccess>(
+    'googleIdp',
+    'login',
+    {
+      'idToken': idToken,
+      'accessToken': accessToken,
+    },
+  );
 
   @override
-  _i2.Future<bool> hasAccount() =>
-      caller.callServerEndpoint<bool>('googleIdp', 'hasAccount', {});
+  _i2.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
+    'googleIdp',
+    'hasAccount',
+    {},
+  );
 }
 
 /// By extending [RefreshJwtTokensEndpoint], the JWT token refresh endpoint
@@ -384,7 +438,12 @@ class EndpointBudgetTemplate extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i6.BudgetTemplate>(
     'budgetTemplate',
     'saveFromMonth',
-    {'budgetId': budgetId, 'name': name, 'year': year, 'month': month},
+    {
+      'budgetId': budgetId,
+      'name': name,
+      'year': year,
+      'month': month,
+    },
   );
 
   /// Lists all templates for a budget.
@@ -432,19 +491,33 @@ class EndpointBudget extends _i1.EndpointRef {
   String get name => 'budget';
 
   /// Creates a new budget for the authenticated user.
-  _i2.Future<_i8.Budget> create(String name, String currencyCode) =>
-      caller.callServerEndpoint<_i8.Budget>('budget', 'create', {
-        'name': name,
-        'currencyCode': currencyCode,
-      });
+  _i2.Future<_i8.Budget> create(
+    String name,
+    String currencyCode,
+  ) => caller.callServerEndpoint<_i8.Budget>(
+    'budget',
+    'create',
+    {
+      'name': name,
+      'currencyCode': currencyCode,
+    },
+  );
 
   /// Lists all budgets for the authenticated user.
   _i2.Future<List<_i8.Budget>> list() =>
-      caller.callServerEndpoint<List<_i8.Budget>>('budget', 'list', {});
+      caller.callServerEndpoint<List<_i8.Budget>>(
+        'budget',
+        'list',
+        {},
+      );
 
   /// Gets a single budget by ID, verifying ownership.
-  _i2.Future<_i8.Budget> get(_i1.UuidValue budgetId) => caller
-      .callServerEndpoint<_i8.Budget>('budget', 'get', {'budgetId': budgetId});
+  _i2.Future<_i8.Budget> get(_i1.UuidValue budgetId) =>
+      caller.callServerEndpoint<_i8.Budget>(
+        'budget',
+        'get',
+        {'budgetId': budgetId},
+      );
 
   /// Updates a budget by ID, verifying ownership.
   _i2.Future<_i8.Budget> update(
@@ -453,30 +526,38 @@ class EndpointBudget extends _i1.EndpointRef {
     String? currencyCode,
     String? displayCurrencyCode,
     bool? clearDisplayCurrencyCode,
-  }) => caller.callServerEndpoint<_i8.Budget>('budget', 'update', {
-    'budgetId': budgetId,
-    'name': name,
-    'currencyCode': currencyCode,
-    'displayCurrencyCode': displayCurrencyCode,
-    'clearDisplayCurrencyCode': clearDisplayCurrencyCode,
-  });
+  }) => caller.callServerEndpoint<_i8.Budget>(
+    'budget',
+    'update',
+    {
+      'budgetId': budgetId,
+      'name': name,
+      'currencyCode': currencyCode,
+      'displayCurrencyCode': displayCurrencyCode,
+      'clearDisplayCurrencyCode': clearDisplayCurrencyCode,
+    },
+  );
 
   /// Deletes a budget by ID, verifying ownership.
   _i2.Future<_i8.Budget> delete(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<_i8.Budget>('budget', 'delete', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<_i8.Budget>(
+        'budget',
+        'delete',
+        {'budgetId': budgetId},
+      );
 
   /// Exports all budget data as a JSON string for data portability.
   _i2.Future<String> exportData(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<String>('budget', 'exportData', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<String>(
+        'budget',
+        'exportData',
+        {'budgetId': budgetId},
+      );
 }
 
 /// Streaming endpoint for real-time budget updates.
 ///
-/// Client sends budget IDs, server streams back the current budget state.
+/// Client sends a budget ID once, server streams live budget snapshots.
 /// {@category Endpoint}
 class EndpointBudgetStream extends _i1.EndpointRef {
   EndpointBudgetStream(_i1.EndpointCaller caller) : super(caller);
@@ -486,9 +567,9 @@ class EndpointBudgetStream extends _i1.EndpointRef {
 
   /// Streams budget updates to the connected client.
   ///
-  /// Client sends [UuidValue] budget IDs, server responds with the current
-  /// [Budget] state for each requested ID. Ownership is verified on each
-  /// request.
+  /// Client sends a [UuidValue] budget ID. The stream yields an initial
+  /// [Budget] snapshot and then emits fresh snapshots whenever that budget
+  /// changes.
   _i2.Stream<_i8.Budget> budgetUpdates(
     _i2.Stream<_i1.UuidValue> budgetIdStream,
   ) => caller.callStreamingServerEndpoint<_i2.Stream<_i8.Budget>, _i8.Budget>(
@@ -514,23 +595,31 @@ class EndpointCategory extends _i1.EndpointRef {
     String name,
     _i1.UuidValue budgetId,
     int sortOrder,
-  ) => caller.callServerEndpoint<_i9.Category>('category', 'create', {
-    'name': name,
-    'budgetId': budgetId,
-    'sortOrder': sortOrder,
-  });
+  ) => caller.callServerEndpoint<_i9.Category>(
+    'category',
+    'create',
+    {
+      'name': name,
+      'budgetId': budgetId,
+      'sortOrder': sortOrder,
+    },
+  );
 
   /// Lists all categories for a budget.
   _i2.Future<List<_i9.Category>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i9.Category>>('category', 'list', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<List<_i9.Category>>(
+        'category',
+        'list',
+        {'budgetId': budgetId},
+      );
 
   /// Gets a single category by ID.
   _i2.Future<_i9.Category> get(_i1.UuidValue categoryId) =>
-      caller.callServerEndpoint<_i9.Category>('category', 'get', {
-        'categoryId': categoryId,
-      });
+      caller.callServerEndpoint<_i9.Category>(
+        'category',
+        'get',
+        {'categoryId': categoryId},
+      );
 
   /// Updates a category by ID.
   _i2.Future<_i9.Category> update(
@@ -538,12 +627,16 @@ class EndpointCategory extends _i1.EndpointRef {
     String? name,
     int? sortOrder,
     bool? isHidden,
-  }) => caller.callServerEndpoint<_i9.Category>('category', 'update', {
-    'categoryId': categoryId,
-    'name': name,
-    'sortOrder': sortOrder,
-    'isHidden': isHidden,
-  });
+  }) => caller.callServerEndpoint<_i9.Category>(
+    'category',
+    'update',
+    {
+      'categoryId': categoryId,
+      'name': name,
+      'sortOrder': sortOrder,
+      'isHidden': isHidden,
+    },
+  );
 
   /// Batch-reorders categories by their new position.
   ///
@@ -552,16 +645,22 @@ class EndpointCategory extends _i1.EndpointRef {
   _i2.Future<List<_i9.Category>> reorder(
     _i1.UuidValue budgetId,
     List<_i1.UuidValue> categoryIds,
-  ) => caller.callServerEndpoint<List<_i9.Category>>('category', 'reorder', {
-    'budgetId': budgetId,
-    'categoryIds': categoryIds,
-  });
+  ) => caller.callServerEndpoint<List<_i9.Category>>(
+    'category',
+    'reorder',
+    {
+      'budgetId': budgetId,
+      'categoryIds': categoryIds,
+    },
+  );
 
   /// Deletes a category by ID.
   _i2.Future<_i9.Category> delete(_i1.UuidValue categoryId) =>
-      caller.callServerEndpoint<_i9.Category>('category', 'delete', {
-        'categoryId': categoryId,
-      });
+      caller.callServerEndpoint<_i9.Category>(
+        'category',
+        'delete',
+        {'categoryId': categoryId},
+      );
 }
 
 /// API surface for envelope goal operations.
@@ -581,13 +680,17 @@ class EndpointEnvelopeGoal extends _i1.EndpointRef {
     int targetAmountCents, {
     DateTime? targetDate,
     int? monthlyFundingCents,
-  }) => caller.callServerEndpoint<_i10.EnvelopeGoal>('envelopeGoal', 'upsert', {
-    'envelopeId': envelopeId,
-    'goalType': goalType,
-    'targetAmountCents': targetAmountCents,
-    'targetDate': targetDate,
-    'monthlyFundingCents': monthlyFundingCents,
-  });
+  }) => caller.callServerEndpoint<_i10.EnvelopeGoal>(
+    'envelopeGoal',
+    'upsert',
+    {
+      'envelopeId': envelopeId,
+      'goalType': goalType,
+      'targetAmountCents': targetAmountCents,
+      'targetDate': targetDate,
+      'monthlyFundingCents': monthlyFundingCents,
+    },
+  );
 
   /// Gets the goal for an envelope.
   _i2.Future<_i10.EnvelopeGoal?> getForEnvelope(_i1.UuidValue envelopeId) =>
@@ -608,9 +711,11 @@ class EndpointEnvelopeGoal extends _i1.EndpointRef {
 
   /// Deletes a goal by ID.
   _i2.Future<_i10.EnvelopeGoal> delete(_i1.UuidValue goalId) =>
-      caller.callServerEndpoint<_i10.EnvelopeGoal>('envelopeGoal', 'delete', {
-        'goalId': goalId,
-      });
+      caller.callServerEndpoint<_i10.EnvelopeGoal>(
+        'envelopeGoal',
+        'delete',
+        {'goalId': goalId},
+      );
 }
 
 /// API surface for envelope operations.
@@ -629,24 +734,32 @@ class EndpointEnvelope extends _i1.EndpointRef {
     _i1.UuidValue categoryId,
     int budgetedAmountCents,
     String currencyCode,
-  ) => caller.callServerEndpoint<_i11.Envelope>('envelope', 'create', {
-    'name': name,
-    'categoryId': categoryId,
-    'budgetedAmountCents': budgetedAmountCents,
-    'currencyCode': currencyCode,
-  });
+  ) => caller.callServerEndpoint<_i11.Envelope>(
+    'envelope',
+    'create',
+    {
+      'name': name,
+      'categoryId': categoryId,
+      'budgetedAmountCents': budgetedAmountCents,
+      'currencyCode': currencyCode,
+    },
+  );
 
   /// Lists all envelopes for a category.
   _i2.Future<List<_i11.Envelope>> list(_i1.UuidValue categoryId) =>
-      caller.callServerEndpoint<List<_i11.Envelope>>('envelope', 'list', {
-        'categoryId': categoryId,
-      });
+      caller.callServerEndpoint<List<_i11.Envelope>>(
+        'envelope',
+        'list',
+        {'categoryId': categoryId},
+      );
 
   /// Gets a single envelope by ID.
   _i2.Future<_i11.Envelope> get(_i1.UuidValue envelopeId) =>
-      caller.callServerEndpoint<_i11.Envelope>('envelope', 'get', {
-        'envelopeId': envelopeId,
-      });
+      caller.callServerEndpoint<_i11.Envelope>(
+        'envelope',
+        'get',
+        {'envelopeId': envelopeId},
+      );
 
   /// Updates an envelope by ID.
   _i2.Future<_i11.Envelope> update(
@@ -656,29 +769,39 @@ class EndpointEnvelope extends _i1.EndpointRef {
     int? spentAmountCents,
     String? note,
     bool? isHidden,
-  }) => caller.callServerEndpoint<_i11.Envelope>('envelope', 'update', {
-    'envelopeId': envelopeId,
-    'name': name,
-    'budgetedAmountCents': budgetedAmountCents,
-    'spentAmountCents': spentAmountCents,
-    'note': note,
-    'isHidden': isHidden,
-  });
+  }) => caller.callServerEndpoint<_i11.Envelope>(
+    'envelope',
+    'update',
+    {
+      'envelopeId': envelopeId,
+      'name': name,
+      'budgetedAmountCents': budgetedAmountCents,
+      'spentAmountCents': spentAmountCents,
+      'note': note,
+      'isHidden': isHidden,
+    },
+  );
 
   /// Reorders envelopes within a category.
   _i2.Future<List<_i11.Envelope>> reorder(
     _i1.UuidValue categoryId,
     List<String> envelopeIds,
-  ) => caller.callServerEndpoint<List<_i11.Envelope>>('envelope', 'reorder', {
-    'categoryId': categoryId,
-    'envelopeIds': envelopeIds,
-  });
+  ) => caller.callServerEndpoint<List<_i11.Envelope>>(
+    'envelope',
+    'reorder',
+    {
+      'categoryId': categoryId,
+      'envelopeIds': envelopeIds,
+    },
+  );
 
   /// Deletes an envelope by ID.
   _i2.Future<_i11.Envelope> delete(_i1.UuidValue envelopeId) =>
-      caller.callServerEndpoint<_i11.Envelope>('envelope', 'delete', {
-        'envelopeId': envelopeId,
-      });
+      caller.callServerEndpoint<_i11.Envelope>(
+        'envelope',
+        'delete',
+        {'envelopeId': envelopeId},
+      );
 }
 
 /// API surface for exchange rates used by display-currency conversion.
@@ -691,11 +814,19 @@ class EndpointFxRate extends _i1.EndpointRef {
 
   /// Returns the latest FX snapshot persisted by the backend.
   _i2.Future<_i12.FxLatestSnapshot> latest() =>
-      caller.callServerEndpoint<_i12.FxLatestSnapshot>('fxRate', 'latest', {});
+      caller.callServerEndpoint<_i12.FxLatestSnapshot>(
+        'fxRate',
+        'latest',
+        {},
+      );
 
   /// Forces an immediate refresh from the upstream FX provider and persists it.
   _i2.Future<_i12.FxLatestSnapshot> refresh() =>
-      caller.callServerEndpoint<_i12.FxLatestSnapshot>('fxRate', 'refresh', {});
+      caller.callServerEndpoint<_i12.FxLatestSnapshot>(
+        'fxRate',
+        'refresh',
+        {},
+      );
 }
 
 /// API surface for institution catalog discovery.
@@ -708,9 +839,11 @@ class EndpointInstitution extends _i1.EndpointRef {
 
   /// Returns the seeded institution catalog sorted for a user's location.
   _i2.Future<List<_i13.Institution>> list({String? locationCode}) =>
-      caller.callServerEndpoint<List<_i13.Institution>>('institution', 'list', {
-        'locationCode': locationCode,
-      });
+      caller.callServerEndpoint<List<_i13.Institution>>(
+        'institution',
+        'list',
+        {'locationCode': locationCode},
+      );
 }
 
 /// API surface for monthly allocation operations.
@@ -752,7 +885,11 @@ class EndpointMonthlyAllocation extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i7.MonthlyAllocation>>(
     'monthlyAllocation',
     'list',
-    {'budgetId': budgetId, 'year': year, 'month': month},
+    {
+      'budgetId': budgetId,
+      'year': year,
+      'month': month,
+    },
   );
 
   /// Copies all allocations from a source month to a target month.
@@ -815,28 +952,46 @@ class EndpointPayee extends _i1.EndpointRef {
   String get name => 'payee';
 
   /// Creates a new payee within a budget.
-  _i2.Future<_i14.Payee> create(String name, _i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<_i14.Payee>('payee', 'create', {
-        'name': name,
-        'budgetId': budgetId,
-      });
+  _i2.Future<_i14.Payee> create(
+    String name,
+    _i1.UuidValue budgetId,
+  ) => caller.callServerEndpoint<_i14.Payee>(
+    'payee',
+    'create',
+    {
+      'name': name,
+      'budgetId': budgetId,
+    },
+  );
 
   /// Lists all payees for a budget.
   _i2.Future<List<_i14.Payee>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i14.Payee>>('payee', 'list', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<List<_i14.Payee>>(
+        'payee',
+        'list',
+        {'budgetId': budgetId},
+      );
 
   /// Gets a single payee by ID.
-  _i2.Future<_i14.Payee> get(_i1.UuidValue payeeId) => caller
-      .callServerEndpoint<_i14.Payee>('payee', 'get', {'payeeId': payeeId});
+  _i2.Future<_i14.Payee> get(_i1.UuidValue payeeId) =>
+      caller.callServerEndpoint<_i14.Payee>(
+        'payee',
+        'get',
+        {'payeeId': payeeId},
+      );
 
   /// Updates a payee by ID.
-  _i2.Future<_i14.Payee> update(_i1.UuidValue payeeId, {String? name}) =>
-      caller.callServerEndpoint<_i14.Payee>('payee', 'update', {
-        'payeeId': payeeId,
-        'name': name,
-      });
+  _i2.Future<_i14.Payee> update(
+    _i1.UuidValue payeeId, {
+    String? name,
+  }) => caller.callServerEndpoint<_i14.Payee>(
+    'payee',
+    'update',
+    {
+      'payeeId': payeeId,
+      'name': name,
+    },
+  );
 
   /// Returns the envelope ID from the most recent transaction for a payee.
   _i2.Future<_i1.UuidValue?> lastUsedEnvelopeId(
@@ -845,7 +1000,10 @@ class EndpointPayee extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i1.UuidValue?>(
     'payee',
     'lastUsedEnvelopeId',
-    {'payeeId': payeeId, 'budgetId': budgetId},
+    {
+      'payeeId': payeeId,
+      'budgetId': budgetId,
+    },
   );
 
   /// Merges the source payee into the target payee.
@@ -856,14 +1014,22 @@ class EndpointPayee extends _i1.EndpointRef {
   _i2.Future<int> merge(
     _i1.UuidValue sourcePayeeId,
     _i1.UuidValue targetPayeeId,
-  ) => caller.callServerEndpoint<int>('payee', 'merge', {
-    'sourcePayeeId': sourcePayeeId,
-    'targetPayeeId': targetPayeeId,
-  });
+  ) => caller.callServerEndpoint<int>(
+    'payee',
+    'merge',
+    {
+      'sourcePayeeId': sourcePayeeId,
+      'targetPayeeId': targetPayeeId,
+    },
+  );
 
   /// Deletes a payee by ID.
-  _i2.Future<_i14.Payee> delete(_i1.UuidValue payeeId) => caller
-      .callServerEndpoint<_i14.Payee>('payee', 'delete', {'payeeId': payeeId});
+  _i2.Future<_i14.Payee> delete(_i1.UuidValue payeeId) =>
+      caller.callServerEndpoint<_i14.Payee>(
+        'payee',
+        'delete',
+        {'payeeId': payeeId},
+      );
 }
 
 /// API surface for Plaid-linked account integration.
@@ -876,9 +1042,11 @@ class EndpointPlaid extends _i1.EndpointRef {
 
   /// Creates a short-lived link token for starting Plaid Link in the client.
   _i2.Future<String> createLinkToken(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<String>('plaid', 'createLinkToken', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<String>(
+        'plaid',
+        'createLinkToken',
+        {'budgetId': budgetId},
+      );
 
   /// Exchanges a public token and imports linked bank accounts into OpenBudget.
   _i2.Future<List<_i3.Account>> exchangePublicToken(
@@ -887,17 +1055,24 @@ class EndpointPlaid extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i3.Account>>(
     'plaid',
     'exchangePublicToken',
-    {'budgetId': budgetId, 'publicToken': publicToken},
+    {
+      'budgetId': budgetId,
+      'publicToken': publicToken,
+    },
   );
 
   /// Refreshes an existing Plaid item connection and updates imported accounts.
   _i2.Future<List<_i3.Account>> syncConnection(
     _i1.UuidValue budgetId,
     _i1.UuidValue connectionId,
-  ) => caller.callServerEndpoint<List<_i3.Account>>('plaid', 'syncConnection', {
-    'budgetId': budgetId,
-    'connectionId': connectionId,
-  });
+  ) => caller.callServerEndpoint<List<_i3.Account>>(
+    'plaid',
+    'syncConnection',
+    {
+      'budgetId': budgetId,
+      'connectionId': connectionId,
+    },
+  );
 
   /// Creates a Plaid sandbox item and imports accounts without client-side Link.
   _i2.Future<List<_i3.Account>> importSandboxAccounts(
@@ -906,7 +1081,10 @@ class EndpointPlaid extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<List<_i3.Account>>(
     'plaid',
     'importSandboxAccounts',
-    {'budgetId': budgetId, 'plaidInstitutionId': plaidInstitutionId},
+    {
+      'budgetId': budgetId,
+      'plaidInstitutionId': plaidInstitutionId,
+    },
   );
 }
 
@@ -956,7 +1134,10 @@ class EndpointRecurringTransaction extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<List<_i15.RecurringTransaction>>(
     'recurringTransaction',
     'list',
-    {'budgetId': budgetId, 'activeOnly': activeOnly},
+    {
+      'budgetId': budgetId,
+      'activeOnly': activeOnly,
+    },
   );
 
   /// Gets a recurring transaction by ID.
@@ -1020,15 +1201,19 @@ class EndpointRecurringTransaction extends _i1.EndpointRef {
   /// transactions and advancing the schedule. Returns the count of created
   /// transactions.
   _i2.Future<int> postDue(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<int>('recurringTransaction', 'postDue', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<int>(
+        'recurringTransaction',
+        'postDue',
+        {'budgetId': budgetId},
+      );
 
   /// Returns the count of active recurring transactions that are currently due.
   _i2.Future<int> countDue(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<int>('recurringTransaction', 'countDue', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<int>(
+        'recurringTransaction',
+        'countDue',
+        {'budgetId': budgetId},
+      );
 }
 
 /// API surface for Solana wallet operations.
@@ -1046,13 +1231,17 @@ class EndpointSolanaWallet extends _i1.EndpointRef {
     String address, {
     String? label,
     required String cluster,
-  }) => caller.callServerEndpoint<_i16.SolanaWallet>('solanaWallet', 'attach', {
-    'budgetId': budgetId,
-    'accountId': accountId,
-    'address': address,
-    'label': label,
-    'cluster': cluster,
-  });
+  }) => caller.callServerEndpoint<_i16.SolanaWallet>(
+    'solanaWallet',
+    'attach',
+    {
+      'budgetId': budgetId,
+      'accountId': accountId,
+      'address': address,
+      'label': label,
+      'cluster': cluster,
+    },
+  );
 
   /// Returns all Solana wallets for a budget.
   _i2.Future<List<_i16.SolanaWallet>> list(_i1.UuidValue budgetId) =>
@@ -1069,7 +1258,10 @@ class EndpointSolanaWallet extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i16.SolanaWallet?>(
     'solanaWallet',
     'getForAccount',
-    {'budgetId': budgetId, 'accountId': accountId},
+    {
+      'budgetId': budgetId,
+      'accountId': accountId,
+    },
   );
 
   /// Syncs recent chain activity and holdings for the wallet.
@@ -1080,7 +1272,11 @@ class EndpointSolanaWallet extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<_i17.SolanaWalletSyncResult>(
     'solanaWallet',
     'sync',
-    {'budgetId': budgetId, 'walletId': walletId, 'limit': limit},
+    {
+      'budgetId': budgetId,
+      'walletId': walletId,
+      'limit': limit,
+    },
   );
 
   /// Lists parsed wallet transactions.
@@ -1091,7 +1287,11 @@ class EndpointSolanaWallet extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<List<_i18.SolanaWalletTransaction>>(
     'solanaWallet',
     'listTransactions',
-    {'budgetId': budgetId, 'walletId': walletId, 'limit': limit},
+    {
+      'budgetId': budgetId,
+      'walletId': walletId,
+      'limit': limit,
+    },
   );
 
   /// Lists current wallet holdings.
@@ -1101,7 +1301,10 @@ class EndpointSolanaWallet extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i19.SolanaWalletHolding>>(
     'solanaWallet',
     'listHoldings',
-    {'budgetId': budgetId, 'walletId': walletId},
+    {
+      'budgetId': budgetId,
+      'walletId': walletId,
+    },
   );
 
   /// Returns estimated realized wallet P&L grouped by tax year.
@@ -1111,7 +1314,10 @@ class EndpointSolanaWallet extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i20.SolanaWalletTaxYearSummary>>(
     'solanaWallet',
     'listTaxYearSummaries',
-    {'budgetId': budgetId, 'walletId': walletId},
+    {
+      'budgetId': budgetId,
+      'walletId': walletId,
+    },
   );
 
   /// Updates category/tags/memo for a wallet transaction.
@@ -1197,7 +1403,10 @@ class EndpointTransactionRule extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i1.UuidValue?>(
     'transactionRule',
     'findMatchingEnvelope',
-    {'budgetId': budgetId, 'payeeId': payeeId},
+    {
+      'budgetId': budgetId,
+      'payeeId': payeeId,
+    },
   );
 
   /// Deletes a transaction rule.
@@ -1229,22 +1438,28 @@ class EndpointTransaction extends _i1.EndpointRef {
     _i1.UuidValue? envelopeId,
     _i1.UuidValue? payeeId,
     String? memo,
-  }) => caller.callServerEndpoint<_i22.Transaction>('transaction', 'create', {
-    'description': description,
-    'amountCents': amountCents,
-    'currencyCode': currencyCode,
-    'budgetId': budgetId,
-    'transactionDate': transactionDate,
-    'envelopeId': envelopeId,
-    'payeeId': payeeId,
-    'memo': memo,
-  });
+  }) => caller.callServerEndpoint<_i22.Transaction>(
+    'transaction',
+    'create',
+    {
+      'description': description,
+      'amountCents': amountCents,
+      'currencyCode': currencyCode,
+      'budgetId': budgetId,
+      'transactionDate': transactionDate,
+      'envelopeId': envelopeId,
+      'payeeId': payeeId,
+      'memo': memo,
+    },
+  );
 
   /// Lists all transactions for a budget.
   _i2.Future<List<_i22.Transaction>> list(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<List<_i22.Transaction>>('transaction', 'list', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<List<_i22.Transaction>>(
+        'transaction',
+        'list',
+        {'budgetId': budgetId},
+      );
 
   /// Lists transactions for a budget within a specific month.
   _i2.Future<List<_i22.Transaction>> listByMonth(
@@ -1254,14 +1469,20 @@ class EndpointTransaction extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i22.Transaction>>(
     'transaction',
     'listByMonth',
-    {'budgetId': budgetId, 'year': year, 'month': month},
+    {
+      'budgetId': budgetId,
+      'year': year,
+      'month': month,
+    },
   );
 
   /// Gets a single transaction by ID.
   _i2.Future<_i22.Transaction> get(_i1.UuidValue transactionId) =>
-      caller.callServerEndpoint<_i22.Transaction>('transaction', 'get', {
-        'transactionId': transactionId,
-      });
+      caller.callServerEndpoint<_i22.Transaction>(
+        'transaction',
+        'get',
+        {'transactionId': transactionId},
+      );
 
   /// Updates a transaction by ID.
   _i2.Future<_i22.Transaction> update(
@@ -1273,25 +1494,33 @@ class EndpointTransaction extends _i1.EndpointRef {
     DateTime? transactionDate,
     String? memo,
     String? flagColor,
-  }) => caller.callServerEndpoint<_i22.Transaction>('transaction', 'update', {
-    'transactionId': transactionId,
-    'description': description,
-    'amountCents': amountCents,
-    'envelopeId': envelopeId,
-    'payeeId': payeeId,
-    'transactionDate': transactionDate,
-    'memo': memo,
-    'flagColor': flagColor,
-  });
+  }) => caller.callServerEndpoint<_i22.Transaction>(
+    'transaction',
+    'update',
+    {
+      'transactionId': transactionId,
+      'description': description,
+      'amountCents': amountCents,
+      'envelopeId': envelopeId,
+      'payeeId': payeeId,
+      'transactionDate': transactionDate,
+      'memo': memo,
+      'flagColor': flagColor,
+    },
+  );
 
   /// Sets or clears the flag color on a transaction.
   _i2.Future<_i22.Transaction> setFlag(
     _i1.UuidValue transactionId, {
     String? flagColor,
-  }) => caller.callServerEndpoint<_i22.Transaction>('transaction', 'setFlag', {
-    'transactionId': transactionId,
-    'flagColor': flagColor,
-  });
+  }) => caller.callServerEndpoint<_i22.Transaction>(
+    'transaction',
+    'setFlag',
+    {
+      'transactionId': transactionId,
+      'flagColor': flagColor,
+    },
+  );
 
   /// Creates a transfer between two accounts.
   _i2.Future<List<_i22.Transaction>> transfer(
@@ -1302,16 +1531,19 @@ class EndpointTransaction extends _i1.EndpointRef {
     _i1.UuidValue fromAccountId,
     _i1.UuidValue toAccountId,
     DateTime transactionDate,
-  ) => caller
-      .callServerEndpoint<List<_i22.Transaction>>('transaction', 'transfer', {
-        'description': description,
-        'amountCents': amountCents,
-        'currencyCode': currencyCode,
-        'budgetId': budgetId,
-        'fromAccountId': fromAccountId,
-        'toAccountId': toAccountId,
-        'transactionDate': transactionDate,
-      });
+  ) => caller.callServerEndpoint<List<_i22.Transaction>>(
+    'transaction',
+    'transfer',
+    {
+      'description': description,
+      'amountCents': amountCents,
+      'currencyCode': currencyCode,
+      'budgetId': budgetId,
+      'fromAccountId': fromAccountId,
+      'toAccountId': toAccountId,
+      'transactionDate': transactionDate,
+    },
+  );
 
   /// Lists transactions for a specific account.
   _i2.Future<List<_i22.Transaction>> listByAccount(
@@ -1320,7 +1552,10 @@ class EndpointTransaction extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i22.Transaction>>(
     'transaction',
     'listByAccount',
-    {'accountId': accountId, 'budgetId': budgetId},
+    {
+      'accountId': accountId,
+      'budgetId': budgetId,
+    },
   );
 
   /// Toggles the cleared status of a transaction.
@@ -1335,10 +1570,14 @@ class EndpointTransaction extends _i1.EndpointRef {
   _i2.Future<int> reconcileAccount(
     _i1.UuidValue accountId,
     _i1.UuidValue budgetId,
-  ) => caller.callServerEndpoint<int>('transaction', 'reconcileAccount', {
-    'accountId': accountId,
-    'budgetId': budgetId,
-  });
+  ) => caller.callServerEndpoint<int>(
+    'transaction',
+    'reconcileAccount',
+    {
+      'accountId': accountId,
+      'budgetId': budgetId,
+    },
+  );
 
   /// Reconciles an account with a statement balance.
   ///
@@ -1348,21 +1587,26 @@ class EndpointTransaction extends _i1.EndpointRef {
     _i1.UuidValue accountId,
     _i1.UuidValue budgetId,
     int statementBalanceCents,
-  ) => caller
-      .callServerEndpoint<List<int>>('transaction', 'reconcileWithBalance', {
-        'accountId': accountId,
-        'budgetId': budgetId,
-        'statementBalanceCents': statementBalanceCents,
-      });
+  ) => caller.callServerEndpoint<List<int>>(
+    'transaction',
+    'reconcileWithBalance',
+    {
+      'accountId': accountId,
+      'budgetId': budgetId,
+      'statementBalanceCents': statementBalanceCents,
+    },
+  );
 
   /// Calculates the "Age of Money" for a budget.
   ///
   /// Returns the average days between income and spending, or null if
   /// there is insufficient data.
   _i2.Future<int?> ageOfMoney(_i1.UuidValue budgetId) =>
-      caller.callServerEndpoint<int?>('transaction', 'ageOfMoney', {
-        'budgetId': budgetId,
-      });
+      caller.callServerEndpoint<int?>(
+        'transaction',
+        'ageOfMoney',
+        {'budgetId': budgetId},
+      );
 
   /// Creates a split transaction with multiple envelope assignments.
   _i2.Future<List<_i22.Transaction>> createSplit(
@@ -1406,12 +1650,16 @@ class EndpointTransaction extends _i1.EndpointRef {
     String currencyCode,
     List<_i24.ImportRow> rows, {
     _i1.UuidValue? accountId,
-  }) => caller.callServerEndpoint<int>('transaction', 'bulkImport', {
-    'budgetId': budgetId,
-    'currencyCode': currencyCode,
-    'rows': rows,
-    'accountId': accountId,
-  });
+  }) => caller.callServerEndpoint<int>(
+    'transaction',
+    'bulkImport',
+    {
+      'budgetId': budgetId,
+      'currencyCode': currencyCode,
+      'rows': rows,
+      'accountId': accountId,
+    },
+  );
 
   /// Finds potential duplicate transactions with the same amount near a date.
   _i2.Future<List<_i22.Transaction>> findDuplicates(
@@ -1430,9 +1678,11 @@ class EndpointTransaction extends _i1.EndpointRef {
 
   /// Deletes a transaction by ID.
   _i2.Future<_i22.Transaction> delete(_i1.UuidValue transactionId) =>
-      caller.callServerEndpoint<_i22.Transaction>('transaction', 'delete', {
-        'transactionId': transactionId,
-      });
+      caller.callServerEndpoint<_i22.Transaction>(
+        'transaction',
+        'delete',
+        {'transactionId': transactionId},
+      );
 }
 
 /// API surface for read-only blockchain wallet account integration.
@@ -1467,7 +1717,10 @@ class EndpointWallet extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<_i25.WalletConnectResult>(
     'wallet',
     'refreshSolanaWallet',
-    {'budgetId': budgetId, 'connectionId': connectionId},
+    {
+      'budgetId': budgetId,
+      'connectionId': connectionId,
+    },
   );
 
   /// Returns the latest persisted holdings for a wallet connection.
@@ -1477,7 +1730,10 @@ class EndpointWallet extends _i1.EndpointRef {
   ) => caller.callServerEndpoint<List<_i26.WalletHolding>>(
     'wallet',
     'listWalletHoldings',
-    {'budgetId': budgetId, 'connectionId': connectionId},
+    {
+      'budgetId': budgetId,
+      'connectionId': connectionId,
+    },
   );
 }
 
@@ -1502,7 +1758,12 @@ class Client extends _i1.ServerpodClientShared {
     super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
-    Function(_i1.MethodCallContext, Object, StackTrace)? onFailedCall,
+    Function(
+      _i1.MethodCallContext,
+      Object,
+      StackTrace,
+    )?
+    onFailedCall,
     Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(

--- a/openbudget_client/lib/src/protocol/envelopes/envelope.dart
+++ b/openbudget_client/lib/src/protocol/envelopes/envelope.dart
@@ -55,7 +55,9 @@ abstract class Envelope implements _i1.SerializableModel {
       currencyCode: jsonSerialization['currencyCode'] as String,
       sortOrder: jsonSerialization['sortOrder'] as int,
       note: jsonSerialization['note'] as String?,
-      isHidden: jsonSerialization['isHidden'] as bool?,
+      isHidden: jsonSerialization['isHidden'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isHidden']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),

--- a/openbudget_client/lib/src/protocol/fx_rates/fx_latest_snapshot.dart
+++ b/openbudget_client/lib/src/protocol/fx_rates/fx_latest_snapshot.dart
@@ -36,7 +36,7 @@ abstract class FxLatestSnapshot implements _i1.SerializableModel {
       fetchedAt: _i1.DateTimeJsonExtension.fromJson(
         jsonSerialization['fetchedAt'],
       ),
-      isStale: jsonSerialization['isStale'] as bool,
+      isStale: _i1.BoolJsonExtension.fromJson(jsonSerialization['isStale']),
       rates: _i3.Protocol().deserialize<List<_i2.FxRateQuote>>(
         jsonSerialization['rates'],
       ),

--- a/openbudget_client/lib/src/protocol/fx_rates/fx_rate_quote.dart
+++ b/openbudget_client/lib/src/protocol/fx_rates/fx_rate_quote.dart
@@ -14,10 +14,15 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 /// Currency exchange rate pair used in API responses.
 abstract class FxRateQuote implements _i1.SerializableModel {
-  FxRateQuote._({required this.currencyCode, required this.rate});
+  FxRateQuote._({
+    required this.currencyCode,
+    required this.rate,
+  });
 
-  factory FxRateQuote({required String currencyCode, required double rate}) =
-      _FxRateQuoteImpl;
+  factory FxRateQuote({
+    required String currencyCode,
+    required double rate,
+  }) = _FxRateQuoteImpl;
 
   factory FxRateQuote.fromJson(Map<String, dynamic> jsonSerialization) {
     return FxRateQuote(
@@ -33,7 +38,10 @@ abstract class FxRateQuote implements _i1.SerializableModel {
   /// Returns a shallow copy of this [FxRateQuote]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  FxRateQuote copyWith({String? currencyCode, double? rate});
+  FxRateQuote copyWith({
+    String? currencyCode,
+    double? rate,
+  });
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -50,14 +58,22 @@ abstract class FxRateQuote implements _i1.SerializableModel {
 }
 
 class _FxRateQuoteImpl extends FxRateQuote {
-  _FxRateQuoteImpl({required String currencyCode, required double rate})
-    : super._(currencyCode: currencyCode, rate: rate);
+  _FxRateQuoteImpl({
+    required String currencyCode,
+    required double rate,
+  }) : super._(
+         currencyCode: currencyCode,
+         rate: rate,
+       );
 
   /// Returns a shallow copy of this [FxRateQuote]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
   @override
-  FxRateQuote copyWith({String? currencyCode, double? rate}) {
+  FxRateQuote copyWith({
+    String? currencyCode,
+    double? rate,
+  }) {
     return FxRateQuote(
       currencyCode: currencyCode ?? this.currencyCode,
       rate: rate ?? this.rate,

--- a/openbudget_client/lib/src/protocol/fx_rates/fx_rate_snapshot.dart
+++ b/openbudget_client/lib/src/protocol/fx_rates/fx_rate_snapshot.dart
@@ -43,7 +43,9 @@ abstract class FxRateSnapshot implements _i1.SerializableModel {
       fetchedAt: _i1.DateTimeJsonExtension.fromJson(
         jsonSerialization['fetchedAt'],
       ),
-      isLatest: jsonSerialization['isLatest'] as bool?,
+      isLatest: jsonSerialization['isLatest'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isLatest']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),

--- a/openbudget_client/lib/src/protocol/institutions/institution.dart
+++ b/openbudget_client/lib/src/protocol/institutions/institution.dart
@@ -44,7 +44,9 @@ abstract class Institution implements _i1.SerializableModel {
       name: jsonSerialization['name'] as String,
       website: jsonSerialization['website'] as String?,
       plaidInstitutionId: jsonSerialization['plaidInstitutionId'] as String?,
-      isDigitalBank: jsonSerialization['isDigitalBank'] as bool?,
+      isDigitalBank: jsonSerialization['isDigitalBank'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isDigitalBank']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),

--- a/openbudget_client/lib/src/protocol/institutions/institution_location.dart
+++ b/openbudget_client/lib/src/protocol/institutions/institution_location.dart
@@ -42,7 +42,9 @@ abstract class InstitutionLocation implements _i1.SerializableModel {
         jsonSerialization['institutionId'],
       ),
       locationCode: jsonSerialization['locationCode'] as String,
-      isPopular: jsonSerialization['isPopular'] as bool?,
+      isPopular: jsonSerialization['isPopular'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isPopular']),
       popularityRank: jsonSerialization['popularityRank'] as int?,
       createdAt: jsonSerialization['createdAt'] == null
           ? null

--- a/openbudget_client/lib/src/protocol/payees/payee.dart
+++ b/openbudget_client/lib/src/protocol/payees/payee.dart
@@ -88,7 +88,12 @@ class _PayeeImpl extends Payee {
     required String name,
     required _i1.UuidValue budgetId,
     DateTime? createdAt,
-  }) : super._(id: id, name: name, budgetId: budgetId, createdAt: createdAt);
+  }) : super._(
+         id: id,
+         name: name,
+         budgetId: budgetId,
+         createdAt: createdAt,
+       );
 
   /// Returns a shallow copy of this [Payee]
   /// with some or all fields replaced by the given arguments.

--- a/openbudget_client/lib/src/protocol/protocol.dart
+++ b/openbudget_client/lib/src/protocol/protocol.dart
@@ -123,7 +123,10 @@ class Protocol extends _i1.SerializationManager {
   }
 
   @override
-  T deserialize<T>(dynamic data, [Type? t]) {
+  T deserialize<T>(
+    dynamic data, [
+    Type? t,
+  ]) {
     t ??= T;
 
     final dataClassName = getClassNameFromObjectJson(data);

--- a/openbudget_client/lib/src/protocol/recurring_transactions/recurring_transaction.dart
+++ b/openbudget_client/lib/src/protocol/recurring_transactions/recurring_transaction.dart
@@ -80,7 +80,7 @@ abstract class RecurringTransaction implements _i1.SerializableModel {
       endDate: jsonSerialization['endDate'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['endDate']),
-      isActive: jsonSerialization['isActive'] as bool,
+      isActive: _i1.BoolJsonExtension.fromJson(jsonSerialization['isActive']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),

--- a/openbudget_client/lib/src/protocol/solana_wallets/solana_wallet_holding.dart
+++ b/openbudget_client/lib/src/protocol/solana_wallets/solana_wallet_holding.dart
@@ -92,7 +92,7 @@ abstract class SolanaWalletHolding implements _i1.SerializableModel {
       decimals: jsonSerialization['decimals'] as int,
       balanceRaw: jsonSerialization['balanceRaw'] as String,
       balanceUi: jsonSerialization['balanceUi'] as String,
-      isNft: jsonSerialization['isNft'] as bool,
+      isNft: _i1.BoolJsonExtension.fromJson(jsonSerialization['isNft']),
       priceCurrency: jsonSerialization['priceCurrency'] as String?,
       pricePerToken: (jsonSerialization['pricePerToken'] as num?)?.toDouble(),
       totalValue: (jsonSerialization['totalValue'] as num?)?.toDouble(),
@@ -112,7 +112,9 @@ abstract class SolanaWalletHolding implements _i1.SerializableModel {
       priceSource: jsonSerialization['priceSource'] as String?,
       priceQuality: jsonSerialization['priceQuality'] as String?,
       priceConfidence: jsonSerialization['priceConfidence'] as String?,
-      isPriceStale: jsonSerialization['isPriceStale'] as bool?,
+      isPriceStale: jsonSerialization['isPriceStale'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isPriceStale']),
       priceAsOf: jsonSerialization['priceAsOf'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['priceAsOf']),

--- a/openbudget_client/lib/src/protocol/transaction_rules/transaction_rule.dart
+++ b/openbudget_client/lib/src/protocol/transaction_rules/transaction_rule.dart
@@ -47,7 +47,9 @@ abstract class TransactionRule implements _i1.SerializableModel {
       targetEnvelopeId: _i1.UuidValueJsonExtension.fromJson(
         jsonSerialization['targetEnvelopeId'],
       ),
-      enabled: jsonSerialization['enabled'] as bool?,
+      enabled: jsonSerialization['enabled'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['enabled']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),

--- a/openbudget_client/lib/src/protocol/transactions/split_item.dart
+++ b/openbudget_client/lib/src/protocol/transactions/split_item.dart
@@ -14,7 +14,11 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 /// A single split within a split transaction.
 abstract class SplitItem implements _i1.SerializableModel {
-  SplitItem._({required this.amountCents, this.envelopeId, this.memo});
+  SplitItem._({
+    required this.amountCents,
+    this.envelopeId,
+    this.memo,
+  });
 
   factory SplitItem({
     required int amountCents,
@@ -74,7 +78,11 @@ class _SplitItemImpl extends SplitItem {
     required int amountCents,
     _i1.UuidValue? envelopeId,
     String? memo,
-  }) : super._(amountCents: amountCents, envelopeId: envelopeId, memo: memo);
+  }) : super._(
+         amountCents: amountCents,
+         envelopeId: envelopeId,
+         memo: memo,
+       );
 
   /// Returns a shallow copy of this [SplitItem]
   /// with some or all fields replaced by the given arguments.

--- a/openbudget_client/lib/src/protocol/transactions/transaction.dart
+++ b/openbudget_client/lib/src/protocol/transactions/transaction.dart
@@ -90,8 +90,12 @@ abstract class Transaction implements _i1.SerializableModel {
               jsonSerialization['parentTransactionId'],
             ),
       memo: jsonSerialization['memo'] as String?,
-      cleared: jsonSerialization['cleared'] as bool?,
-      reconciled: jsonSerialization['reconciled'] as bool?,
+      cleared: jsonSerialization['cleared'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['cleared']),
+      reconciled: jsonSerialization['reconciled'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['reconciled']),
       flagColor: jsonSerialization['flagColor'] as String?,
       createdAt: jsonSerialization['createdAt'] == null
           ? null

--- a/openbudget_client/pubspec.yaml
+++ b/openbudget_client/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  serverpod_auth_idp_client: 3.3.1
-  serverpod_client: 3.3.1
+  serverpod_auth_idp_client: 3.4.6
+  serverpod_client: 3.4.6
 
 dev_dependencies:
   openbudget_lints:

--- a/openbudget_lints/lib/analysis_options.yaml
+++ b/openbudget_lints/lib/analysis_options.yaml
@@ -8,6 +8,10 @@ analyzer:
     unused_element: error
     unused_import: error
     unused_local_variable: error
+    unused_field: error
+    unnecessary_null_comparison: error
+    invalid_use_of_protected_member: error
+    invalid_override: error
     todo: ignore
   exclude:
     - "**/*.g.dart"
@@ -21,6 +25,90 @@ linter:
     # Relax rules that conflict with Serverpod generated code
     public_member_api_docs: false
     lines_longer_than_80_chars: false
+
+    # ── Strictness & safety ──
+    always_declare_return_types: true
+    always_put_required_named_parameters_first: true
+    annotate_redeclares: true
+    avoid_bool_literals_in_conditional_expressions: true
+    avoid_double_and_int_checks: true
+    avoid_equals_and_hash_code_on_mutable_classes: true
+    avoid_escaping_inner_quotes: true
+    avoid_field_initializers_in_const_classes: true
+    avoid_implementing_value_types: true
+    avoid_multiple_declarations_per_line: true
+    avoid_positional_boolean_parameters: true
+    avoid_private_typedef_functions: true
+    avoid_redundant_argument_values: true
+    avoid_returning_this: true
+    avoid_setters_without_getters: true
+    avoid_slow_async_io: true
+    avoid_type_to_string: true
+    avoid_types_on_closure_parameters: true
+    avoid_unused_constructor_parameters: true
+    avoid_void_async: true
+    cancel_subscriptions: true
+    close_sinks: true
+    combinators_ordering: true
+    comment_references: true
+    conditional_uri_does_not_exist: true
+    deprecated_consistency: true
+    directives_ordering: true
+    # Disabled: project uses String.fromEnvironment for compile-time --dart-define config
+    do_not_use_environment: false
+    eol_at_end_of_file: true
+    implicit_call_tearoffs: true
+    join_return_with_assignment: true
+    leading_newlines_in_multiline_strings: true
+    literal_only_boolean_expressions: true
+    missing_code_block_language_in_doc_comment: true
+    no_adjacent_strings_in_list: true
+    no_literal_bool_comparisons: true
+    no_self_assignments: true
+    no_wildcard_variable_uses: true
+    noop_primitive_operations: true
+    omit_local_variable_types: true
+    only_throw_errors: true
+    parameter_assignments: true
+    prefer_asserts_in_initializer_lists: true
+    prefer_constructors_over_static_methods: true
+    prefer_expression_function_bodies: true
+    prefer_final_in_for_each: true
+    prefer_final_locals: true
+    prefer_if_elements_to_conditional_expressions: true
+    prefer_int_literals: true
+    prefer_mixin: true
+    prefer_null_aware_method_calls: true
+    prefer_single_quotes: true
+    require_trailing_commas: true
+    sort_constructors_first: true
+    sort_pub_dependencies: true
+    sort_unnamed_constructors_first: true
+    test_types_in_equals: true
+    throw_in_finally: true
+    tighten_type_of_initializing_formals: true
+    type_annotate_public_apis: true
+    unawaited_futures: true
+    unnecessary_await_in_return: true
+    unnecessary_breaks: true
+    unnecessary_lambdas: true
+    unnecessary_null_aware_assignments: true
+    unnecessary_null_aware_operator_on_extension_on_nullable: true
+    unnecessary_parenthesis: true
+    unnecessary_raw_strings: true
+    unnecessary_statements: true
+    unnecessary_to_list_in_spreads: true
+    unreachable_from_main: true
+    use_colored_box: true
+    use_decorated_box: true
+    use_enums: true
+    use_is_even_rather_than_modulo: true
+    use_named_constants: true
+    use_raw_strings: true
+    use_string_buffers: true
+    use_string_in_part_of_directives: true
+    use_super_parameters: true
+    use_to_and_as_if_applicable: true
 
 analyzer_plugins:
   - riverpod_lint

--- a/openbudget_server/Dockerfile
+++ b/openbudget_server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM dart:3.8.0 AS build
+FROM dart:3.11 AS build
 WORKDIR /app
 COPY . .
 

--- a/openbudget_server/lib/src/generated/accounts/account.dart
+++ b/openbudget_server/lib/src/generated/accounts/account.dart
@@ -75,9 +75,9 @@ abstract class Account
           : _i1.UuidValueJsonExtension.fromJson(
               jsonSerialization['institutionId'],
             ),
-      onBudget: jsonSerialization['onBudget'] as bool,
+      onBudget: _i1.BoolJsonExtension.fromJson(jsonSerialization['onBudget']),
       sortOrder: jsonSerialization['sortOrder'] as int,
-      isClosed: jsonSerialization['isClosed'] as bool,
+      isClosed: _i1.BoolJsonExtension.fromJson(jsonSerialization['isClosed']),
       sourceType: jsonSerialization['sourceType'] as String?,
       externalAccountId: jsonSerialization['externalAccountId'] as String?,
       connectionId: jsonSerialization['connectionId'] == null
@@ -635,7 +635,7 @@ class AccountRepository {
   /// );
   /// ```
   Future<List<Account>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<AccountTable>? where,
     int? limit,
     int? offset,
@@ -643,6 +643,8 @@ class AccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AccountTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<Account>(
       where: where?.call(Account.t),
@@ -652,6 +654,8 @@ class AccountRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -673,13 +677,15 @@ class AccountRepository {
   /// );
   /// ```
   Future<Account?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<AccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<AccountTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<AccountTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<Account>(
       where: where?.call(Account.t),
@@ -688,18 +694,24 @@ class AccountRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [Account] by its [id] or null if no such row exists.
   Future<Account?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<Account>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -709,14 +721,20 @@ class AccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<Account>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Account> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<Account>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -724,7 +742,7 @@ class AccountRepository {
   ///
   /// The returned [Account] will have its `id` field set.
   Future<Account> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Account row, {
     _i1.Transaction? transaction,
   }) async {
@@ -740,7 +758,7 @@ class AccountRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<Account>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Account> rows, {
     _i1.ColumnSelections<AccountTable>? columns,
     _i1.Transaction? transaction,
@@ -756,7 +774,7 @@ class AccountRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<Account> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Account row, {
     _i1.ColumnSelections<AccountTable>? columns,
     _i1.Transaction? transaction,
@@ -771,7 +789,7 @@ class AccountRepository {
   /// Updates a single [Account] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<Account?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<AccountUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -786,7 +804,7 @@ class AccountRepository {
   /// Updates all [Account]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<Account>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AccountUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<AccountTable> where,
     int? limit,
@@ -812,7 +830,7 @@ class AccountRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<Account>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Account> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -824,7 +842,7 @@ class AccountRepository {
 
   /// Deletes a single [Account].
   Future<Account> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Account row, {
     _i1.Transaction? transaction,
   }) async {
@@ -836,7 +854,7 @@ class AccountRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<Account>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AccountTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -849,7 +867,7 @@ class AccountRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<AccountTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -857,6 +875,22 @@ class AccountRepository {
     return session.db.count<Account>(
       where: where?.call(Account.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Account] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<AccountTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Account>(
+      where: where(Account.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/budget_templates/budget_template.dart
+++ b/openbudget_server/lib/src/generated/budget_templates/budget_template.dart
@@ -326,7 +326,7 @@ class BudgetTemplateRepository {
   /// );
   /// ```
   Future<List<BudgetTemplate>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<BudgetTemplateTable>? where,
     int? limit,
     int? offset,
@@ -334,6 +334,8 @@ class BudgetTemplateRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BudgetTemplateTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<BudgetTemplate>(
       where: where?.call(BudgetTemplate.t),
@@ -343,6 +345,8 @@ class BudgetTemplateRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -364,13 +368,15 @@ class BudgetTemplateRepository {
   /// );
   /// ```
   Future<BudgetTemplate?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<BudgetTemplateTable>? where,
     int? offset,
     _i1.OrderByBuilder<BudgetTemplateTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<BudgetTemplateTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<BudgetTemplate>(
       where: where?.call(BudgetTemplate.t),
@@ -379,18 +385,24 @@ class BudgetTemplateRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [BudgetTemplate] by its [id] or null if no such row exists.
   Future<BudgetTemplate?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<BudgetTemplate>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -400,14 +412,20 @@ class BudgetTemplateRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<BudgetTemplate>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<BudgetTemplate> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<BudgetTemplate>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -415,7 +433,7 @@ class BudgetTemplateRepository {
   ///
   /// The returned [BudgetTemplate] will have its `id` field set.
   Future<BudgetTemplate> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     BudgetTemplate row, {
     _i1.Transaction? transaction,
   }) async {
@@ -431,7 +449,7 @@ class BudgetTemplateRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<BudgetTemplate>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<BudgetTemplate> rows, {
     _i1.ColumnSelections<BudgetTemplateTable>? columns,
     _i1.Transaction? transaction,
@@ -447,7 +465,7 @@ class BudgetTemplateRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<BudgetTemplate> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     BudgetTemplate row, {
     _i1.ColumnSelections<BudgetTemplateTable>? columns,
     _i1.Transaction? transaction,
@@ -462,7 +480,7 @@ class BudgetTemplateRepository {
   /// Updates a single [BudgetTemplate] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<BudgetTemplate?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<BudgetTemplateUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -477,7 +495,7 @@ class BudgetTemplateRepository {
   /// Updates all [BudgetTemplate]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<BudgetTemplate>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BudgetTemplateUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<BudgetTemplateTable> where,
     int? limit,
@@ -503,7 +521,7 @@ class BudgetTemplateRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<BudgetTemplate>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<BudgetTemplate> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -515,7 +533,7 @@ class BudgetTemplateRepository {
 
   /// Deletes a single [BudgetTemplate].
   Future<BudgetTemplate> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     BudgetTemplate row, {
     _i1.Transaction? transaction,
   }) async {
@@ -527,7 +545,7 @@ class BudgetTemplateRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<BudgetTemplate>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BudgetTemplateTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -540,7 +558,7 @@ class BudgetTemplateRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<BudgetTemplateTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -548,6 +566,22 @@ class BudgetTemplateRepository {
     return session.db.count<BudgetTemplate>(
       where: where?.call(BudgetTemplate.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [BudgetTemplate] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<BudgetTemplateTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<BudgetTemplate>(
+      where: where(BudgetTemplate.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/budgets/budget.dart
+++ b/openbudget_server/lib/src/generated/budgets/budget.dart
@@ -357,7 +357,7 @@ class BudgetRepository {
   /// );
   /// ```
   Future<List<Budget>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<BudgetTable>? where,
     int? limit,
     int? offset,
@@ -365,6 +365,8 @@ class BudgetRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BudgetTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<Budget>(
       where: where?.call(Budget.t),
@@ -374,6 +376,8 @@ class BudgetRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -395,13 +399,15 @@ class BudgetRepository {
   /// );
   /// ```
   Future<Budget?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<BudgetTable>? where,
     int? offset,
     _i1.OrderByBuilder<BudgetTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<BudgetTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<Budget>(
       where: where?.call(Budget.t),
@@ -410,18 +416,24 @@ class BudgetRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [Budget] by its [id] or null if no such row exists.
   Future<Budget?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<Budget>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -431,14 +443,20 @@ class BudgetRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<Budget>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Budget> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<Budget>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -446,7 +464,7 @@ class BudgetRepository {
   ///
   /// The returned [Budget] will have its `id` field set.
   Future<Budget> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Budget row, {
     _i1.Transaction? transaction,
   }) async {
@@ -462,7 +480,7 @@ class BudgetRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<Budget>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Budget> rows, {
     _i1.ColumnSelections<BudgetTable>? columns,
     _i1.Transaction? transaction,
@@ -478,7 +496,7 @@ class BudgetRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<Budget> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Budget row, {
     _i1.ColumnSelections<BudgetTable>? columns,
     _i1.Transaction? transaction,
@@ -493,7 +511,7 @@ class BudgetRepository {
   /// Updates a single [Budget] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<Budget?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<BudgetUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -508,7 +526,7 @@ class BudgetRepository {
   /// Updates all [Budget]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<Budget>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BudgetUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<BudgetTable> where,
     int? limit,
@@ -534,7 +552,7 @@ class BudgetRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<Budget>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Budget> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -546,7 +564,7 @@ class BudgetRepository {
 
   /// Deletes a single [Budget].
   Future<Budget> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Budget row, {
     _i1.Transaction? transaction,
   }) async {
@@ -558,7 +576,7 @@ class BudgetRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<Budget>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BudgetTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -571,7 +589,7 @@ class BudgetRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<BudgetTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -579,6 +597,22 @@ class BudgetRepository {
     return session.db.count<Budget>(
       where: where?.call(Budget.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Budget] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<BudgetTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Budget>(
+      where: where(Budget.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/categories/category.dart
+++ b/openbudget_server/lib/src/generated/categories/category.dart
@@ -44,7 +44,9 @@ abstract class Category
         jsonSerialization['budgetId'],
       ),
       sortOrder: jsonSerialization['sortOrder'] as int,
-      isHidden: jsonSerialization['isHidden'] as bool?,
+      isHidden: jsonSerialization['isHidden'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isHidden']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
@@ -319,7 +321,7 @@ class CategoryRepository {
   /// );
   /// ```
   Future<List<Category>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<CategoryTable>? where,
     int? limit,
     int? offset,
@@ -327,6 +329,8 @@ class CategoryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CategoryTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<Category>(
       where: where?.call(Category.t),
@@ -336,6 +340,8 @@ class CategoryRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -357,13 +363,15 @@ class CategoryRepository {
   /// );
   /// ```
   Future<Category?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<CategoryTable>? where,
     int? offset,
     _i1.OrderByBuilder<CategoryTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<CategoryTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<Category>(
       where: where?.call(Category.t),
@@ -372,18 +380,24 @@ class CategoryRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [Category] by its [id] or null if no such row exists.
   Future<Category?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<Category>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -393,14 +407,20 @@ class CategoryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<Category>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Category> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<Category>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -408,7 +428,7 @@ class CategoryRepository {
   ///
   /// The returned [Category] will have its `id` field set.
   Future<Category> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Category row, {
     _i1.Transaction? transaction,
   }) async {
@@ -424,7 +444,7 @@ class CategoryRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<Category>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Category> rows, {
     _i1.ColumnSelections<CategoryTable>? columns,
     _i1.Transaction? transaction,
@@ -440,7 +460,7 @@ class CategoryRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<Category> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Category row, {
     _i1.ColumnSelections<CategoryTable>? columns,
     _i1.Transaction? transaction,
@@ -455,7 +475,7 @@ class CategoryRepository {
   /// Updates a single [Category] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<Category?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<CategoryUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -470,7 +490,7 @@ class CategoryRepository {
   /// Updates all [Category]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<Category>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CategoryUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<CategoryTable> where,
     int? limit,
@@ -496,7 +516,7 @@ class CategoryRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<Category>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Category> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -508,7 +528,7 @@ class CategoryRepository {
 
   /// Deletes a single [Category].
   Future<Category> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Category row, {
     _i1.Transaction? transaction,
   }) async {
@@ -520,7 +540,7 @@ class CategoryRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<Category>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CategoryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -533,7 +553,7 @@ class CategoryRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<CategoryTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -541,6 +561,22 @@ class CategoryRepository {
     return session.db.count<Category>(
       where: where?.call(Category.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Category] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<CategoryTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Category>(
+      where: where(Category.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/endpoints.dart
+++ b/openbudget_server/lib/src/generated/endpoints.dart
@@ -1598,46 +1598,6 @@ class Endpoints extends _i1.EndpointDispatch {
                         params['targetMonth'],
                       ),
         ),
-        'copyMonth': _i1.MethodConnector(
-          name: 'copyMonth',
-          params: {
-            'budgetId': _i1.ParameterDescription(
-              name: 'budgetId',
-              type: _i1.getType<_i1.UuidValue>(),
-              nullable: false,
-            ),
-            'sourceYear': _i1.ParameterDescription(
-              name: 'sourceYear',
-              type: _i1.getType<int>(),
-              nullable: false,
-            ),
-            'sourceMonth': _i1.ParameterDescription(
-              name: 'sourceMonth',
-              type: _i1.getType<int>(),
-              nullable: false,
-            ),
-            'targetYear': _i1.ParameterDescription(
-              name: 'targetYear',
-              type: _i1.getType<int>(),
-              nullable: false,
-            ),
-            'targetMonth': _i1.ParameterDescription(
-              name: 'targetMonth',
-              type: _i1.getType<int>(),
-              nullable: false,
-            ),
-          },
-          call: (_i1.Session session, Map<String, dynamic> params) async =>
-              (endpoints['monthlyAllocation'] as _i15.MonthlyAllocationEndpoint)
-                  .copyMonth(
-                    session,
-                    params['budgetId'],
-                    params['sourceYear'],
-                    params['sourceMonth'],
-                    params['targetYear'],
-                    params['targetMonth'],
-                  ),
-        ),
         'moveMoney': _i1.MethodConnector(
           name: 'moveMoney',
           params: {

--- a/openbudget_server/lib/src/generated/envelope_goals/envelope_goal.dart
+++ b/openbudget_server/lib/src/generated/envelope_goals/envelope_goal.dart
@@ -384,7 +384,7 @@ class EnvelopeGoalRepository {
   /// );
   /// ```
   Future<List<EnvelopeGoal>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<EnvelopeGoalTable>? where,
     int? limit,
     int? offset,
@@ -392,6 +392,8 @@ class EnvelopeGoalRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnvelopeGoalTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<EnvelopeGoal>(
       where: where?.call(EnvelopeGoal.t),
@@ -401,6 +403,8 @@ class EnvelopeGoalRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -422,13 +426,15 @@ class EnvelopeGoalRepository {
   /// );
   /// ```
   Future<EnvelopeGoal?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<EnvelopeGoalTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnvelopeGoalTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnvelopeGoalTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<EnvelopeGoal>(
       where: where?.call(EnvelopeGoal.t),
@@ -437,18 +443,24 @@ class EnvelopeGoalRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [EnvelopeGoal] by its [id] or null if no such row exists.
   Future<EnvelopeGoal?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<EnvelopeGoal>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -458,14 +470,20 @@ class EnvelopeGoalRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<EnvelopeGoal>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<EnvelopeGoal> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<EnvelopeGoal>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -473,7 +491,7 @@ class EnvelopeGoalRepository {
   ///
   /// The returned [EnvelopeGoal] will have its `id` field set.
   Future<EnvelopeGoal> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     EnvelopeGoal row, {
     _i1.Transaction? transaction,
   }) async {
@@ -489,7 +507,7 @@ class EnvelopeGoalRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<EnvelopeGoal>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<EnvelopeGoal> rows, {
     _i1.ColumnSelections<EnvelopeGoalTable>? columns,
     _i1.Transaction? transaction,
@@ -505,7 +523,7 @@ class EnvelopeGoalRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<EnvelopeGoal> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     EnvelopeGoal row, {
     _i1.ColumnSelections<EnvelopeGoalTable>? columns,
     _i1.Transaction? transaction,
@@ -520,7 +538,7 @@ class EnvelopeGoalRepository {
   /// Updates a single [EnvelopeGoal] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<EnvelopeGoal?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<EnvelopeGoalUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -535,7 +553,7 @@ class EnvelopeGoalRepository {
   /// Updates all [EnvelopeGoal]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<EnvelopeGoal>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnvelopeGoalUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<EnvelopeGoalTable> where,
     int? limit,
@@ -561,7 +579,7 @@ class EnvelopeGoalRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<EnvelopeGoal>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<EnvelopeGoal> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -573,7 +591,7 @@ class EnvelopeGoalRepository {
 
   /// Deletes a single [EnvelopeGoal].
   Future<EnvelopeGoal> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     EnvelopeGoal row, {
     _i1.Transaction? transaction,
   }) async {
@@ -585,7 +603,7 @@ class EnvelopeGoalRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<EnvelopeGoal>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnvelopeGoalTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -598,7 +616,7 @@ class EnvelopeGoalRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<EnvelopeGoalTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -606,6 +624,22 @@ class EnvelopeGoalRepository {
     return session.db.count<EnvelopeGoal>(
       where: where?.call(EnvelopeGoal.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [EnvelopeGoal] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<EnvelopeGoalTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<EnvelopeGoal>(
+      where: where(EnvelopeGoal.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/envelopes/envelope.dart
+++ b/openbudget_server/lib/src/generated/envelopes/envelope.dart
@@ -56,7 +56,9 @@ abstract class Envelope
       currencyCode: jsonSerialization['currencyCode'] as String,
       sortOrder: jsonSerialization['sortOrder'] as int,
       note: jsonSerialization['note'] as String?,
-      isHidden: jsonSerialization['isHidden'] as bool?,
+      isHidden: jsonSerialization['isHidden'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isHidden']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
@@ -426,7 +428,7 @@ class EnvelopeRepository {
   /// );
   /// ```
   Future<List<Envelope>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<EnvelopeTable>? where,
     int? limit,
     int? offset,
@@ -434,6 +436,8 @@ class EnvelopeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnvelopeTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<Envelope>(
       where: where?.call(Envelope.t),
@@ -443,6 +447,8 @@ class EnvelopeRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -464,13 +470,15 @@ class EnvelopeRepository {
   /// );
   /// ```
   Future<Envelope?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<EnvelopeTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnvelopeTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnvelopeTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<Envelope>(
       where: where?.call(Envelope.t),
@@ -479,18 +487,24 @@ class EnvelopeRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [Envelope] by its [id] or null if no such row exists.
   Future<Envelope?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<Envelope>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -500,14 +514,20 @@ class EnvelopeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<Envelope>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Envelope> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<Envelope>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -515,7 +535,7 @@ class EnvelopeRepository {
   ///
   /// The returned [Envelope] will have its `id` field set.
   Future<Envelope> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Envelope row, {
     _i1.Transaction? transaction,
   }) async {
@@ -531,7 +551,7 @@ class EnvelopeRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<Envelope>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Envelope> rows, {
     _i1.ColumnSelections<EnvelopeTable>? columns,
     _i1.Transaction? transaction,
@@ -547,7 +567,7 @@ class EnvelopeRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<Envelope> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Envelope row, {
     _i1.ColumnSelections<EnvelopeTable>? columns,
     _i1.Transaction? transaction,
@@ -562,7 +582,7 @@ class EnvelopeRepository {
   /// Updates a single [Envelope] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<Envelope?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<EnvelopeUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -577,7 +597,7 @@ class EnvelopeRepository {
   /// Updates all [Envelope]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<Envelope>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnvelopeUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<EnvelopeTable> where,
     int? limit,
@@ -603,7 +623,7 @@ class EnvelopeRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<Envelope>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Envelope> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -615,7 +635,7 @@ class EnvelopeRepository {
 
   /// Deletes a single [Envelope].
   Future<Envelope> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Envelope row, {
     _i1.Transaction? transaction,
   }) async {
@@ -627,7 +647,7 @@ class EnvelopeRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<Envelope>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnvelopeTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -640,7 +660,7 @@ class EnvelopeRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<EnvelopeTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -648,6 +668,22 @@ class EnvelopeRepository {
     return session.db.count<Envelope>(
       where: where?.call(Envelope.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Envelope] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<EnvelopeTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Envelope>(
+      where: where(Envelope.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/fx_rates/fx_latest_snapshot.dart
+++ b/openbudget_server/lib/src/generated/fx_rates/fx_latest_snapshot.dart
@@ -37,7 +37,7 @@ abstract class FxLatestSnapshot
       fetchedAt: _i1.DateTimeJsonExtension.fromJson(
         jsonSerialization['fetchedAt'],
       ),
-      isStale: jsonSerialization['isStale'] as bool,
+      isStale: _i1.BoolJsonExtension.fromJson(jsonSerialization['isStale']),
       rates: _i3.Protocol().deserialize<List<_i2.FxRateQuote>>(
         jsonSerialization['rates'],
       ),

--- a/openbudget_server/lib/src/generated/fx_rates/fx_rate_entry.dart
+++ b/openbudget_server/lib/src/generated/fx_rates/fx_rate_entry.dart
@@ -292,7 +292,7 @@ class FxRateEntryRepository {
   /// );
   /// ```
   Future<List<FxRateEntry>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<FxRateEntryTable>? where,
     int? limit,
     int? offset,
@@ -300,6 +300,8 @@ class FxRateEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FxRateEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<FxRateEntry>(
       where: where?.call(FxRateEntry.t),
@@ -309,6 +311,8 @@ class FxRateEntryRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -330,13 +334,15 @@ class FxRateEntryRepository {
   /// );
   /// ```
   Future<FxRateEntry?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<FxRateEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<FxRateEntryTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<FxRateEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<FxRateEntry>(
       where: where?.call(FxRateEntry.t),
@@ -345,18 +351,24 @@ class FxRateEntryRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [FxRateEntry] by its [id] or null if no such row exists.
   Future<FxRateEntry?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<FxRateEntry>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -366,14 +378,20 @@ class FxRateEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<FxRateEntry>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<FxRateEntry> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<FxRateEntry>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -381,7 +399,7 @@ class FxRateEntryRepository {
   ///
   /// The returned [FxRateEntry] will have its `id` field set.
   Future<FxRateEntry> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     FxRateEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -397,7 +415,7 @@ class FxRateEntryRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<FxRateEntry>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<FxRateEntry> rows, {
     _i1.ColumnSelections<FxRateEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -413,7 +431,7 @@ class FxRateEntryRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<FxRateEntry> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     FxRateEntry row, {
     _i1.ColumnSelections<FxRateEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -428,7 +446,7 @@ class FxRateEntryRepository {
   /// Updates a single [FxRateEntry] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<FxRateEntry?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<FxRateEntryUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -443,7 +461,7 @@ class FxRateEntryRepository {
   /// Updates all [FxRateEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<FxRateEntry>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<FxRateEntryUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<FxRateEntryTable> where,
     int? limit,
@@ -469,7 +487,7 @@ class FxRateEntryRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<FxRateEntry>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<FxRateEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -481,7 +499,7 @@ class FxRateEntryRepository {
 
   /// Deletes a single [FxRateEntry].
   Future<FxRateEntry> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     FxRateEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -493,7 +511,7 @@ class FxRateEntryRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<FxRateEntry>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FxRateEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -506,7 +524,7 @@ class FxRateEntryRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<FxRateEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -514,6 +532,22 @@ class FxRateEntryRepository {
     return session.db.count<FxRateEntry>(
       where: where?.call(FxRateEntry.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [FxRateEntry] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<FxRateEntryTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<FxRateEntry>(
+      where: where(FxRateEntry.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/fx_rates/fx_rate_snapshot.dart
+++ b/openbudget_server/lib/src/generated/fx_rates/fx_rate_snapshot.dart
@@ -44,7 +44,9 @@ abstract class FxRateSnapshot
       fetchedAt: _i1.DateTimeJsonExtension.fromJson(
         jsonSerialization['fetchedAt'],
       ),
-      isLatest: jsonSerialization['isLatest'] as bool?,
+      isLatest: jsonSerialization['isLatest'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isLatest']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
@@ -319,7 +321,7 @@ class FxRateSnapshotRepository {
   /// );
   /// ```
   Future<List<FxRateSnapshot>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<FxRateSnapshotTable>? where,
     int? limit,
     int? offset,
@@ -327,6 +329,8 @@ class FxRateSnapshotRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FxRateSnapshotTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<FxRateSnapshot>(
       where: where?.call(FxRateSnapshot.t),
@@ -336,6 +340,8 @@ class FxRateSnapshotRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -357,13 +363,15 @@ class FxRateSnapshotRepository {
   /// );
   /// ```
   Future<FxRateSnapshot?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<FxRateSnapshotTable>? where,
     int? offset,
     _i1.OrderByBuilder<FxRateSnapshotTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<FxRateSnapshotTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<FxRateSnapshot>(
       where: where?.call(FxRateSnapshot.t),
@@ -372,18 +380,24 @@ class FxRateSnapshotRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [FxRateSnapshot] by its [id] or null if no such row exists.
   Future<FxRateSnapshot?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<FxRateSnapshot>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -393,14 +407,20 @@ class FxRateSnapshotRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<FxRateSnapshot>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<FxRateSnapshot> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<FxRateSnapshot>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -408,7 +428,7 @@ class FxRateSnapshotRepository {
   ///
   /// The returned [FxRateSnapshot] will have its `id` field set.
   Future<FxRateSnapshot> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     FxRateSnapshot row, {
     _i1.Transaction? transaction,
   }) async {
@@ -424,7 +444,7 @@ class FxRateSnapshotRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<FxRateSnapshot>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<FxRateSnapshot> rows, {
     _i1.ColumnSelections<FxRateSnapshotTable>? columns,
     _i1.Transaction? transaction,
@@ -440,7 +460,7 @@ class FxRateSnapshotRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<FxRateSnapshot> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     FxRateSnapshot row, {
     _i1.ColumnSelections<FxRateSnapshotTable>? columns,
     _i1.Transaction? transaction,
@@ -455,7 +475,7 @@ class FxRateSnapshotRepository {
   /// Updates a single [FxRateSnapshot] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<FxRateSnapshot?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<FxRateSnapshotUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -470,7 +490,7 @@ class FxRateSnapshotRepository {
   /// Updates all [FxRateSnapshot]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<FxRateSnapshot>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<FxRateSnapshotUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<FxRateSnapshotTable> where,
     int? limit,
@@ -496,7 +516,7 @@ class FxRateSnapshotRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<FxRateSnapshot>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<FxRateSnapshot> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -508,7 +528,7 @@ class FxRateSnapshotRepository {
 
   /// Deletes a single [FxRateSnapshot].
   Future<FxRateSnapshot> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     FxRateSnapshot row, {
     _i1.Transaction? transaction,
   }) async {
@@ -520,7 +540,7 @@ class FxRateSnapshotRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<FxRateSnapshot>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FxRateSnapshotTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -533,7 +553,7 @@ class FxRateSnapshotRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<FxRateSnapshotTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -541,6 +561,22 @@ class FxRateSnapshotRepository {
     return session.db.count<FxRateSnapshot>(
       where: where?.call(FxRateSnapshot.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [FxRateSnapshot] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<FxRateSnapshotTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<FxRateSnapshot>(
+      where: where(FxRateSnapshot.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/institutions/institution.dart
+++ b/openbudget_server/lib/src/generated/institutions/institution.dart
@@ -45,7 +45,9 @@ abstract class Institution
       name: jsonSerialization['name'] as String,
       website: jsonSerialization['website'] as String?,
       plaidInstitutionId: jsonSerialization['plaidInstitutionId'] as String?,
-      isDigitalBank: jsonSerialization['isDigitalBank'] as bool?,
+      isDigitalBank: jsonSerialization['isDigitalBank'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isDigitalBank']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
@@ -351,7 +353,7 @@ class InstitutionRepository {
   /// );
   /// ```
   Future<List<Institution>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<InstitutionTable>? where,
     int? limit,
     int? offset,
@@ -359,6 +361,8 @@ class InstitutionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<InstitutionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<Institution>(
       where: where?.call(Institution.t),
@@ -368,6 +372,8 @@ class InstitutionRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -389,13 +395,15 @@ class InstitutionRepository {
   /// );
   /// ```
   Future<Institution?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<InstitutionTable>? where,
     int? offset,
     _i1.OrderByBuilder<InstitutionTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<InstitutionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<Institution>(
       where: where?.call(Institution.t),
@@ -404,18 +412,24 @@ class InstitutionRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [Institution] by its [id] or null if no such row exists.
   Future<Institution?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<Institution>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -425,14 +439,20 @@ class InstitutionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<Institution>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Institution> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<Institution>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -440,7 +460,7 @@ class InstitutionRepository {
   ///
   /// The returned [Institution] will have its `id` field set.
   Future<Institution> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Institution row, {
     _i1.Transaction? transaction,
   }) async {
@@ -456,7 +476,7 @@ class InstitutionRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<Institution>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Institution> rows, {
     _i1.ColumnSelections<InstitutionTable>? columns,
     _i1.Transaction? transaction,
@@ -472,7 +492,7 @@ class InstitutionRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<Institution> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Institution row, {
     _i1.ColumnSelections<InstitutionTable>? columns,
     _i1.Transaction? transaction,
@@ -487,7 +507,7 @@ class InstitutionRepository {
   /// Updates a single [Institution] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<Institution?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<InstitutionUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -502,7 +522,7 @@ class InstitutionRepository {
   /// Updates all [Institution]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<Institution>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<InstitutionUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<InstitutionTable> where,
     int? limit,
@@ -528,7 +548,7 @@ class InstitutionRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<Institution>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Institution> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -540,7 +560,7 @@ class InstitutionRepository {
 
   /// Deletes a single [Institution].
   Future<Institution> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Institution row, {
     _i1.Transaction? transaction,
   }) async {
@@ -552,7 +572,7 @@ class InstitutionRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<Institution>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<InstitutionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -565,7 +585,7 @@ class InstitutionRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<InstitutionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -573,6 +593,22 @@ class InstitutionRepository {
     return session.db.count<Institution>(
       where: where?.call(Institution.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Institution] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<InstitutionTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Institution>(
+      where: where(Institution.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/institutions/institution_location.dart
+++ b/openbudget_server/lib/src/generated/institutions/institution_location.dart
@@ -43,7 +43,9 @@ abstract class InstitutionLocation
         jsonSerialization['institutionId'],
       ),
       locationCode: jsonSerialization['locationCode'] as String,
-      isPopular: jsonSerialization['isPopular'] as bool?,
+      isPopular: jsonSerialization['isPopular'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isPopular']),
       popularityRank: jsonSerialization['popularityRank'] as int?,
       createdAt: jsonSerialization['createdAt'] == null
           ? null
@@ -328,7 +330,7 @@ class InstitutionLocationRepository {
   /// );
   /// ```
   Future<List<InstitutionLocation>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<InstitutionLocationTable>? where,
     int? limit,
     int? offset,
@@ -336,6 +338,8 @@ class InstitutionLocationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<InstitutionLocationTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<InstitutionLocation>(
       where: where?.call(InstitutionLocation.t),
@@ -345,6 +349,8 @@ class InstitutionLocationRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -366,13 +372,15 @@ class InstitutionLocationRepository {
   /// );
   /// ```
   Future<InstitutionLocation?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<InstitutionLocationTable>? where,
     int? offset,
     _i1.OrderByBuilder<InstitutionLocationTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<InstitutionLocationTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<InstitutionLocation>(
       where: where?.call(InstitutionLocation.t),
@@ -381,18 +389,24 @@ class InstitutionLocationRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [InstitutionLocation] by its [id] or null if no such row exists.
   Future<InstitutionLocation?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<InstitutionLocation>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -402,14 +416,20 @@ class InstitutionLocationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<InstitutionLocation>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<InstitutionLocation> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<InstitutionLocation>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -417,7 +437,7 @@ class InstitutionLocationRepository {
   ///
   /// The returned [InstitutionLocation] will have its `id` field set.
   Future<InstitutionLocation> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     InstitutionLocation row, {
     _i1.Transaction? transaction,
   }) async {
@@ -433,7 +453,7 @@ class InstitutionLocationRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<InstitutionLocation>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<InstitutionLocation> rows, {
     _i1.ColumnSelections<InstitutionLocationTable>? columns,
     _i1.Transaction? transaction,
@@ -449,7 +469,7 @@ class InstitutionLocationRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<InstitutionLocation> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     InstitutionLocation row, {
     _i1.ColumnSelections<InstitutionLocationTable>? columns,
     _i1.Transaction? transaction,
@@ -464,7 +484,7 @@ class InstitutionLocationRepository {
   /// Updates a single [InstitutionLocation] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<InstitutionLocation?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<InstitutionLocationUpdateTable>
     columnValues,
@@ -480,7 +500,7 @@ class InstitutionLocationRepository {
   /// Updates all [InstitutionLocation]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<InstitutionLocation>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<InstitutionLocationUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<InstitutionLocationTable> where,
@@ -507,7 +527,7 @@ class InstitutionLocationRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<InstitutionLocation>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<InstitutionLocation> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -519,7 +539,7 @@ class InstitutionLocationRepository {
 
   /// Deletes a single [InstitutionLocation].
   Future<InstitutionLocation> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     InstitutionLocation row, {
     _i1.Transaction? transaction,
   }) async {
@@ -531,7 +551,7 @@ class InstitutionLocationRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<InstitutionLocation>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<InstitutionLocationTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -544,7 +564,7 @@ class InstitutionLocationRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<InstitutionLocationTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -552,6 +572,22 @@ class InstitutionLocationRepository {
     return session.db.count<InstitutionLocation>(
       where: where?.call(InstitutionLocation.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [InstitutionLocation] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<InstitutionLocationTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<InstitutionLocation>(
+      where: where(InstitutionLocation.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/monthly_allocations/monthly_allocation.dart
+++ b/openbudget_server/lib/src/generated/monthly_allocations/monthly_allocation.dart
@@ -406,7 +406,7 @@ class MonthlyAllocationRepository {
   /// );
   /// ```
   Future<List<MonthlyAllocation>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<MonthlyAllocationTable>? where,
     int? limit,
     int? offset,
@@ -414,6 +414,8 @@ class MonthlyAllocationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MonthlyAllocationTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<MonthlyAllocation>(
       where: where?.call(MonthlyAllocation.t),
@@ -423,6 +425,8 @@ class MonthlyAllocationRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -444,13 +448,15 @@ class MonthlyAllocationRepository {
   /// );
   /// ```
   Future<MonthlyAllocation?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<MonthlyAllocationTable>? where,
     int? offset,
     _i1.OrderByBuilder<MonthlyAllocationTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<MonthlyAllocationTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<MonthlyAllocation>(
       where: where?.call(MonthlyAllocation.t),
@@ -459,18 +465,24 @@ class MonthlyAllocationRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [MonthlyAllocation] by its [id] or null if no such row exists.
   Future<MonthlyAllocation?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<MonthlyAllocation>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -480,14 +492,20 @@ class MonthlyAllocationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<MonthlyAllocation>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<MonthlyAllocation> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<MonthlyAllocation>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -495,7 +513,7 @@ class MonthlyAllocationRepository {
   ///
   /// The returned [MonthlyAllocation] will have its `id` field set.
   Future<MonthlyAllocation> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     MonthlyAllocation row, {
     _i1.Transaction? transaction,
   }) async {
@@ -511,7 +529,7 @@ class MonthlyAllocationRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<MonthlyAllocation>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<MonthlyAllocation> rows, {
     _i1.ColumnSelections<MonthlyAllocationTable>? columns,
     _i1.Transaction? transaction,
@@ -527,7 +545,7 @@ class MonthlyAllocationRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<MonthlyAllocation> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     MonthlyAllocation row, {
     _i1.ColumnSelections<MonthlyAllocationTable>? columns,
     _i1.Transaction? transaction,
@@ -542,7 +560,7 @@ class MonthlyAllocationRepository {
   /// Updates a single [MonthlyAllocation] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<MonthlyAllocation?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<MonthlyAllocationUpdateTable>
     columnValues,
@@ -558,7 +576,7 @@ class MonthlyAllocationRepository {
   /// Updates all [MonthlyAllocation]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<MonthlyAllocation>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MonthlyAllocationUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<MonthlyAllocationTable> where,
@@ -585,7 +603,7 @@ class MonthlyAllocationRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<MonthlyAllocation>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<MonthlyAllocation> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -597,7 +615,7 @@ class MonthlyAllocationRepository {
 
   /// Deletes a single [MonthlyAllocation].
   Future<MonthlyAllocation> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     MonthlyAllocation row, {
     _i1.Transaction? transaction,
   }) async {
@@ -609,7 +627,7 @@ class MonthlyAllocationRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<MonthlyAllocation>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MonthlyAllocationTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -622,7 +640,7 @@ class MonthlyAllocationRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<MonthlyAllocationTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -630,6 +648,22 @@ class MonthlyAllocationRepository {
     return session.db.count<MonthlyAllocation>(
       where: where?.call(MonthlyAllocation.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [MonthlyAllocation] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<MonthlyAllocationTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<MonthlyAllocation>(
+      where: where(MonthlyAllocation.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/payees/payee.dart
+++ b/openbudget_server/lib/src/generated/payees/payee.dart
@@ -267,7 +267,7 @@ class PayeeRepository {
   /// );
   /// ```
   Future<List<Payee>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<PayeeTable>? where,
     int? limit,
     int? offset,
@@ -275,6 +275,8 @@ class PayeeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PayeeTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<Payee>(
       where: where?.call(Payee.t),
@@ -284,6 +286,8 @@ class PayeeRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -305,13 +309,15 @@ class PayeeRepository {
   /// );
   /// ```
   Future<Payee?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<PayeeTable>? where,
     int? offset,
     _i1.OrderByBuilder<PayeeTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<PayeeTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<Payee>(
       where: where?.call(Payee.t),
@@ -320,18 +326,24 @@ class PayeeRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [Payee] by its [id] or null if no such row exists.
   Future<Payee?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<Payee>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -341,14 +353,20 @@ class PayeeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<Payee>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Payee> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<Payee>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -356,7 +374,7 @@ class PayeeRepository {
   ///
   /// The returned [Payee] will have its `id` field set.
   Future<Payee> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Payee row, {
     _i1.Transaction? transaction,
   }) async {
@@ -372,7 +390,7 @@ class PayeeRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<Payee>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Payee> rows, {
     _i1.ColumnSelections<PayeeTable>? columns,
     _i1.Transaction? transaction,
@@ -388,7 +406,7 @@ class PayeeRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<Payee> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Payee row, {
     _i1.ColumnSelections<PayeeTable>? columns,
     _i1.Transaction? transaction,
@@ -403,7 +421,7 @@ class PayeeRepository {
   /// Updates a single [Payee] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<Payee?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<PayeeUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -418,7 +436,7 @@ class PayeeRepository {
   /// Updates all [Payee]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<Payee>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PayeeUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<PayeeTable> where,
     int? limit,
@@ -444,7 +462,7 @@ class PayeeRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<Payee>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Payee> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -456,7 +474,7 @@ class PayeeRepository {
 
   /// Deletes a single [Payee].
   Future<Payee> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Payee row, {
     _i1.Transaction? transaction,
   }) async {
@@ -468,7 +486,7 @@ class PayeeRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<Payee>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PayeeTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -481,7 +499,7 @@ class PayeeRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<PayeeTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -489,6 +507,22 @@ class PayeeRepository {
     return session.db.count<Payee>(
       where: where?.call(Payee.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Payee] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<PayeeTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Payee>(
+      where: where(Payee.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/plaid/plaid_connection.dart
+++ b/openbudget_server/lib/src/generated/plaid/plaid_connection.dart
@@ -406,7 +406,7 @@ class PlaidConnectionRepository {
   /// );
   /// ```
   Future<List<PlaidConnection>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<PlaidConnectionTable>? where,
     int? limit,
     int? offset,
@@ -414,6 +414,8 @@ class PlaidConnectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlaidConnectionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<PlaidConnection>(
       where: where?.call(PlaidConnection.t),
@@ -423,6 +425,8 @@ class PlaidConnectionRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -444,13 +448,15 @@ class PlaidConnectionRepository {
   /// );
   /// ```
   Future<PlaidConnection?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<PlaidConnectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<PlaidConnectionTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlaidConnectionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<PlaidConnection>(
       where: where?.call(PlaidConnection.t),
@@ -459,18 +465,24 @@ class PlaidConnectionRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [PlaidConnection] by its [id] or null if no such row exists.
   Future<PlaidConnection?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<PlaidConnection>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -480,14 +492,20 @@ class PlaidConnectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<PlaidConnection>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<PlaidConnection> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<PlaidConnection>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -495,7 +513,7 @@ class PlaidConnectionRepository {
   ///
   /// The returned [PlaidConnection] will have its `id` field set.
   Future<PlaidConnection> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     PlaidConnection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -511,7 +529,7 @@ class PlaidConnectionRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<PlaidConnection>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<PlaidConnection> rows, {
     _i1.ColumnSelections<PlaidConnectionTable>? columns,
     _i1.Transaction? transaction,
@@ -527,7 +545,7 @@ class PlaidConnectionRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<PlaidConnection> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     PlaidConnection row, {
     _i1.ColumnSelections<PlaidConnectionTable>? columns,
     _i1.Transaction? transaction,
@@ -542,7 +560,7 @@ class PlaidConnectionRepository {
   /// Updates a single [PlaidConnection] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<PlaidConnection?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<PlaidConnectionUpdateTable>
     columnValues,
@@ -558,7 +576,7 @@ class PlaidConnectionRepository {
   /// Updates all [PlaidConnection]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<PlaidConnection>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PlaidConnectionUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<PlaidConnectionTable> where,
@@ -585,7 +603,7 @@ class PlaidConnectionRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<PlaidConnection>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<PlaidConnection> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -597,7 +615,7 @@ class PlaidConnectionRepository {
 
   /// Deletes a single [PlaidConnection].
   Future<PlaidConnection> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     PlaidConnection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -609,7 +627,7 @@ class PlaidConnectionRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<PlaidConnection>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlaidConnectionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -622,7 +640,7 @@ class PlaidConnectionRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<PlaidConnectionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -630,6 +648,22 @@ class PlaidConnectionRepository {
     return session.db.count<PlaidConnection>(
       where: where?.call(PlaidConnection.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [PlaidConnection] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<PlaidConnectionTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<PlaidConnection>(
+      where: where(PlaidConnection.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/recurring_transactions/recurring_transaction.dart
+++ b/openbudget_server/lib/src/generated/recurring_transactions/recurring_transaction.dart
@@ -81,7 +81,7 @@ abstract class RecurringTransaction
       endDate: jsonSerialization['endDate'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['endDate']),
-      isActive: jsonSerialization['isActive'] as bool,
+      isActive: _i1.BoolJsonExtension.fromJson(jsonSerialization['isActive']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
@@ -547,7 +547,7 @@ class RecurringTransactionRepository {
   /// );
   /// ```
   Future<List<RecurringTransaction>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<RecurringTransactionTable>? where,
     int? limit,
     int? offset,
@@ -555,6 +555,8 @@ class RecurringTransactionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RecurringTransactionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<RecurringTransaction>(
       where: where?.call(RecurringTransaction.t),
@@ -564,6 +566,8 @@ class RecurringTransactionRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -585,13 +589,15 @@ class RecurringTransactionRepository {
   /// );
   /// ```
   Future<RecurringTransaction?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<RecurringTransactionTable>? where,
     int? offset,
     _i1.OrderByBuilder<RecurringTransactionTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<RecurringTransactionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<RecurringTransaction>(
       where: where?.call(RecurringTransaction.t),
@@ -600,18 +606,24 @@ class RecurringTransactionRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [RecurringTransaction] by its [id] or null if no such row exists.
   Future<RecurringTransaction?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<RecurringTransaction>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -621,14 +633,20 @@ class RecurringTransactionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<RecurringTransaction>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<RecurringTransaction> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<RecurringTransaction>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -636,7 +654,7 @@ class RecurringTransactionRepository {
   ///
   /// The returned [RecurringTransaction] will have its `id` field set.
   Future<RecurringTransaction> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     RecurringTransaction row, {
     _i1.Transaction? transaction,
   }) async {
@@ -652,7 +670,7 @@ class RecurringTransactionRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<RecurringTransaction>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<RecurringTransaction> rows, {
     _i1.ColumnSelections<RecurringTransactionTable>? columns,
     _i1.Transaction? transaction,
@@ -668,7 +686,7 @@ class RecurringTransactionRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<RecurringTransaction> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     RecurringTransaction row, {
     _i1.ColumnSelections<RecurringTransactionTable>? columns,
     _i1.Transaction? transaction,
@@ -683,7 +701,7 @@ class RecurringTransactionRepository {
   /// Updates a single [RecurringTransaction] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<RecurringTransaction?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<RecurringTransactionUpdateTable>
     columnValues,
@@ -699,7 +717,7 @@ class RecurringTransactionRepository {
   /// Updates all [RecurringTransaction]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<RecurringTransaction>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RecurringTransactionUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<RecurringTransactionTable> where,
@@ -726,7 +744,7 @@ class RecurringTransactionRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<RecurringTransaction>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<RecurringTransaction> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -738,7 +756,7 @@ class RecurringTransactionRepository {
 
   /// Deletes a single [RecurringTransaction].
   Future<RecurringTransaction> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     RecurringTransaction row, {
     _i1.Transaction? transaction,
   }) async {
@@ -750,7 +768,7 @@ class RecurringTransactionRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<RecurringTransaction>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RecurringTransactionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -763,7 +781,7 @@ class RecurringTransactionRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<RecurringTransactionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -771,6 +789,22 @@ class RecurringTransactionRepository {
     return session.db.count<RecurringTransaction>(
       where: where?.call(RecurringTransaction.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [RecurringTransaction] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<RecurringTransactionTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<RecurringTransaction>(
+      where: where(RecurringTransaction.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/solana_wallets/solana_wallet.dart
+++ b/openbudget_server/lib/src/generated/solana_wallets/solana_wallet.dart
@@ -495,7 +495,7 @@ class SolanaWalletRepository {
   /// );
   /// ```
   Future<List<SolanaWallet>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletTable>? where,
     int? limit,
     int? offset,
@@ -503,6 +503,8 @@ class SolanaWalletRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SolanaWalletTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<SolanaWallet>(
       where: where?.call(SolanaWallet.t),
@@ -512,6 +514,8 @@ class SolanaWalletRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -533,13 +537,15 @@ class SolanaWalletRepository {
   /// );
   /// ```
   Future<SolanaWallet?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletTable>? where,
     int? offset,
     _i1.OrderByBuilder<SolanaWalletTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<SolanaWalletTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<SolanaWallet>(
       where: where?.call(SolanaWallet.t),
@@ -548,18 +554,24 @@ class SolanaWalletRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [SolanaWallet] by its [id] or null if no such row exists.
   Future<SolanaWallet?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<SolanaWallet>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -569,14 +581,20 @@ class SolanaWalletRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<SolanaWallet>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWallet> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<SolanaWallet>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -584,7 +602,7 @@ class SolanaWalletRepository {
   ///
   /// The returned [SolanaWallet] will have its `id` field set.
   Future<SolanaWallet> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWallet row, {
     _i1.Transaction? transaction,
   }) async {
@@ -600,7 +618,7 @@ class SolanaWalletRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<SolanaWallet>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWallet> rows, {
     _i1.ColumnSelections<SolanaWalletTable>? columns,
     _i1.Transaction? transaction,
@@ -616,7 +634,7 @@ class SolanaWalletRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<SolanaWallet> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWallet row, {
     _i1.ColumnSelections<SolanaWalletTable>? columns,
     _i1.Transaction? transaction,
@@ -631,7 +649,7 @@ class SolanaWalletRepository {
   /// Updates a single [SolanaWallet] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<SolanaWallet?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<SolanaWalletUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -646,7 +664,7 @@ class SolanaWalletRepository {
   /// Updates all [SolanaWallet]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<SolanaWallet>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SolanaWalletUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<SolanaWalletTable> where,
     int? limit,
@@ -672,7 +690,7 @@ class SolanaWalletRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<SolanaWallet>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWallet> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -684,7 +702,7 @@ class SolanaWalletRepository {
 
   /// Deletes a single [SolanaWallet].
   Future<SolanaWallet> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWallet row, {
     _i1.Transaction? transaction,
   }) async {
@@ -696,7 +714,7 @@ class SolanaWalletRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<SolanaWallet>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SolanaWalletTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -709,7 +727,7 @@ class SolanaWalletRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -717,6 +735,22 @@ class SolanaWalletRepository {
     return session.db.count<SolanaWallet>(
       where: where?.call(SolanaWallet.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [SolanaWallet] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<SolanaWalletTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<SolanaWallet>(
+      where: where(SolanaWallet.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/solana_wallets/solana_wallet_holding.dart
+++ b/openbudget_server/lib/src/generated/solana_wallets/solana_wallet_holding.dart
@@ -93,7 +93,7 @@ abstract class SolanaWalletHolding
       decimals: jsonSerialization['decimals'] as int,
       balanceRaw: jsonSerialization['balanceRaw'] as String,
       balanceUi: jsonSerialization['balanceUi'] as String,
-      isNft: jsonSerialization['isNft'] as bool,
+      isNft: _i1.BoolJsonExtension.fromJson(jsonSerialization['isNft']),
       priceCurrency: jsonSerialization['priceCurrency'] as String?,
       pricePerToken: (jsonSerialization['pricePerToken'] as num?)?.toDouble(),
       totalValue: (jsonSerialization['totalValue'] as num?)?.toDouble(),
@@ -113,7 +113,9 @@ abstract class SolanaWalletHolding
       priceSource: jsonSerialization['priceSource'] as String?,
       priceQuality: jsonSerialization['priceQuality'] as String?,
       priceConfidence: jsonSerialization['priceConfidence'] as String?,
-      isPriceStale: jsonSerialization['isPriceStale'] as bool?,
+      isPriceStale: jsonSerialization['isPriceStale'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['isPriceStale']),
       priceAsOf: jsonSerialization['priceAsOf'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['priceAsOf']),
@@ -896,7 +898,7 @@ class SolanaWalletHoldingRepository {
   /// );
   /// ```
   Future<List<SolanaWalletHolding>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletHoldingTable>? where,
     int? limit,
     int? offset,
@@ -904,6 +906,8 @@ class SolanaWalletHoldingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SolanaWalletHoldingTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<SolanaWalletHolding>(
       where: where?.call(SolanaWalletHolding.t),
@@ -913,6 +917,8 @@ class SolanaWalletHoldingRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -934,13 +940,15 @@ class SolanaWalletHoldingRepository {
   /// );
   /// ```
   Future<SolanaWalletHolding?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletHoldingTable>? where,
     int? offset,
     _i1.OrderByBuilder<SolanaWalletHoldingTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<SolanaWalletHoldingTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<SolanaWalletHolding>(
       where: where?.call(SolanaWalletHolding.t),
@@ -949,18 +957,24 @@ class SolanaWalletHoldingRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [SolanaWalletHolding] by its [id] or null if no such row exists.
   Future<SolanaWalletHolding?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<SolanaWalletHolding>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -970,14 +984,20 @@ class SolanaWalletHoldingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<SolanaWalletHolding>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWalletHolding> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<SolanaWalletHolding>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -985,7 +1005,7 @@ class SolanaWalletHoldingRepository {
   ///
   /// The returned [SolanaWalletHolding] will have its `id` field set.
   Future<SolanaWalletHolding> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWalletHolding row, {
     _i1.Transaction? transaction,
   }) async {
@@ -1001,7 +1021,7 @@ class SolanaWalletHoldingRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<SolanaWalletHolding>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWalletHolding> rows, {
     _i1.ColumnSelections<SolanaWalletHoldingTable>? columns,
     _i1.Transaction? transaction,
@@ -1017,7 +1037,7 @@ class SolanaWalletHoldingRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<SolanaWalletHolding> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWalletHolding row, {
     _i1.ColumnSelections<SolanaWalletHoldingTable>? columns,
     _i1.Transaction? transaction,
@@ -1032,7 +1052,7 @@ class SolanaWalletHoldingRepository {
   /// Updates a single [SolanaWalletHolding] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<SolanaWalletHolding?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<SolanaWalletHoldingUpdateTable>
     columnValues,
@@ -1048,7 +1068,7 @@ class SolanaWalletHoldingRepository {
   /// Updates all [SolanaWalletHolding]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<SolanaWalletHolding>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SolanaWalletHoldingUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<SolanaWalletHoldingTable> where,
@@ -1075,7 +1095,7 @@ class SolanaWalletHoldingRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<SolanaWalletHolding>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWalletHolding> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -1087,7 +1107,7 @@ class SolanaWalletHoldingRepository {
 
   /// Deletes a single [SolanaWalletHolding].
   Future<SolanaWalletHolding> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWalletHolding row, {
     _i1.Transaction? transaction,
   }) async {
@@ -1099,7 +1119,7 @@ class SolanaWalletHoldingRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<SolanaWalletHolding>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SolanaWalletHoldingTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -1112,7 +1132,7 @@ class SolanaWalletHoldingRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletHoldingTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -1120,6 +1140,22 @@ class SolanaWalletHoldingRepository {
     return session.db.count<SolanaWalletHolding>(
       where: where?.call(SolanaWalletHolding.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [SolanaWalletHolding] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<SolanaWalletHoldingTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<SolanaWalletHolding>(
+      where: where(SolanaWalletHolding.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/solana_wallets/solana_wallet_transaction.dart
+++ b/openbudget_server/lib/src/generated/solana_wallets/solana_wallet_transaction.dart
@@ -829,7 +829,7 @@ class SolanaWalletTransactionRepository {
   /// );
   /// ```
   Future<List<SolanaWalletTransaction>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletTransactionTable>? where,
     int? limit,
     int? offset,
@@ -837,6 +837,8 @@ class SolanaWalletTransactionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SolanaWalletTransactionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<SolanaWalletTransaction>(
       where: where?.call(SolanaWalletTransaction.t),
@@ -846,6 +848,8 @@ class SolanaWalletTransactionRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -867,13 +871,15 @@ class SolanaWalletTransactionRepository {
   /// );
   /// ```
   Future<SolanaWalletTransaction?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletTransactionTable>? where,
     int? offset,
     _i1.OrderByBuilder<SolanaWalletTransactionTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<SolanaWalletTransactionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<SolanaWalletTransaction>(
       where: where?.call(SolanaWalletTransaction.t),
@@ -882,18 +888,24 @@ class SolanaWalletTransactionRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [SolanaWalletTransaction] by its [id] or null if no such row exists.
   Future<SolanaWalletTransaction?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<SolanaWalletTransaction>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -903,14 +915,20 @@ class SolanaWalletTransactionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<SolanaWalletTransaction>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWalletTransaction> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<SolanaWalletTransaction>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -918,7 +936,7 @@ class SolanaWalletTransactionRepository {
   ///
   /// The returned [SolanaWalletTransaction] will have its `id` field set.
   Future<SolanaWalletTransaction> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWalletTransaction row, {
     _i1.Transaction? transaction,
   }) async {
@@ -934,7 +952,7 @@ class SolanaWalletTransactionRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<SolanaWalletTransaction>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWalletTransaction> rows, {
     _i1.ColumnSelections<SolanaWalletTransactionTable>? columns,
     _i1.Transaction? transaction,
@@ -950,7 +968,7 @@ class SolanaWalletTransactionRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<SolanaWalletTransaction> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWalletTransaction row, {
     _i1.ColumnSelections<SolanaWalletTransactionTable>? columns,
     _i1.Transaction? transaction,
@@ -965,7 +983,7 @@ class SolanaWalletTransactionRepository {
   /// Updates a single [SolanaWalletTransaction] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<SolanaWalletTransaction?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<SolanaWalletTransactionUpdateTable>
     columnValues,
@@ -981,7 +999,7 @@ class SolanaWalletTransactionRepository {
   /// Updates all [SolanaWalletTransaction]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<SolanaWalletTransaction>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SolanaWalletTransactionUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<SolanaWalletTransactionTable> where,
@@ -1008,7 +1026,7 @@ class SolanaWalletTransactionRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<SolanaWalletTransaction>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<SolanaWalletTransaction> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -1020,7 +1038,7 @@ class SolanaWalletTransactionRepository {
 
   /// Deletes a single [SolanaWalletTransaction].
   Future<SolanaWalletTransaction> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     SolanaWalletTransaction row, {
     _i1.Transaction? transaction,
   }) async {
@@ -1032,7 +1050,7 @@ class SolanaWalletTransactionRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<SolanaWalletTransaction>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SolanaWalletTransactionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -1045,7 +1063,7 @@ class SolanaWalletTransactionRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<SolanaWalletTransactionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -1053,6 +1071,22 @@ class SolanaWalletTransactionRepository {
     return session.db.count<SolanaWalletTransaction>(
       where: where?.call(SolanaWalletTransaction.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [SolanaWalletTransaction] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<SolanaWalletTransactionTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<SolanaWalletTransaction>(
+      where: where(SolanaWalletTransaction.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/transaction_rules/transaction_rule.dart
+++ b/openbudget_server/lib/src/generated/transaction_rules/transaction_rule.dart
@@ -48,7 +48,9 @@ abstract class TransactionRule
       targetEnvelopeId: _i1.UuidValueJsonExtension.fromJson(
         jsonSerialization['targetEnvelopeId'],
       ),
-      enabled: jsonSerialization['enabled'] as bool?,
+      enabled: jsonSerialization['enabled'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['enabled']),
       createdAt: jsonSerialization['createdAt'] == null
           ? null
           : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
@@ -331,7 +333,7 @@ class TransactionRuleRepository {
   /// );
   /// ```
   Future<List<TransactionRule>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<TransactionRuleTable>? where,
     int? limit,
     int? offset,
@@ -339,6 +341,8 @@ class TransactionRuleRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TransactionRuleTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<TransactionRule>(
       where: where?.call(TransactionRule.t),
@@ -348,6 +352,8 @@ class TransactionRuleRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -369,13 +375,15 @@ class TransactionRuleRepository {
   /// );
   /// ```
   Future<TransactionRule?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<TransactionRuleTable>? where,
     int? offset,
     _i1.OrderByBuilder<TransactionRuleTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<TransactionRuleTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<TransactionRule>(
       where: where?.call(TransactionRule.t),
@@ -384,18 +392,24 @@ class TransactionRuleRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [TransactionRule] by its [id] or null if no such row exists.
   Future<TransactionRule?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<TransactionRule>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -405,14 +419,20 @@ class TransactionRuleRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<TransactionRule>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<TransactionRule> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<TransactionRule>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -420,7 +440,7 @@ class TransactionRuleRepository {
   ///
   /// The returned [TransactionRule] will have its `id` field set.
   Future<TransactionRule> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     TransactionRule row, {
     _i1.Transaction? transaction,
   }) async {
@@ -436,7 +456,7 @@ class TransactionRuleRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<TransactionRule>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<TransactionRule> rows, {
     _i1.ColumnSelections<TransactionRuleTable>? columns,
     _i1.Transaction? transaction,
@@ -452,7 +472,7 @@ class TransactionRuleRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<TransactionRule> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     TransactionRule row, {
     _i1.ColumnSelections<TransactionRuleTable>? columns,
     _i1.Transaction? transaction,
@@ -467,7 +487,7 @@ class TransactionRuleRepository {
   /// Updates a single [TransactionRule] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<TransactionRule?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<TransactionRuleUpdateTable>
     columnValues,
@@ -483,7 +503,7 @@ class TransactionRuleRepository {
   /// Updates all [TransactionRule]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<TransactionRule>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TransactionRuleUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<TransactionRuleTable> where,
@@ -510,7 +530,7 @@ class TransactionRuleRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<TransactionRule>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<TransactionRule> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -522,7 +542,7 @@ class TransactionRuleRepository {
 
   /// Deletes a single [TransactionRule].
   Future<TransactionRule> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     TransactionRule row, {
     _i1.Transaction? transaction,
   }) async {
@@ -534,7 +554,7 @@ class TransactionRuleRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<TransactionRule>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TransactionRuleTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -547,7 +567,7 @@ class TransactionRuleRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<TransactionRuleTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -555,6 +575,22 @@ class TransactionRuleRepository {
     return session.db.count<TransactionRule>(
       where: where?.call(TransactionRule.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [TransactionRule] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<TransactionRuleTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<TransactionRule>(
+      where: where(TransactionRule.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/transactions/transaction.dart
+++ b/openbudget_server/lib/src/generated/transactions/transaction.dart
@@ -91,8 +91,12 @@ abstract class Transaction
               jsonSerialization['parentTransactionId'],
             ),
       memo: jsonSerialization['memo'] as String?,
-      cleared: jsonSerialization['cleared'] as bool?,
-      reconciled: jsonSerialization['reconciled'] as bool?,
+      cleared: jsonSerialization['cleared'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['cleared']),
+      reconciled: jsonSerialization['reconciled'] == null
+          ? null
+          : _i1.BoolJsonExtension.fromJson(jsonSerialization['reconciled']),
       flagColor: jsonSerialization['flagColor'] as String?,
       createdAt: jsonSerialization['createdAt'] == null
           ? null
@@ -613,7 +617,7 @@ class TransactionRepository {
   /// );
   /// ```
   Future<List<Transaction>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<TransactionTable>? where,
     int? limit,
     int? offset,
@@ -621,6 +625,8 @@ class TransactionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TransactionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<Transaction>(
       where: where?.call(Transaction.t),
@@ -630,6 +636,8 @@ class TransactionRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -651,13 +659,15 @@ class TransactionRepository {
   /// );
   /// ```
   Future<Transaction?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<TransactionTable>? where,
     int? offset,
     _i1.OrderByBuilder<TransactionTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<TransactionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<Transaction>(
       where: where?.call(Transaction.t),
@@ -666,18 +676,24 @@ class TransactionRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [Transaction] by its [id] or null if no such row exists.
   Future<Transaction?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<Transaction>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -687,14 +703,20 @@ class TransactionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<Transaction>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Transaction> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<Transaction>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -702,7 +724,7 @@ class TransactionRepository {
   ///
   /// The returned [Transaction] will have its `id` field set.
   Future<Transaction> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Transaction row, {
     _i1.Transaction? transaction,
   }) async {
@@ -718,7 +740,7 @@ class TransactionRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<Transaction>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Transaction> rows, {
     _i1.ColumnSelections<TransactionTable>? columns,
     _i1.Transaction? transaction,
@@ -734,7 +756,7 @@ class TransactionRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<Transaction> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Transaction row, {
     _i1.ColumnSelections<TransactionTable>? columns,
     _i1.Transaction? transaction,
@@ -749,7 +771,7 @@ class TransactionRepository {
   /// Updates a single [Transaction] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<Transaction?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<TransactionUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -764,7 +786,7 @@ class TransactionRepository {
   /// Updates all [Transaction]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<Transaction>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TransactionUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<TransactionTable> where,
     int? limit,
@@ -790,7 +812,7 @@ class TransactionRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<Transaction>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<Transaction> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -802,7 +824,7 @@ class TransactionRepository {
 
   /// Deletes a single [Transaction].
   Future<Transaction> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     Transaction row, {
     _i1.Transaction? transaction,
   }) async {
@@ -814,7 +836,7 @@ class TransactionRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<Transaction>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TransactionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -827,7 +849,7 @@ class TransactionRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<TransactionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -835,6 +857,22 @@ class TransactionRepository {
     return session.db.count<Transaction>(
       where: where?.call(Transaction.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Transaction] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<TransactionTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Transaction>(
+      where: where(Transaction.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/wallets/asset_quote_cache.dart
+++ b/openbudget_server/lib/src/generated/wallets/asset_quote_cache.dart
@@ -340,7 +340,7 @@ class AssetQuoteCacheRepository {
   /// );
   /// ```
   Future<List<AssetQuoteCache>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<AssetQuoteCacheTable>? where,
     int? limit,
     int? offset,
@@ -348,6 +348,8 @@ class AssetQuoteCacheRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AssetQuoteCacheTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<AssetQuoteCache>(
       where: where?.call(AssetQuoteCache.t),
@@ -357,6 +359,8 @@ class AssetQuoteCacheRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -378,13 +382,15 @@ class AssetQuoteCacheRepository {
   /// );
   /// ```
   Future<AssetQuoteCache?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<AssetQuoteCacheTable>? where,
     int? offset,
     _i1.OrderByBuilder<AssetQuoteCacheTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<AssetQuoteCacheTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<AssetQuoteCache>(
       where: where?.call(AssetQuoteCache.t),
@@ -393,18 +399,24 @@ class AssetQuoteCacheRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [AssetQuoteCache] by its [id] or null if no such row exists.
   Future<AssetQuoteCache?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<AssetQuoteCache>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -414,14 +426,20 @@ class AssetQuoteCacheRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<AssetQuoteCache>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<AssetQuoteCache> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<AssetQuoteCache>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -429,7 +447,7 @@ class AssetQuoteCacheRepository {
   ///
   /// The returned [AssetQuoteCache] will have its `id` field set.
   Future<AssetQuoteCache> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     AssetQuoteCache row, {
     _i1.Transaction? transaction,
   }) async {
@@ -445,7 +463,7 @@ class AssetQuoteCacheRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<AssetQuoteCache>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<AssetQuoteCache> rows, {
     _i1.ColumnSelections<AssetQuoteCacheTable>? columns,
     _i1.Transaction? transaction,
@@ -461,7 +479,7 @@ class AssetQuoteCacheRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<AssetQuoteCache> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     AssetQuoteCache row, {
     _i1.ColumnSelections<AssetQuoteCacheTable>? columns,
     _i1.Transaction? transaction,
@@ -476,7 +494,7 @@ class AssetQuoteCacheRepository {
   /// Updates a single [AssetQuoteCache] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<AssetQuoteCache?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<AssetQuoteCacheUpdateTable>
     columnValues,
@@ -492,7 +510,7 @@ class AssetQuoteCacheRepository {
   /// Updates all [AssetQuoteCache]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<AssetQuoteCache>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AssetQuoteCacheUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<AssetQuoteCacheTable> where,
@@ -519,7 +537,7 @@ class AssetQuoteCacheRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<AssetQuoteCache>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<AssetQuoteCache> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -531,7 +549,7 @@ class AssetQuoteCacheRepository {
 
   /// Deletes a single [AssetQuoteCache].
   Future<AssetQuoteCache> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     AssetQuoteCache row, {
     _i1.Transaction? transaction,
   }) async {
@@ -543,7 +561,7 @@ class AssetQuoteCacheRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<AssetQuoteCache>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AssetQuoteCacheTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -556,7 +574,7 @@ class AssetQuoteCacheRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<AssetQuoteCacheTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -564,6 +582,22 @@ class AssetQuoteCacheRepository {
     return session.db.count<AssetQuoteCache>(
       where: where?.call(AssetQuoteCache.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [AssetQuoteCache] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<AssetQuoteCacheTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<AssetQuoteCache>(
+      where: where(AssetQuoteCache.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/wallets/wallet_connection.dart
+++ b/openbudget_server/lib/src/generated/wallets/wallet_connection.dart
@@ -425,7 +425,7 @@ class WalletConnectionRepository {
   /// );
   /// ```
   Future<List<WalletConnection>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<WalletConnectionTable>? where,
     int? limit,
     int? offset,
@@ -433,6 +433,8 @@ class WalletConnectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<WalletConnectionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<WalletConnection>(
       where: where?.call(WalletConnection.t),
@@ -442,6 +444,8 @@ class WalletConnectionRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -463,13 +467,15 @@ class WalletConnectionRepository {
   /// );
   /// ```
   Future<WalletConnection?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<WalletConnectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<WalletConnectionTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<WalletConnectionTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<WalletConnection>(
       where: where?.call(WalletConnection.t),
@@ -478,18 +484,24 @@ class WalletConnectionRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [WalletConnection] by its [id] or null if no such row exists.
   Future<WalletConnection?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<WalletConnection>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -499,14 +511,20 @@ class WalletConnectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<WalletConnection>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<WalletConnection> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<WalletConnection>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -514,7 +532,7 @@ class WalletConnectionRepository {
   ///
   /// The returned [WalletConnection] will have its `id` field set.
   Future<WalletConnection> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     WalletConnection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -530,7 +548,7 @@ class WalletConnectionRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<WalletConnection>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<WalletConnection> rows, {
     _i1.ColumnSelections<WalletConnectionTable>? columns,
     _i1.Transaction? transaction,
@@ -546,7 +564,7 @@ class WalletConnectionRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<WalletConnection> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     WalletConnection row, {
     _i1.ColumnSelections<WalletConnectionTable>? columns,
     _i1.Transaction? transaction,
@@ -561,7 +579,7 @@ class WalletConnectionRepository {
   /// Updates a single [WalletConnection] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<WalletConnection?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<WalletConnectionUpdateTable>
     columnValues,
@@ -577,7 +595,7 @@ class WalletConnectionRepository {
   /// Updates all [WalletConnection]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<WalletConnection>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<WalletConnectionUpdateTable>
     columnValues,
     required _i1.WhereExpressionBuilder<WalletConnectionTable> where,
@@ -604,7 +622,7 @@ class WalletConnectionRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<WalletConnection>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<WalletConnection> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -616,7 +634,7 @@ class WalletConnectionRepository {
 
   /// Deletes a single [WalletConnection].
   Future<WalletConnection> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     WalletConnection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -628,7 +646,7 @@ class WalletConnectionRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<WalletConnection>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<WalletConnectionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -641,7 +659,7 @@ class WalletConnectionRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<WalletConnectionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -649,6 +667,22 @@ class WalletConnectionRepository {
     return session.db.count<WalletConnection>(
       where: where?.call(WalletConnection.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [WalletConnection] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<WalletConnectionTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<WalletConnection>(
+      where: where(WalletConnection.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/lib/src/generated/wallets/wallet_holding.dart
+++ b/openbudget_server/lib/src/generated/wallets/wallet_holding.dart
@@ -441,7 +441,7 @@ class WalletHoldingRepository {
   /// );
   /// ```
   Future<List<WalletHolding>> find(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<WalletHoldingTable>? where,
     int? limit,
     int? offset,
@@ -449,6 +449,8 @@ class WalletHoldingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<WalletHoldingTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.find<WalletHolding>(
       where: where?.call(WalletHolding.t),
@@ -458,6 +460,8 @@ class WalletHoldingRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -479,13 +483,15 @@ class WalletHoldingRepository {
   /// );
   /// ```
   Future<WalletHolding?> findFirstRow(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<WalletHoldingTable>? where,
     int? offset,
     _i1.OrderByBuilder<WalletHoldingTable>? orderBy,
     bool orderDescending = false,
     _i1.OrderByListBuilder<WalletHoldingTable>? orderByList,
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findFirstRow<WalletHolding>(
       where: where?.call(WalletHolding.t),
@@ -494,18 +500,24 @@ class WalletHoldingRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
   /// Finds a single [WalletHolding] by its [id] or null if no such row exists.
   Future<WalletHolding?> findById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
   }) async {
     return session.db.findById<WalletHolding>(
       id,
       transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
     );
   }
 
@@ -515,14 +527,20 @@ class WalletHoldingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
   Future<List<WalletHolding>> insert(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<WalletHolding> rows, {
     _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
   }) async {
     return session.db.insert<WalletHolding>(
       rows,
       transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
     );
   }
 
@@ -530,7 +548,7 @@ class WalletHoldingRepository {
   ///
   /// The returned [WalletHolding] will have its `id` field set.
   Future<WalletHolding> insertRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     WalletHolding row, {
     _i1.Transaction? transaction,
   }) async {
@@ -546,7 +564,7 @@ class WalletHoldingRepository {
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
   Future<List<WalletHolding>> update(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<WalletHolding> rows, {
     _i1.ColumnSelections<WalletHoldingTable>? columns,
     _i1.Transaction? transaction,
@@ -562,7 +580,7 @@ class WalletHoldingRepository {
   /// Optionally, a list of [columns] can be provided to only update those
   /// columns. Defaults to all columns.
   Future<WalletHolding> updateRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     WalletHolding row, {
     _i1.ColumnSelections<WalletHoldingTable>? columns,
     _i1.Transaction? transaction,
@@ -577,7 +595,7 @@ class WalletHoldingRepository {
   /// Updates a single [WalletHolding] by its [id] with the specified [columnValues].
   /// Returns the updated row or null if no row with the given id exists.
   Future<WalletHolding?> updateById(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     _i1.UuidValue id, {
     required _i1.ColumnValueListBuilder<WalletHoldingUpdateTable> columnValues,
     _i1.Transaction? transaction,
@@ -592,7 +610,7 @@ class WalletHoldingRepository {
   /// Updates all [WalletHolding]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
   Future<List<WalletHolding>> updateWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<WalletHoldingUpdateTable> columnValues,
     required _i1.WhereExpressionBuilder<WalletHoldingTable> where,
     int? limit,
@@ -618,7 +636,7 @@ class WalletHoldingRepository {
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
   Future<List<WalletHolding>> delete(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     List<WalletHolding> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -630,7 +648,7 @@ class WalletHoldingRepository {
 
   /// Deletes a single [WalletHolding].
   Future<WalletHolding> deleteRow(
-    _i1.Session session,
+    _i1.DatabaseSession session,
     WalletHolding row, {
     _i1.Transaction? transaction,
   }) async {
@@ -642,7 +660,7 @@ class WalletHoldingRepository {
 
   /// Deletes all rows matching the [where] expression.
   Future<List<WalletHolding>> deleteWhere(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<WalletHoldingTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -655,7 +673,7 @@ class WalletHoldingRepository {
   /// Counts the number of rows matching the [where] expression. If omitted,
   /// will return the count of all rows in the table.
   Future<int> count(
-    _i1.Session session, {
+    _i1.DatabaseSession session, {
     _i1.WhereExpressionBuilder<WalletHoldingTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -663,6 +681,22 @@ class WalletHoldingRepository {
     return session.db.count<WalletHolding>(
       where: where?.call(WalletHolding.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [WalletHolding] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<WalletHoldingTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<WalletHolding>(
+      where: where(WalletHolding.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
       transaction: transaction,
     );
   }

--- a/openbudget_server/pubspec.yaml
+++ b/openbudget_server/pubspec.yaml
@@ -13,15 +13,15 @@ dependencies:
   mailer: ^6.5.0
   openbudget_core:
     path: ../openbudget_core
-  serverpod: 3.3.1
-  serverpod_auth_idp_server: 3.3.1
+  serverpod: 3.4.6
+  serverpod_auth_idp_server: 3.4.6
   solana_kit: ^0.2.1
   solana_kit_helius: ^0.2.1
 
 dev_dependencies:
   openbudget_lints:
     path: ../openbudget_lints
-  serverpod_test: 3.3.1
+  serverpod_test: 3.4.6
   test: ^1.25.5
 
 serverpod:

--- a/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/openbudget_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -121,6 +121,11 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// }
 /// ```
 ///
+/// [configOverride] A function to override the server configuration. This function is called with
+/// the default server configuration after it is loaded from the config/ directory
+/// and before it is used to start the server. Use this to override particular
+/// settings in the server configuration.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -131,6 +136,7 @@ void withServerpod(
   String testGroupName,
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
+  _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ workspace:
 
 dev_dependencies:
   melos: ^7.4.0
-  serverpod_cli: 3.3.1
+  serverpod_cli: 3.4.6
 
 melos:
   name: openbudget


### PR DESCRIPTION
## Summary

- Regenerates all Serverpod protocol and generated code after the 3.3.1 to 3.4.6 upgrade (from PR #196)
- Updates 41 files across `openbudget_server` (generated code) and `openbudget_client` (protocol stubs)
- Key change: repository methods now use `DatabaseSession` parameter types (Serverpod 3.4.3 breaking change)

Closes #199

## Test plan

- [x] `dart analyze openbudget_server` passes (no errors or warnings)
- [x] `dart analyze openbudget_client` passes (no issues)
- [ ] CI pipeline passes (analyze, test, format)