### PR TITLE
fix(integration): add institution catalog fixture for account flow tests

### DIFF
--- a/openbudget_app/integration_test/account_flow_test.dart
+++ b/openbudget_app/integration_test/account_flow_test.dart
@@ -11,6 +11,7 @@ import 'package:openbudget_app/l10n/generated/app_localizations.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_actions_provider.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_list_provider.dart';
 import 'package:openbudget_app/src/features/accounts/providers/account_transactions_provider.dart';
+import 'package:openbudget_app/src/features/accounts/providers/institution_catalog_provider.dart';
 import 'package:openbudget_app/src/features/accounts/screens/account_detail_screen.dart';
 import 'package:openbudget_app/src/features/accounts/screens/account_list_screen.dart';
 import 'package:openbudget_app/src/features/accounts/screens/add_account_screen.dart';
@@ -27,6 +28,26 @@ const _budgetId = 'test-budget-id';
 final _budgetUuid = UuidValue.fromString(
   '00000000-0000-0000-0000-000000000010',
 );
+
+final _testInstitutions = <Institution>[
+  Institution(slug: 'chase', name: 'Chase', website: 'chase.com'),
+  Institution(slug: 'citi', name: 'Citi', website: 'citi.com'),
+  Institution(
+    slug: 'bank-of-america',
+    name: 'Bank of America',
+    website: 'bankofamerica.com',
+  ),
+  Institution(
+    slug: 'wells-fargo',
+    name: 'Wells Fargo',
+    website: 'wellsfargo.com',
+  ),
+  Institution(
+    slug: 'capital-one',
+    name: 'Capital One',
+    website: 'capitalone.com',
+  ),
+];
 const _addAccountUnlinkedButtonKey = Key('add-account-add-unlinked-button');
 const _addAccountUnlinkedScrollKey = Key('add-account-unlinked-scroll');
 const _addAccountNicknameFieldKey = Key('add-account-unlinked-nickname-field');
@@ -176,6 +197,9 @@ Widget _buildApp({
       ),
       budgetDetailProvider.overrideWith(
         (ref, budgetId) async => _makeBudget(currencyCode: budgetCurrencyCode),
+      ),
+      institutionCatalogProvider.overrideWith(
+        (ref, locationCode) async => _testInstitutions,
       ),
     ],
     child: MaterialApp.router(


### PR DESCRIPTION
## Summary

- Override `institutionCatalogProvider` in account flow integration tests with fixture data containing Chase, Citi, Bank of America, Wells Fargo, and Capital One
- Fixes 5 pre-existing integration test failures that expected institution names in search results but got nothing (provider was fetching from real Serverpod client, which returns empty in test)

## Fixes

- `bank search shortcut moves user to unlinked account flow`
- `submitting search query keeps user in bank search mode`
- `desktop add accounts flow shows search controls and options`
- `desktop add accounts search filters institutions to matching results`
- `desktop linked bank tap falls back to unlinked account guidance`

## Test plan
- [ ] CI integration-test job passes (all 5 previously-failing tests should now find the expected institution names)
