### PR TITLE
chore: update aging app dependencies

### DIFF
--- a/openbudget_app/pubspec.yaml
+++ b/openbudget_app/pubspec.yaml
@@ -19,9 +19,9 @@ dependencies:
     sdk: flutter
   go_router: 15.1.3
   google_fonts: 8.0.1
-  hooks_riverpod: 3.2.1
+  hooks_riverpod: 3.3.1
   intl: any
-  json_annotation: 4.9.0
+  json_annotation: 4.11.0
   logging: 1.3.0
   openbudget_client:
     path: ../openbudget_client
@@ -30,7 +30,7 @@ dependencies:
   openbudget_ui:
     path: ../openbudget_ui
   plaid_flutter: 5.0.5
-  posthog_flutter: 5.14.0
+  posthog_flutter: 5.23.1
   riverpod_annotation: 4.0.2
   serverpod_auth_idp_flutter: 3.3.1
   serverpod_flutter: 3.3.1
@@ -39,7 +39,7 @@ dependencies:
   simple_icons: 14.6.1
 
 dev_dependencies:
-  build_runner: 2.11.1
+  build_runner: 2.13.1
   flutter_driver:
     sdk: flutter
   flutter_launcher_icons: 0.14.4
@@ -48,7 +48,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  json_serializable: 6.11.4
+  json_serializable: 6.13.0
   openbudget_lints:
     path: ../openbudget_lints
   openbudget_test_utils:


### PR DESCRIPTION
## Summary

- Update `hooks_riverpod` from 3.2.1 to 3.3.1
- Update `json_annotation` from 4.9.0 to 4.11.0
- Update `posthog_flutter` from 5.14.0 to 5.23.1
- Update `build_runner` (dev) from 2.11.1 to 2.13.1
- Update `json_serializable` (dev) from 6.11.4 to 6.13.0

All updates are within the same major version and introduce no breaking API changes. `dart pub get` resolves cleanly and `dart analyze` passes with zero issues.

### Already at latest (no update needed)

- `riverpod_generator`: 4.0.3 (latest)
- `flutter_launcher_icons`: 0.14.4 (latest)
- `flutter_native_splash`: 2.4.7 (latest)

### Deferred updates (separate migration PRs needed)

The following dependencies have new **major** versions available but are intentionally **not** updated in this PR due to breaking changes that require dedicated migration work:

- **`go_router`**: 15.1.3 -> 17.x (2 major versions ahead)
- **`patrol`**: 3.20.0 -> 4.x (1 major version ahead)
- **`very_good_analysis`**: 7.0.0 -> 10.x (3 major versions ahead, in `openbudget_lints`)

### Note on `json_serializable`

`json_serializable` 6.13.1 (absolute latest) requires `analyzer >=10.0.0`, which conflicts with `openbudget_lints`'s `analyzer ^9.0.0` constraint. Pinned to 6.13.0 which is the highest resolvable version within current workspace constraints.

Closes #202

## Test plan

- [x] `dart pub get` resolves without errors
- [x] `dart analyze openbudget_app` passes with no issues
- [ ] CI pipeline passes (analyze, test, format, pinned-deps)