### PR TITLE
ci: add GitHub Actions release workflow for Knope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    # Run on every push to main EXCEPT when the release PR was just merged.
+    if: "!startsWith(github.event.head_commit.message, 'chore: prepare releases')"
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: check for pending changesets
+        id: changesets
+        run: |
+          if knope release --dry-run 2>&1; then
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+            echo "No pending changesets — skipping release preparation."
+          fi
+        shell: devenv shell -- bash -e {0}
+
+      - name: prepare release PR
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: knope release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: devenv shell -- bash -e {0}
+
+  publish-release:
+    # Run only when the release PR commit lands on main.
+    if: "startsWith(github.event.head_commit.message, 'chore: prepare releases')"
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: create GitHub releases and tags
+        run: knope forced-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: devenv shell -- bash -e {0}
+
+      # Uncomment when packages are publishable (publish_to: none removed).
+      # Requires a PUB_CREDENTIALS secret with valid pub.dev credentials.
+      # - name: publish packages to pub.dev
+      #   run: melos run publish --no-select
+      #   env:
+      #     PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+      #   shell: devenv shell -- bash -e {0}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` with two jobs triggered on push to `main`
- **`prepare-release`** runs `knope release` when pending changesets exist, creating/updating a release PR on the `knope/release` branch
- **`publish-release`** runs `knope forced-release` when the release PR is merged (detected by commit message prefix `chore: prepare releases`), creating GitHub releases and git tags

Uses the same runner (`blacksmith-2vcpu-ubuntu-2404`), devenv action, and shell pattern as `ci.yml`. Pub.dev publishing step is present but commented out until packages remove `publish_to: none`.

Closes #200

## Test plan

- [ ] Verify workflow YAML is valid (GitHub Actions lint)
- [ ] Confirm `prepare-release` job is skipped when no changesets exist
- [ ] Confirm `prepare-release` creates a release PR when changesets are present
- [ ] Confirm `publish-release` job only runs when the release PR commit message starts with `chore: prepare releases`
- [ ] Confirm `publish-release` runs `knope forced-release` and creates GitHub releases/tags